### PR TITLE
add default case syntax for Z-lang switch

### DIFF
--- a/proc/switcher/ztests/switch-default.yaml
+++ b/proc/switcher/ztests/switch-default.yaml
@@ -1,0 +1,18 @@
+zql: |
+  switch (
+     case a=2 => put v='two'
+     case a=1 => put v='one'
+     case a=3 => filter null
+     default => count() | put a=-1
+     ) | sort a
+
+input: |
+  {a:1,s:"a"}
+  {a:2,s:"B"}
+  {a:3,s:"c"}
+  {a:4,s:"c"}
+
+output: |
+  {count:1 (uint64),a:-1} (=0)
+  {a:1,s:"a",v:"one"}
+  {a:2,s:"B",v:"two"}

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -328,52 +328,57 @@ function peg$parse(input, options) {
       peg$c21 = peg$literalExpectation("=>", false),
       peg$c22 = function(ch) { return ch },
       peg$c23 = function(filter, proc) {
-          return {"filter": filter, "proc": proc}
-        },
-      peg$c24 = "case",
-      peg$c25 = peg$literalExpectation("case", false),
-      peg$c26 = "split",
-      peg$c27 = peg$literalExpectation("split", false),
-      peg$c28 = "(",
-      peg$c29 = peg$literalExpectation("(", false),
-      peg$c30 = ")",
-      peg$c31 = peg$literalExpectation(")", false),
-      peg$c32 = function(procArray) {
+            return {"filter": filter, "proc": proc}
+          },
+      peg$c24 = function(proc) {
+            return {"filter": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
+          },
+      peg$c25 = "case",
+      peg$c26 = peg$literalExpectation("case", true),
+      peg$c27 = "default",
+      peg$c28 = peg$literalExpectation("default", true),
+      peg$c29 = "split",
+      peg$c30 = peg$literalExpectation("split", false),
+      peg$c31 = "(",
+      peg$c32 = peg$literalExpectation("(", false),
+      peg$c33 = ")",
+      peg$c34 = peg$literalExpectation(")", false),
+      peg$c35 = function(procArray) {
             return {"op": "ParallelProc", "procs": procArray}
           },
-      peg$c33 = "switch",
-      peg$c34 = peg$literalExpectation("switch", false),
-      peg$c35 = function(caseArray) {
+      peg$c36 = "switch",
+      peg$c37 = peg$literalExpectation("switch", false),
+      peg$c38 = function(caseArray) {
             return {"op": "SwitchProc", "cases": caseArray}
           },
-      peg$c36 = function(f) { return f },
-      peg$c37 = function(a) { return a },
-      peg$c38 = function(expr) {
+      peg$c39 = function(f) { return f },
+      peg$c40 = function(a) { return a },
+      peg$c41 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c39 = ":",
-      peg$c40 = peg$literalExpectation(":", false),
-      peg$c41 = "-with",
-      peg$c42 = peg$literalExpectation("-with", false),
-      peg$c43 = ",",
-      peg$c44 = peg$literalExpectation(",", false),
-      peg$c45 = function(first, rest) {
+      peg$c42 = ":",
+      peg$c43 = peg$literalExpectation(":", false),
+      peg$c44 = "-with",
+      peg$c45 = peg$literalExpectation("-with", false),
+      peg$c46 = ",",
+      peg$c47 = peg$literalExpectation(",", false),
+      peg$c48 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c46 = function(t) { return ["or", t] },
-      peg$c47 = function(first, expr) { return ["and", expr] },
-      peg$c48 = function(first, rest) {
+      peg$c49 = function(t) { return ["or", t] },
+      peg$c50 = function(first, expr) { return ["and", expr] },
+      peg$c51 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c49 = "!",
-      peg$c50 = peg$literalExpectation("!", false),
-      peg$c51 = function(e) {
+      peg$c52 = "!",
+      peg$c53 = peg$literalExpectation("!", false),
+      peg$c54 = function(e) {
             return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c52 = function(expr) { return expr },
-      peg$c53 = "*",
-      peg$c54 = peg$literalExpectation("*", false),
-      peg$c55 = function(compareOp, v) {
+      peg$c55 = function(expr) { return expr },
+      peg$c56 = "*",
+      peg$c57 = peg$literalExpectation("*", false),
+      peg$c58 = function(compareOp, v) {
             return {"op": "FunctionCall", "function": "or",
               
             "args": [
@@ -400,10 +405,10 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c56 = function(f, comp, v) {
+      peg$c59 = function(f, comp, v) {
             return {"op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v}
           },
-      peg$c57 = function(v) {
+      peg$c60 = function(v) {
             return {"op": "FunctionCall", "function": "or",
               
             "args": [
@@ -430,16 +435,16 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c58 = function(v) {
+      peg$c61 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c59 = function() {
+      peg$c62 = function() {
             return {"op": "Literal", "type": "bool", "value": "true"}
           },
-      peg$c60 = function(v) {
+      peg$c63 = function(v) {
             return {"op": "Literal", "type": "string", "value": v}
           },
-      peg$c61 = function(v) {
+      peg$c64 = function(v) {
             let str = v;
             let literal = {"op": "Literal", "type": "string", "value": v};
             if (reglob$1.IsGlobby(str)) {
@@ -448,86 +453,86 @@ function peg$parse(input, options) {
             }
             return literal
           },
-      peg$c62 = function(head, tail) {
+      peg$c65 = function(head, tail) {
             return joinChars(head) + joinChars(tail)
           },
-      peg$c63 = function(s, v) { return s+v },
-      peg$c64 = function() { return text() },
-      peg$c65 = "type(",
-      peg$c66 = peg$literalExpectation("type(", false),
-      peg$c67 = "!=",
-      peg$c68 = peg$literalExpectation("!=", false),
-      peg$c69 = "in",
-      peg$c70 = peg$literalExpectation("in", false),
-      peg$c71 = "<=",
-      peg$c72 = peg$literalExpectation("<=", false),
-      peg$c73 = "<",
-      peg$c74 = peg$literalExpectation("<", false),
-      peg$c75 = ">=",
-      peg$c76 = peg$literalExpectation(">=", false),
-      peg$c77 = ">",
-      peg$c78 = peg$literalExpectation(">", false),
-      peg$c79 = function(first, op, expr) { return [op, expr] },
-      peg$c80 = function(first, rest) {
+      peg$c66 = function(s, v) { return s+v },
+      peg$c67 = function() { return text() },
+      peg$c68 = "type(",
+      peg$c69 = peg$literalExpectation("type(", false),
+      peg$c70 = "!=",
+      peg$c71 = peg$literalExpectation("!=", false),
+      peg$c72 = "in",
+      peg$c73 = peg$literalExpectation("in", false),
+      peg$c74 = "<=",
+      peg$c75 = peg$literalExpectation("<=", false),
+      peg$c76 = "<",
+      peg$c77 = peg$literalExpectation("<", false),
+      peg$c78 = ">=",
+      peg$c79 = peg$literalExpectation(">=", false),
+      peg$c80 = ">",
+      peg$c81 = peg$literalExpectation(">", false),
+      peg$c82 = function(first, op, expr) { return [op, expr] },
+      peg$c83 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c81 = function(e, typ) {
+      peg$c84 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c82 = function(every, keys, limit) {
+      peg$c85 = function(every, keys, limit) {
             return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
-      peg$c83 = function(every, reducers, keys, limit) {
+      peg$c86 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
             return p
           },
-      peg$c84 = "summarize",
-      peg$c85 = peg$literalExpectation("summarize", false),
-      peg$c86 = "",
-      peg$c87 = "every",
-      peg$c88 = peg$literalExpectation("every", true),
-      peg$c89 = function(dur) { return dur },
-      peg$c90 = function() { return null },
-      peg$c91 = function(columns) { return columns },
-      peg$c92 = "with",
-      peg$c93 = peg$literalExpectation("with", false),
-      peg$c94 = "-limit",
-      peg$c95 = peg$literalExpectation("-limit", false),
-      peg$c96 = function(limit) { return limit },
-      peg$c97 = function() { return 0 },
-      peg$c98 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c99 = function(first, expr) { return expr },
-      peg$c100 = function(lval, reducer) {
+      peg$c87 = "summarize",
+      peg$c88 = peg$literalExpectation("summarize", false),
+      peg$c89 = "",
+      peg$c90 = "every",
+      peg$c91 = peg$literalExpectation("every", true),
+      peg$c92 = function(dur) { return dur },
+      peg$c93 = function() { return null },
+      peg$c94 = function(columns) { return columns },
+      peg$c95 = "with",
+      peg$c96 = peg$literalExpectation("with", false),
+      peg$c97 = "-limit",
+      peg$c98 = peg$literalExpectation("-limit", false),
+      peg$c99 = function(limit) { return limit },
+      peg$c100 = function() { return 0 },
+      peg$c101 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c102 = function(first, expr) { return expr },
+      peg$c103 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c101 = function(reducer) {
+      peg$c104 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c102 = ".",
-      peg$c103 = peg$literalExpectation(".", false),
-      peg$c104 = function(op, expr, where) {
+      peg$c105 = ".",
+      peg$c106 = peg$literalExpectation(".", false),
+      peg$c107 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c105 = "where",
-      peg$c106 = peg$literalExpectation("where", false),
-      peg$c107 = function(first, rest) {
+      peg$c108 = "where",
+      peg$c109 = peg$literalExpectation("where", false),
+      peg$c110 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c108 = "sort",
-      peg$c109 = peg$literalExpectation("sort", true),
-      peg$c110 = function(args, l) { return l },
-      peg$c111 = function(args, list) {
+      peg$c111 = "sort",
+      peg$c112 = peg$literalExpectation("sort", true),
+      peg$c113 = function(args, l) { return l },
+      peg$c114 = function(args, list) {
             let argm = args;
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
@@ -540,24 +545,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c112 = function(args) { return makeArgMap(args) },
-      peg$c113 = "-r",
-      peg$c114 = peg$literalExpectation("-r", false),
-      peg$c115 = function() { return {"name": "r", "value": null} },
-      peg$c116 = "-nulls",
-      peg$c117 = peg$literalExpectation("-nulls", false),
-      peg$c118 = "first",
-      peg$c119 = peg$literalExpectation("first", false),
-      peg$c120 = "last",
-      peg$c121 = peg$literalExpectation("last", false),
-      peg$c122 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c123 = "top",
-      peg$c124 = peg$literalExpectation("top", true),
-      peg$c125 = function(n) { return n},
-      peg$c126 = "-flush",
-      peg$c127 = peg$literalExpectation("-flush", false),
-      peg$c128 = function(limit, flush, f) { return f },
-      peg$c129 = function(limit, flush, fields) {
+      peg$c115 = function(args) { return makeArgMap(args) },
+      peg$c116 = "-r",
+      peg$c117 = peg$literalExpectation("-r", false),
+      peg$c118 = function() { return {"name": "r", "value": null} },
+      peg$c119 = "-nulls",
+      peg$c120 = peg$literalExpectation("-nulls", false),
+      peg$c121 = "first",
+      peg$c122 = peg$literalExpectation("first", false),
+      peg$c123 = "last",
+      peg$c124 = peg$literalExpectation("last", false),
+      peg$c125 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c126 = "top",
+      peg$c127 = peg$literalExpectation("top", true),
+      peg$c128 = function(n) { return n},
+      peg$c129 = "-flush",
+      peg$c130 = peg$literalExpectation("-flush", false),
+      peg$c131 = function(limit, flush, f) { return f },
+      peg$c132 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
@@ -570,93 +575,93 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c130 = "cut",
-      peg$c131 = peg$literalExpectation("cut", true),
-      peg$c132 = function(columns) {
+      peg$c133 = "cut",
+      peg$c134 = peg$literalExpectation("cut", true),
+      peg$c135 = function(columns) {
             return {"op": "CutProc", "fields": columns}
           },
-      peg$c133 = "pick",
-      peg$c134 = peg$literalExpectation("pick", true),
-      peg$c135 = function(columns) {
+      peg$c136 = "pick",
+      peg$c137 = peg$literalExpectation("pick", true),
+      peg$c138 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c136 = "drop",
-      peg$c137 = peg$literalExpectation("drop", true),
-      peg$c138 = function(columns) {
+      peg$c139 = "drop",
+      peg$c140 = peg$literalExpectation("drop", true),
+      peg$c141 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c139 = "head",
-      peg$c140 = peg$literalExpectation("head", true),
-      peg$c141 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c142 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c143 = "tail",
-      peg$c144 = peg$literalExpectation("tail", true),
-      peg$c145 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c146 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c147 = "filter",
-      peg$c148 = peg$literalExpectation("filter", true),
-      peg$c149 = function(op) {
+      peg$c142 = "head",
+      peg$c143 = peg$literalExpectation("head", true),
+      peg$c144 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c145 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c146 = "tail",
+      peg$c147 = peg$literalExpectation("tail", true),
+      peg$c148 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c149 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c150 = "filter",
+      peg$c151 = peg$literalExpectation("filter", true),
+      peg$c152 = function(op) {
             return op
           },
-      peg$c150 = "uniq",
-      peg$c151 = peg$literalExpectation("uniq", true),
-      peg$c152 = "-c",
-      peg$c153 = peg$literalExpectation("-c", false),
-      peg$c154 = function() {
+      peg$c153 = "uniq",
+      peg$c154 = peg$literalExpectation("uniq", true),
+      peg$c155 = "-c",
+      peg$c156 = peg$literalExpectation("-c", false),
+      peg$c157 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c155 = function() {
+      peg$c158 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c156 = "put",
-      peg$c157 = peg$literalExpectation("put", true),
-      peg$c158 = function(columns) {
+      peg$c159 = "put",
+      peg$c160 = peg$literalExpectation("put", true),
+      peg$c161 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c159 = "rename",
-      peg$c160 = peg$literalExpectation("rename", true),
-      peg$c161 = function(first, cl) { return cl },
-      peg$c162 = function(first, rest) {
+      peg$c162 = "rename",
+      peg$c163 = peg$literalExpectation("rename", true),
+      peg$c164 = function(first, cl) { return cl },
+      peg$c165 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c163 = "fuse",
-      peg$c164 = peg$literalExpectation("fuse", true),
-      peg$c165 = function() {
+      peg$c166 = "fuse",
+      peg$c167 = peg$literalExpectation("fuse", true),
+      peg$c168 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c166 = "shape",
-      peg$c167 = peg$literalExpectation("shape", true),
-      peg$c168 = function() {
+      peg$c169 = "shape",
+      peg$c170 = peg$literalExpectation("shape", true),
+      peg$c171 = function() {
             return {"op": "ShapeProc"}
           },
-      peg$c169 = "join",
-      peg$c170 = peg$literalExpectation("join", true),
-      peg$c171 = function(kind, leftKey, rightKey, columns) {
+      peg$c172 = "join",
+      peg$c173 = peg$literalExpectation("join", true),
+      peg$c174 = function(kind, leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "kind": kind, "left_key": leftKey, "right_key": rightKey, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c172 = function(kind, key, columns) {
+      peg$c175 = function(kind, key, columns) {
             let proc = {"op": "JoinProc", "kind": kind, "left_key": key, "right_key": key, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c173 = "inner",
-      peg$c174 = peg$literalExpectation("inner", true),
-      peg$c175 = function() { return "inner" },
-      peg$c176 = "left",
-      peg$c177 = peg$literalExpectation("left", true),
-      peg$c178 = function() { return "left" },
-      peg$c179 = "right",
-      peg$c180 = peg$literalExpectation("right", true),
-      peg$c181 = function() { return "right" },
-      peg$c182 = "taste",
-      peg$c183 = peg$literalExpectation("taste", true),
-      peg$c184 = function(e) {
+      peg$c176 = "inner",
+      peg$c177 = peg$literalExpectation("inner", true),
+      peg$c178 = function() { return "inner" },
+      peg$c179 = "left",
+      peg$c180 = peg$literalExpectation("left", true),
+      peg$c181 = function() { return "left" },
+      peg$c182 = "right",
+      peg$c183 = peg$literalExpectation("right", true),
+      peg$c184 = function() { return "right" },
+      peg$c185 = "taste",
+      peg$c186 = peg$literalExpectation("taste", true),
+      peg$c187 = function(e) {
             return {"op": "SequentialProc", "procs": [
               
             {"op": "GroupByProc",
@@ -692,9 +697,9 @@ function peg$parse(input, options) {
             "rhs": {"op": "Identifier", "name": "taste"}}]}]}
           
           },
-      peg$c185 = function(lval) { return lval},
-      peg$c186 = function() { return {"op":"RootRecord"} },
-      peg$c187 = function(first, rest) {
+      peg$c188 = function(lval) { return lval},
+      peg$c189 = function() { return {"op":"RootRecord"} },
+      peg$c190 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -703,41 +708,41 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c188 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c189 = "?",
-      peg$c190 = peg$literalExpectation("?", false),
-      peg$c191 = function(condition, thenClause, elseClause) {
+      peg$c191 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c192 = "?",
+      peg$c193 = peg$literalExpectation("?", false),
+      peg$c194 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c192 = function(first, comp, expr) { return [comp, expr] },
-      peg$c193 = "+",
-      peg$c194 = peg$literalExpectation("+", false),
-      peg$c195 = "-",
-      peg$c196 = peg$literalExpectation("-", false),
-      peg$c197 = "/",
-      peg$c198 = peg$literalExpectation("/", false),
-      peg$c199 = function(e) {
+      peg$c195 = function(first, comp, expr) { return [comp, expr] },
+      peg$c196 = "+",
+      peg$c197 = peg$literalExpectation("+", false),
+      peg$c198 = "-",
+      peg$c199 = peg$literalExpectation("-", false),
+      peg$c200 = "/",
+      peg$c201 = peg$literalExpectation("/", false),
+      peg$c202 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c200 = "not",
-      peg$c201 = peg$literalExpectation("not", false),
-      peg$c202 = "match",
-      peg$c203 = peg$literalExpectation("match", false),
-      peg$c204 = "select",
-      peg$c205 = peg$literalExpectation("select", false),
-      peg$c206 = function(args, methods) {
+      peg$c203 = "not",
+      peg$c204 = peg$literalExpectation("not", false),
+      peg$c205 = "match",
+      peg$c206 = peg$literalExpectation("match", false),
+      peg$c207 = "select",
+      peg$c208 = peg$literalExpectation("select", false),
+      peg$c209 = function(args, methods) {
             return {"op":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c207 = function(methods) { return methods },
-      peg$c208 = function(fn, args) {
+      peg$c210 = function(methods) { return methods },
+      peg$c211 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c209 = function(first, e) { return e },
-      peg$c210 = function() { return [] },
-      peg$c211 = function() {
+      peg$c212 = function(first, e) { return e },
+      peg$c213 = function() { return [] },
+      peg$c214 = function() {
             return {"op":"RootRecord"}
           },
-      peg$c212 = function(field) {
+      peg$c215 = function(field) {
             return {"op": "BinaryExpr", "operator":".",
                            
             "lhs":{"op":"RootRecord"},
@@ -746,11 +751,11 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c213 = "[",
-      peg$c214 = peg$literalExpectation("[", false),
-      peg$c215 = "]",
-      peg$c216 = peg$literalExpectation("]", false),
-      peg$c217 = function(expr) {
+      peg$c216 = "[",
+      peg$c217 = peg$literalExpectation("[", false),
+      peg$c218 = "]",
+      peg$c219 = peg$literalExpectation("]", false),
+      peg$c220 = function(expr) {
             return {"op": "BinaryExpr", "operator":"[",
                            
             "lhs":{"op":"RootRecord"},
@@ -759,316 +764,316 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c218 = function(from, to) {
+      peg$c221 = function(from, to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c219 = function(to) {
+      peg$c222 = function(to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c220 = function(from) {
+      peg$c223 = function(from) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c221 = function(expr) { return ["[", expr] },
-      peg$c222 = function(id) { return [".", id] },
-      peg$c223 = function(v) {
+      peg$c224 = function(expr) { return ["[", expr] },
+      peg$c225 = function(id) { return [".", id] },
+      peg$c226 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c224 = function(v) {
+      peg$c227 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c225 = function(v) {
+      peg$c228 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c226 = function(v) {
+      peg$c229 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c227 = function(v) {
+      peg$c230 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c228 = "true",
-      peg$c229 = peg$literalExpectation("true", false),
-      peg$c230 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c231 = "false",
-      peg$c232 = peg$literalExpectation("false", false),
-      peg$c233 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c234 = "null",
-      peg$c235 = peg$literalExpectation("null", false),
-      peg$c236 = function() { return {"op": "Literal", "type": "null", "value": ""} },
-      peg$c237 = function(typ) {
+      peg$c231 = "true",
+      peg$c232 = peg$literalExpectation("true", false),
+      peg$c233 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c234 = "false",
+      peg$c235 = peg$literalExpectation("false", false),
+      peg$c236 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c237 = "null",
+      peg$c238 = peg$literalExpectation("null", false),
+      peg$c239 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c240 = function(typ) {
             return {"op": "TypeExpr", "type": typ}
           },
-      peg$c238 = function(typ) { return typ},
-      peg$c239 = function(typ) { return typ },
-      peg$c240 = function() {
+      peg$c241 = function(typ) { return typ},
+      peg$c242 = function(typ) { return typ },
+      peg$c243 = function() {
             return {"op": "TypeNull"}
           },
-      peg$c241 = function(name, typ) {
+      peg$c244 = function(name, typ) {
             return {"op": "TypeDef", "name": name, "type": typ}
         },
-      peg$c242 = function(name) {
+      peg$c245 = function(name) {
             return {"op": "TypeName", "name": name}
           },
-      peg$c243 = function(u) { return u },
-      peg$c244 = function(types) {
+      peg$c246 = function(u) { return u },
+      peg$c247 = function(types) {
             return {"op": "TypeUnion", "types": types}
           },
-      peg$c245 = function(first, rest) {
+      peg$c248 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c246 = "{",
-      peg$c247 = peg$literalExpectation("{", false),
-      peg$c248 = "}",
-      peg$c249 = peg$literalExpectation("}", false),
-      peg$c250 = function(fields) {
+      peg$c249 = "{",
+      peg$c250 = peg$literalExpectation("{", false),
+      peg$c251 = "}",
+      peg$c252 = peg$literalExpectation("}", false),
+      peg$c253 = function(fields) {
             return {"op":"TypeRecord", "fields":fields}
           },
-      peg$c251 = function(typ) {
+      peg$c254 = function(typ) {
             return {"op":"TypeArray", "type":typ}
           },
-      peg$c252 = "|[",
-      peg$c253 = peg$literalExpectation("|[", false),
-      peg$c254 = "]|",
-      peg$c255 = peg$literalExpectation("]|", false),
-      peg$c256 = function(typ) {
+      peg$c255 = "|[",
+      peg$c256 = peg$literalExpectation("|[", false),
+      peg$c257 = "]|",
+      peg$c258 = peg$literalExpectation("]|", false),
+      peg$c259 = function(typ) {
             return {"op":"TypeSet", "type":typ}
           },
-      peg$c257 = "|{",
-      peg$c258 = peg$literalExpectation("|{", false),
-      peg$c259 = "}|",
-      peg$c260 = peg$literalExpectation("}|", false),
-      peg$c261 = function(keyType, valType) {
+      peg$c260 = "|{",
+      peg$c261 = peg$literalExpectation("|{", false),
+      peg$c262 = "}|",
+      peg$c263 = peg$literalExpectation("}|", false),
+      peg$c264 = function(keyType, valType) {
             return {"op":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c262 = "uint8",
-      peg$c263 = peg$literalExpectation("uint8", false),
-      peg$c264 = "uint16",
-      peg$c265 = peg$literalExpectation("uint16", false),
-      peg$c266 = "uint32",
-      peg$c267 = peg$literalExpectation("uint32", false),
-      peg$c268 = "uint64",
-      peg$c269 = peg$literalExpectation("uint64", false),
-      peg$c270 = "int8",
-      peg$c271 = peg$literalExpectation("int8", false),
-      peg$c272 = "int16",
-      peg$c273 = peg$literalExpectation("int16", false),
-      peg$c274 = "int32",
-      peg$c275 = peg$literalExpectation("int32", false),
-      peg$c276 = "int64",
-      peg$c277 = peg$literalExpectation("int64", false),
-      peg$c278 = "float64",
-      peg$c279 = peg$literalExpectation("float64", false),
-      peg$c280 = "bool",
-      peg$c281 = peg$literalExpectation("bool", false),
-      peg$c282 = "string",
-      peg$c283 = peg$literalExpectation("string", false),
-      peg$c284 = function() {
+      peg$c265 = "uint8",
+      peg$c266 = peg$literalExpectation("uint8", false),
+      peg$c267 = "uint16",
+      peg$c268 = peg$literalExpectation("uint16", false),
+      peg$c269 = "uint32",
+      peg$c270 = peg$literalExpectation("uint32", false),
+      peg$c271 = "uint64",
+      peg$c272 = peg$literalExpectation("uint64", false),
+      peg$c273 = "int8",
+      peg$c274 = peg$literalExpectation("int8", false),
+      peg$c275 = "int16",
+      peg$c276 = peg$literalExpectation("int16", false),
+      peg$c277 = "int32",
+      peg$c278 = peg$literalExpectation("int32", false),
+      peg$c279 = "int64",
+      peg$c280 = peg$literalExpectation("int64", false),
+      peg$c281 = "float64",
+      peg$c282 = peg$literalExpectation("float64", false),
+      peg$c283 = "bool",
+      peg$c284 = peg$literalExpectation("bool", false),
+      peg$c285 = "string",
+      peg$c286 = peg$literalExpectation("string", false),
+      peg$c287 = function() {
                 return {"op": "TypePrimitive", "name": text()}
               },
-      peg$c285 = "duration",
-      peg$c286 = peg$literalExpectation("duration", false),
-      peg$c287 = "time",
-      peg$c288 = peg$literalExpectation("time", false),
-      peg$c289 = "bytes",
-      peg$c290 = peg$literalExpectation("bytes", false),
-      peg$c291 = "bstring",
-      peg$c292 = peg$literalExpectation("bstring", false),
-      peg$c293 = "ip",
-      peg$c294 = peg$literalExpectation("ip", false),
-      peg$c295 = "net",
-      peg$c296 = peg$literalExpectation("net", false),
-      peg$c297 = "error",
-      peg$c298 = peg$literalExpectation("error", false),
-      peg$c299 = function(name, typ) {
+      peg$c288 = "duration",
+      peg$c289 = peg$literalExpectation("duration", false),
+      peg$c290 = "time",
+      peg$c291 = peg$literalExpectation("time", false),
+      peg$c292 = "bytes",
+      peg$c293 = peg$literalExpectation("bytes", false),
+      peg$c294 = "bstring",
+      peg$c295 = peg$literalExpectation("bstring", false),
+      peg$c296 = "ip",
+      peg$c297 = peg$literalExpectation("ip", false),
+      peg$c298 = "net",
+      peg$c299 = peg$literalExpectation("net", false),
+      peg$c300 = "error",
+      peg$c301 = peg$literalExpectation("error", false),
+      peg$c302 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c300 = "and",
-      peg$c301 = peg$literalExpectation("and", true),
-      peg$c302 = function() { return "and" },
-      peg$c303 = "or",
-      peg$c304 = peg$literalExpectation("or", true),
-      peg$c305 = function() { return "or" },
-      peg$c306 = peg$literalExpectation("in", true),
-      peg$c307 = function() { return "in" },
-      peg$c308 = peg$literalExpectation("not", true),
-      peg$c309 = function() { return "not" },
-      peg$c310 = "by",
-      peg$c311 = peg$literalExpectation("by", true),
-      peg$c312 = function() { return "by" },
-      peg$c313 = /^[A-Za-z_$]/,
-      peg$c314 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c315 = /^[0-9]/,
-      peg$c316 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c317 = function(id) { return {"op": "Identifier", "name": id} },
-      peg$c318 = function() {  return text() },
-      peg$c319 = "$",
-      peg$c320 = peg$literalExpectation("$", false),
-      peg$c321 = "\\",
-      peg$c322 = peg$literalExpectation("\\", false),
-      peg$c323 = function(id) { return id },
-      peg$c324 = peg$literalExpectation("and", false),
-      peg$c325 = "seconds",
-      peg$c326 = peg$literalExpectation("seconds", false),
-      peg$c327 = "second",
-      peg$c328 = peg$literalExpectation("second", false),
-      peg$c329 = "secs",
-      peg$c330 = peg$literalExpectation("secs", false),
-      peg$c331 = "sec",
-      peg$c332 = peg$literalExpectation("sec", false),
-      peg$c333 = "s",
-      peg$c334 = peg$literalExpectation("s", false),
-      peg$c335 = "minutes",
-      peg$c336 = peg$literalExpectation("minutes", false),
-      peg$c337 = "minute",
-      peg$c338 = peg$literalExpectation("minute", false),
-      peg$c339 = "mins",
-      peg$c340 = peg$literalExpectation("mins", false),
-      peg$c341 = "min",
-      peg$c342 = peg$literalExpectation("min", false),
-      peg$c343 = "m",
-      peg$c344 = peg$literalExpectation("m", false),
-      peg$c345 = "hours",
-      peg$c346 = peg$literalExpectation("hours", false),
-      peg$c347 = "hrs",
-      peg$c348 = peg$literalExpectation("hrs", false),
-      peg$c349 = "hr",
-      peg$c350 = peg$literalExpectation("hr", false),
-      peg$c351 = "h",
-      peg$c352 = peg$literalExpectation("h", false),
-      peg$c353 = "hour",
-      peg$c354 = peg$literalExpectation("hour", false),
-      peg$c355 = "days",
-      peg$c356 = peg$literalExpectation("days", false),
-      peg$c357 = "day",
-      peg$c358 = peg$literalExpectation("day", false),
-      peg$c359 = "d",
-      peg$c360 = peg$literalExpectation("d", false),
-      peg$c361 = "weeks",
-      peg$c362 = peg$literalExpectation("weeks", false),
-      peg$c363 = "week",
-      peg$c364 = peg$literalExpectation("week", false),
-      peg$c365 = "wks",
-      peg$c366 = peg$literalExpectation("wks", false),
-      peg$c367 = "wk",
-      peg$c368 = peg$literalExpectation("wk", false),
-      peg$c369 = "w",
-      peg$c370 = peg$literalExpectation("w", false),
-      peg$c371 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c372 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c373 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c374 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c375 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c376 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c377 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c378 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c379 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c380 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c381 = function(a, b) {
+      peg$c303 = "and",
+      peg$c304 = peg$literalExpectation("and", true),
+      peg$c305 = function() { return "and" },
+      peg$c306 = "or",
+      peg$c307 = peg$literalExpectation("or", true),
+      peg$c308 = function() { return "or" },
+      peg$c309 = peg$literalExpectation("in", true),
+      peg$c310 = function() { return "in" },
+      peg$c311 = peg$literalExpectation("not", true),
+      peg$c312 = function() { return "not" },
+      peg$c313 = "by",
+      peg$c314 = peg$literalExpectation("by", true),
+      peg$c315 = function() { return "by" },
+      peg$c316 = /^[A-Za-z_$]/,
+      peg$c317 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c318 = /^[0-9]/,
+      peg$c319 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c320 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c321 = function() {  return text() },
+      peg$c322 = "$",
+      peg$c323 = peg$literalExpectation("$", false),
+      peg$c324 = "\\",
+      peg$c325 = peg$literalExpectation("\\", false),
+      peg$c326 = function(id) { return id },
+      peg$c327 = peg$literalExpectation("and", false),
+      peg$c328 = "seconds",
+      peg$c329 = peg$literalExpectation("seconds", false),
+      peg$c330 = "second",
+      peg$c331 = peg$literalExpectation("second", false),
+      peg$c332 = "secs",
+      peg$c333 = peg$literalExpectation("secs", false),
+      peg$c334 = "sec",
+      peg$c335 = peg$literalExpectation("sec", false),
+      peg$c336 = "s",
+      peg$c337 = peg$literalExpectation("s", false),
+      peg$c338 = "minutes",
+      peg$c339 = peg$literalExpectation("minutes", false),
+      peg$c340 = "minute",
+      peg$c341 = peg$literalExpectation("minute", false),
+      peg$c342 = "mins",
+      peg$c343 = peg$literalExpectation("mins", false),
+      peg$c344 = "min",
+      peg$c345 = peg$literalExpectation("min", false),
+      peg$c346 = "m",
+      peg$c347 = peg$literalExpectation("m", false),
+      peg$c348 = "hours",
+      peg$c349 = peg$literalExpectation("hours", false),
+      peg$c350 = "hrs",
+      peg$c351 = peg$literalExpectation("hrs", false),
+      peg$c352 = "hr",
+      peg$c353 = peg$literalExpectation("hr", false),
+      peg$c354 = "h",
+      peg$c355 = peg$literalExpectation("h", false),
+      peg$c356 = "hour",
+      peg$c357 = peg$literalExpectation("hour", false),
+      peg$c358 = "days",
+      peg$c359 = peg$literalExpectation("days", false),
+      peg$c360 = "day",
+      peg$c361 = peg$literalExpectation("day", false),
+      peg$c362 = "d",
+      peg$c363 = peg$literalExpectation("d", false),
+      peg$c364 = "weeks",
+      peg$c365 = peg$literalExpectation("weeks", false),
+      peg$c366 = "week",
+      peg$c367 = peg$literalExpectation("week", false),
+      peg$c368 = "wks",
+      peg$c369 = peg$literalExpectation("wks", false),
+      peg$c370 = "wk",
+      peg$c371 = peg$literalExpectation("wk", false),
+      peg$c372 = "w",
+      peg$c373 = peg$literalExpectation("w", false),
+      peg$c374 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c375 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c376 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c377 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c378 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c379 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c380 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c381 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c382 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c383 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c384 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c382 = "::",
-      peg$c383 = peg$literalExpectation("::", false),
-      peg$c384 = function(a, b, d, e) {
+      peg$c385 = "::",
+      peg$c386 = peg$literalExpectation("::", false),
+      peg$c387 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c385 = function(a, b) {
+      peg$c388 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c386 = function(a, b) {
+      peg$c389 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c387 = function() {
+      peg$c390 = function() {
             return "::"
           },
-      peg$c388 = function(v) { return ":" + v },
-      peg$c389 = function(v) { return v + ":" },
-      peg$c390 = function(a, m) {
+      peg$c391 = function(v) { return ":" + v },
+      peg$c392 = function(v) { return v + ":" },
+      peg$c393 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c391 = function(a, m) {
+      peg$c394 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c392 = function(s) { return parseInt(s) },
-      peg$c393 = function() {
+      peg$c395 = function(s) { return parseInt(s) },
+      peg$c396 = function() {
             return text()
           },
-      peg$c394 = "e",
-      peg$c395 = peg$literalExpectation("e", true),
-      peg$c396 = /^[+\-]/,
-      peg$c397 = peg$classExpectation(["+", "-"], false, false),
-      peg$c398 = /^[0-9a-fA-F]/,
-      peg$c399 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c400 = "\"",
-      peg$c401 = peg$literalExpectation("\"", false),
-      peg$c402 = function(v) { return joinChars(v) },
-      peg$c403 = "'",
-      peg$c404 = peg$literalExpectation("'", false),
-      peg$c405 = peg$anyExpectation(),
-      peg$c406 = function(s) { return s },
-      peg$c407 = function(head, tail) { return head + joinChars(tail) },
-      peg$c408 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c409 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c410 = "x",
-      peg$c411 = peg$literalExpectation("x", false),
-      peg$c412 = function() { return "\\" + text() },
-      peg$c413 = "b",
-      peg$c414 = peg$literalExpectation("b", false),
-      peg$c415 = function() { return "\b" },
-      peg$c416 = "f",
-      peg$c417 = peg$literalExpectation("f", false),
-      peg$c418 = function() { return "\f" },
-      peg$c419 = "n",
-      peg$c420 = peg$literalExpectation("n", false),
-      peg$c421 = function() { return "\n" },
-      peg$c422 = "r",
-      peg$c423 = peg$literalExpectation("r", false),
-      peg$c424 = function() { return "\r" },
-      peg$c425 = "t",
-      peg$c426 = peg$literalExpectation("t", false),
-      peg$c427 = function() { return "\t" },
-      peg$c428 = "v",
-      peg$c429 = peg$literalExpectation("v", false),
-      peg$c430 = function() { return "\v" },
-      peg$c431 = function() { return "=" },
-      peg$c432 = function() { return "\\*" },
-      peg$c433 = "u",
-      peg$c434 = peg$literalExpectation("u", false),
-      peg$c435 = function(chars) {
+      peg$c397 = "e",
+      peg$c398 = peg$literalExpectation("e", true),
+      peg$c399 = /^[+\-]/,
+      peg$c400 = peg$classExpectation(["+", "-"], false, false),
+      peg$c401 = /^[0-9a-fA-F]/,
+      peg$c402 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c403 = "\"",
+      peg$c404 = peg$literalExpectation("\"", false),
+      peg$c405 = function(v) { return joinChars(v) },
+      peg$c406 = "'",
+      peg$c407 = peg$literalExpectation("'", false),
+      peg$c408 = peg$anyExpectation(),
+      peg$c409 = function(s) { return s },
+      peg$c410 = function(head, tail) { return head + joinChars(tail) },
+      peg$c411 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c412 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c413 = "x",
+      peg$c414 = peg$literalExpectation("x", false),
+      peg$c415 = function() { return "\\" + text() },
+      peg$c416 = "b",
+      peg$c417 = peg$literalExpectation("b", false),
+      peg$c418 = function() { return "\b" },
+      peg$c419 = "f",
+      peg$c420 = peg$literalExpectation("f", false),
+      peg$c421 = function() { return "\f" },
+      peg$c422 = "n",
+      peg$c423 = peg$literalExpectation("n", false),
+      peg$c424 = function() { return "\n" },
+      peg$c425 = "r",
+      peg$c426 = peg$literalExpectation("r", false),
+      peg$c427 = function() { return "\r" },
+      peg$c428 = "t",
+      peg$c429 = peg$literalExpectation("t", false),
+      peg$c430 = function() { return "\t" },
+      peg$c431 = "v",
+      peg$c432 = peg$literalExpectation("v", false),
+      peg$c433 = function() { return "\v" },
+      peg$c434 = function() { return "=" },
+      peg$c435 = function() { return "\\*" },
+      peg$c436 = "u",
+      peg$c437 = peg$literalExpectation("u", false),
+      peg$c438 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c436 = function(body) { return body },
-      peg$c437 = /^[^\/\\]/,
-      peg$c438 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c439 = "\\/",
-      peg$c440 = peg$literalExpectation("\\/", false),
-      peg$c441 = /^[\0-\x1F\\]/,
-      peg$c442 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c443 = peg$otherExpectation("whitespace"),
-      peg$c444 = "\t",
-      peg$c445 = peg$literalExpectation("\t", false),
-      peg$c446 = "\x0B",
-      peg$c447 = peg$literalExpectation("\x0B", false),
-      peg$c448 = "\f",
-      peg$c449 = peg$literalExpectation("\f", false),
-      peg$c450 = " ",
-      peg$c451 = peg$literalExpectation(" ", false),
-      peg$c452 = "\xA0",
-      peg$c453 = peg$literalExpectation("\xA0", false),
-      peg$c454 = "\uFEFF",
-      peg$c455 = peg$literalExpectation("\uFEFF", false),
-      peg$c456 = /^[\n\r\u2028\u2029]/,
-      peg$c457 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c458 = peg$otherExpectation("comment"),
-      peg$c463 = "//",
-      peg$c464 = peg$literalExpectation("//", false),
+      peg$c439 = function(body) { return body },
+      peg$c440 = /^[^\/\\]/,
+      peg$c441 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c442 = "\\/",
+      peg$c443 = peg$literalExpectation("\\/", false),
+      peg$c444 = /^[\0-\x1F\\]/,
+      peg$c445 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c446 = peg$otherExpectation("whitespace"),
+      peg$c447 = "\t",
+      peg$c448 = peg$literalExpectation("\t", false),
+      peg$c449 = "\x0B",
+      peg$c450 = peg$literalExpectation("\x0B", false),
+      peg$c451 = "\f",
+      peg$c452 = peg$literalExpectation("\f", false),
+      peg$c453 = " ",
+      peg$c454 = peg$literalExpectation(" ", false),
+      peg$c455 = "\xA0",
+      peg$c456 = peg$literalExpectation("\xA0", false),
+      peg$c457 = "\uFEFF",
+      peg$c458 = peg$literalExpectation("\uFEFF", false),
+      peg$c459 = /^[\n\r\u2028\u2029]/,
+      peg$c460 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c461 = peg$otherExpectation("comment"),
+      peg$c466 = "//",
+      peg$c467 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1640,28 +1645,46 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSwitchBranch() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    s1 = peg$parseSearchBoolean();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      s2 = peg$parseCaseToken();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c20) {
-          s3 = peg$c20;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c21); }
-        }
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseSequential();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c23(s1, s5);
-              s0 = s1;
+              if (input.substr(peg$currPos, 2) === peg$c20) {
+                s6 = peg$c20;
+                peg$currPos += 2;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c21); }
+              }
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parse__();
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parseSequential();
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c23(s4, s8);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1682,6 +1705,54 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseDefaultToken();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse__();
+          if (s3 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c20) {
+              s4 = peg$c20;
+              peg$currPos += 2;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c21); }
+            }
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parse__();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parseSequential();
+                if (s6 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c24(s6);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
 
     return s0;
   }
@@ -1693,11 +1764,11 @@ function peg$parse(input, options) {
     s1 = peg$parseSwitchBranch();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseSwitchTail();
+      s3 = peg$parseSwitchBranch();
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parseSwitchTail();
+          s3 = peg$parseSwitchBranch();
         }
       } else {
         s2 = peg$FAILED;
@@ -1727,50 +1798,29 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSwitchTail() {
-    var s0, s1, s2, s3, s4;
+  function peg$parseCaseToken() {
+    var s0;
 
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseCaseToken();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseSwitchBranch();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c22(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c25) {
+      s0 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
     } else {
-      peg$currPos = s0;
       s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c26); }
     }
 
     return s0;
   }
 
-  function peg$parseCaseToken() {
+  function peg$parseDefaultToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c24) {
-      s0 = peg$c24;
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c27) {
+      s0 = input.substr(peg$currPos, 7);
+      peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
 
     return s0;
@@ -1780,22 +1830,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c26) {
-      s1 = peg$c26;
+    if (input.substr(peg$currPos, 5) === peg$c29) {
+      s1 = peg$c29;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c27); }
+      if (peg$silentFails === 0) { peg$fail(peg$c30); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -1815,15 +1865,15 @@ function peg$parse(input, options) {
                   s8 = peg$parse__();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c30;
+                      s9 = peg$c33;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c34); }
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c32(s7);
+                      s1 = peg$c35(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1863,53 +1913,41 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c33) {
-        s1 = peg$c33;
+      if (input.substr(peg$currPos, 6) === peg$c36) {
+        s1 = peg$c36;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c28;
+            s3 = peg$c31;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseCaseToken();
+              s5 = peg$parseSwitch();
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
-                  s7 = peg$parseSwitch();
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s7 = peg$c33;
+                    peg$currPos++;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
+                  }
                   if (s7 !== peg$FAILED) {
-                    s8 = peg$parse__();
-                    if (s8 !== peg$FAILED) {
-                      if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c30;
-                        peg$currPos++;
-                      } else {
-                        s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c31); }
-                      }
-                      if (s9 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c35(s7);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c38(s5);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1956,7 +1994,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c36(s1);
+              s1 = peg$c39(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1982,7 +2020,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c37(s1);
+                s1 = peg$c40(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2008,7 +2046,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c38(s1);
+                  s1 = peg$c41(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2050,11 +2088,11 @@ function peg$parse(input, options) {
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s2 = peg$c30;
+            s2 = peg$c33;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$parseEOF();
@@ -2118,19 +2156,19 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c39;
+              s2 = peg$c42;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+              if (peg$silentFails === 0) { peg$fail(peg$c43); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c28;
+                s2 = peg$c31;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                if (peg$silentFails === 0) { peg$fail(peg$c32); }
               }
             }
           }
@@ -2159,12 +2197,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseByToken();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c41) {
-          s2 = peg$c41;
+        if (input.substr(peg$currPos, 5) === peg$c44) {
+          s2 = peg$c44;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c45); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -2189,11 +2227,11 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c43;
+          s2 = peg$c46;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -2225,7 +2263,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s1, s2);
+        s1 = peg$c48(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2252,7 +2290,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c49(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2308,7 +2346,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchFactor();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c47(s1, s7);
+              s4 = peg$c50(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2355,7 +2393,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchFactor();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c47(s1, s7);
+                s4 = peg$c50(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2376,7 +2414,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c48(s1, s2);
+        s1 = peg$c51(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2412,11 +2450,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c49;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2436,7 +2474,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51(s2);
+        s1 = peg$c54(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2453,11 +2491,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c28;
+            s1 = peg$c31;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -2467,15 +2505,15 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c30;
+                    s5 = peg$c33;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c52(s3);
+                    s1 = peg$c55(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2509,11 +2547,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c53;
+      s1 = peg$c56;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -2525,7 +2563,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c55(s3, s5);
+              s1 = peg$c58(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2571,7 +2609,7 @@ function peg$parse(input, options) {
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c56(s1, s3, s5);
+                  s1 = peg$c59(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2608,15 +2646,15 @@ function peg$parse(input, options) {
               s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 42) {
-                  s5 = peg$c53;
+                  s5 = peg$c56;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c57); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c57(s1);
+                  s1 = peg$c60(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2679,7 +2717,7 @@ function peg$parse(input, options) {
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c58(s2);
+                s1 = peg$c61(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2696,11 +2734,11 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 42) {
-              s1 = peg$c53;
+              s1 = peg$c56;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              if (peg$silentFails === 0) { peg$fail(peg$c57); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
@@ -2715,7 +2753,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c59();
+                s1 = peg$c62();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2742,7 +2780,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKeyWord();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c60(s1);
+        s1 = peg$c63(s1);
       }
       s0 = s1;
     }
@@ -2759,7 +2797,7 @@ function peg$parse(input, options) {
       s1 = peg$parseSearchGlob();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c61(s1);
+        s1 = peg$c64(s1);
       }
       s0 = s1;
     }
@@ -2784,25 +2822,25 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = [];
       if (input.charCodeAt(peg$currPos) === 42) {
-        s3 = peg$c53;
+        s3 = peg$c56;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c53;
+          s3 = peg$c56;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c65(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2825,7 +2863,7 @@ function peg$parse(input, options) {
       s2 = peg$parseKeyWord();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c63(s1, s2);
+        s1 = peg$c66(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2848,21 +2886,21 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c53;
+      s2 = peg$c56;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
         if (input.charCodeAt(peg$currPos) === 42) {
-          s2 = peg$c53;
+          s2 = peg$c56;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
       }
     } else {
@@ -2870,7 +2908,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -2892,12 +2930,15 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$parseCaseToken();
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c65) {
-                  s0 = peg$c65;
-                  peg$currPos += 5;
-                } else {
-                  s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c66); }
+                s0 = peg$parseDefaultToken();
+                if (s0 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 5) === peg$c68) {
+                    s0 = peg$c68;
+                    peg$currPos += 5;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                  }
                 }
               }
             }
@@ -2921,52 +2962,52 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c6); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c67) {
-        s1 = peg$c67;
+      if (input.substr(peg$currPos, 2) === peg$c70) {
+        s1 = peg$c70;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c69) {
-          s1 = peg$c69;
+        if (input.substr(peg$currPos, 2) === peg$c72) {
+          s1 = peg$c72;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c71) {
-            s1 = peg$c71;
+          if (input.substr(peg$currPos, 2) === peg$c74) {
+            s1 = peg$c74;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c72); }
+            if (peg$silentFails === 0) { peg$fail(peg$c75); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c73;
+              s1 = peg$c76;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c77); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c75) {
-                s1 = peg$c75;
+              if (input.substr(peg$currPos, 2) === peg$c78) {
+                s1 = peg$c78;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                if (peg$silentFails === 0) { peg$fail(peg$c79); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c77;
+                  s1 = peg$c80;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c81); }
                 }
               }
             }
@@ -2976,7 +3017,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -3000,7 +3041,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchExprAdd();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3030,7 +3071,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchExprAdd();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3051,7 +3092,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3082,7 +3123,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchExprMul();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3112,7 +3153,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchExprMul();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3133,7 +3174,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3164,7 +3205,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchExprCast();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3194,7 +3235,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchExprCast();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3215,7 +3256,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3238,11 +3279,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c39;
+          s3 = peg$c42;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3250,7 +3291,7 @@ function peg$parse(input, options) {
             s5 = peg$parseCastType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81(s1, s5);
+              s1 = peg$c84(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3297,7 +3338,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c45(s1, s2);
+            s1 = peg$c48(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3332,7 +3373,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLimitArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s2, s3, s4);
+            s1 = peg$c85(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3380,7 +3421,7 @@ function peg$parse(input, options) {
               s5 = peg$parseLimitArg();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c83(s2, s3, s4, s5);
+                s1 = peg$c86(s2, s3, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3411,12 +3452,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c84) {
-      s1 = peg$c84;
+    if (input.substr(peg$currPos, 9) === peg$c87) {
+      s1 = peg$c87;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3432,7 +3473,7 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$c86;
+      s0 = peg$c89;
     }
 
     return s0;
@@ -3442,12 +3483,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c90) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3457,7 +3498,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c89(s3);
+            s1 = peg$c92(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3477,10 +3518,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90();
+        s1 = peg$c93();
       }
       s0 = s1;
     }
@@ -3499,7 +3540,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c91(s3);
+          s1 = peg$c94(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3523,22 +3564,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c92) {
-        s2 = peg$c92;
+      if (input.substr(peg$currPos, 4) === peg$c95) {
+        s2 = peg$c95;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c93); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c94) {
-            s4 = peg$c94;
+          if (input.substr(peg$currPos, 6) === peg$c97) {
+            s4 = peg$c97;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c95); }
+            if (peg$silentFails === 0) { peg$fail(peg$c98); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3546,7 +3587,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c96(s6);
+                s1 = peg$c99(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3574,10 +3615,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c97();
+        s1 = peg$c100();
       }
       s0 = s1;
     }
@@ -3594,7 +3635,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1);
+        s1 = peg$c101(s1);
       }
       s0 = s1;
     }
@@ -3613,11 +3654,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3625,7 +3666,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c99(s1, s7);
+              s4 = peg$c102(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3649,11 +3690,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3661,7 +3702,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c99(s1, s7);
+                s4 = peg$c102(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3717,7 +3758,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c100(s1, s5);
+              s1 = peg$c103(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3744,7 +3785,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c101(s1);
+        s1 = peg$c104(s1);
       }
       s0 = s1;
     }
@@ -3772,11 +3813,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c28;
+            s4 = peg$c31;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3789,11 +3830,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c30;
+                    s8 = peg$c33;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3802,11 +3843,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c102;
+                        s12 = peg$c105;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c106); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3833,7 +3874,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c104(s2, s6, s10);
+                        s1 = peg$c107(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3899,12 +3940,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c105) {
-        s2 = peg$c105;
+      if (input.substr(peg$currPos, 5) === peg$c108) {
+        s2 = peg$c108;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3912,7 +3953,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c52(s4);
+            s1 = peg$c55(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3945,11 +3986,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3980,11 +4021,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4012,7 +4053,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c107(s1, s2);
+        s1 = peg$c110(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4080,12 +4121,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c108) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c111) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c109); }
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -4096,7 +4137,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c110(s2, s5);
+            s4 = peg$c113(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4111,7 +4152,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c111(s2, s3);
+          s1 = peg$c114(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4140,7 +4181,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c37(s4);
+        s3 = peg$c40(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -4158,7 +4199,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c37(s4);
+          s3 = peg$c40(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4171,7 +4212,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c112(s1);
+      s1 = peg$c115(s1);
     }
     s0 = s1;
 
@@ -4182,55 +4223,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c113) {
-      s1 = peg$c113;
+    if (input.substr(peg$currPos, 2) === peg$c116) {
+      s1 = peg$c116;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      if (peg$silentFails === 0) { peg$fail(peg$c117); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c115();
+      s1 = peg$c118();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c116) {
-        s1 = peg$c116;
+      if (input.substr(peg$currPos, 6) === peg$c119) {
+        s1 = peg$c119;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c118) {
-            s4 = peg$c118;
+          if (input.substr(peg$currPos, 5) === peg$c121) {
+            s4 = peg$c121;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c119); }
+            if (peg$silentFails === 0) { peg$fail(peg$c122); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c120) {
-              s4 = peg$c120;
+            if (input.substr(peg$currPos, 4) === peg$c123) {
+              s4 = peg$c123;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c124); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c64();
+            s4 = peg$c67();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c122(s3);
+            s1 = peg$c125(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4253,12 +4294,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c123) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c126) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4267,7 +4308,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c125(s4);
+          s3 = peg$c128(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4284,12 +4325,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c126) {
-            s5 = peg$c126;
+          if (input.substr(peg$currPos, 6) === peg$c129) {
+            s5 = peg$c129;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4312,7 +4353,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c128(s2, s3, s6);
+              s5 = peg$c131(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4327,7 +4368,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c129(s2, s3, s4);
+            s1 = peg$c132(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4353,44 +4394,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c130) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c133) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c132(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsePickProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c133) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c134); }
@@ -4419,7 +4425,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseDropProc() {
+  function peg$parsePickProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -4433,10 +4439,45 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseFieldExprs();
+        s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c138(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDropProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFieldExprs();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c141(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4458,12 +4499,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4471,7 +4512,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c141(s3);
+          s1 = peg$c144(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4487,16 +4528,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c142();
+        s1 = peg$c145();
       }
       s0 = s1;
     }
@@ -4508,12 +4549,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c146) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c147); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4521,7 +4562,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145(s3);
+          s1 = peg$c148(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4537,16 +4578,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c146) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146();
+        s1 = peg$c149();
       }
       s0 = s1;
     }
@@ -4558,12 +4599,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c150) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4571,7 +4612,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149(s3);
+          s1 = peg$c152(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4596,7 +4637,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c38(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
 
@@ -4607,26 +4648,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c152) {
-          s3 = peg$c152;
+        if (input.substr(peg$currPos, 2) === peg$c155) {
+          s3 = peg$c155;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c153); }
+          if (peg$silentFails === 0) { peg$fail(peg$c156); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c154();
+          s1 = peg$c157();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4642,16 +4683,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c154); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c155();
+        s1 = peg$c158();
       }
       s0 = s1;
     }
@@ -4663,12 +4704,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c159) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4676,7 +4717,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c158(s3);
+          s1 = peg$c161(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4698,12 +4739,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c159) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c162) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c160); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4715,11 +4756,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c43;
+              s7 = peg$c46;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+              if (peg$silentFails === 0) { peg$fail(peg$c47); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4727,7 +4768,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c161(s3, s9);
+                  s6 = peg$c164(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4751,11 +4792,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c43;
+                s7 = peg$c46;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                if (peg$silentFails === 0) { peg$fail(peg$c47); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4763,7 +4804,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c161(s3, s9);
+                    s6 = peg$c164(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4784,7 +4825,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c162(s3, s4);
+            s1 = peg$c165(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4810,12 +4851,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c164); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4824,11 +4865,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c28;
+          s5 = peg$c31;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4850,7 +4891,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c165();
+        s1 = peg$c168();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4868,16 +4909,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c166) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c169) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      if (peg$silentFails === 0) { peg$fail(peg$c170); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c168();
+      s1 = peg$c171();
     }
     s0 = s1;
 
@@ -4890,12 +4931,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinKind();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c169) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c170); }
+        if (peg$silentFails === 0) { peg$fail(peg$c173); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4936,7 +4977,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c171(s1, s4, s8, s9);
+                      s1 = peg$c174(s1, s4, s8, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4978,12 +5019,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinKind();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c169) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5010,7 +5051,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c172(s1, s4, s5);
+                s1 = peg$c175(s1, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5041,18 +5082,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c173) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c176) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c174); }
+      if (peg$silentFails === 0) { peg$fail(peg$c177); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c175();
+        s1 = peg$c178();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5064,18 +5105,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c176) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c179) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c178();
+          s1 = peg$c181();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5087,18 +5128,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c179) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c182) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c180); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c181();
+            s1 = peg$c184();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5110,10 +5151,10 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$c86;
+          s1 = peg$c89;
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175();
+            s1 = peg$c178();
           }
           s0 = s1;
         }
@@ -5130,25 +5171,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c28;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c30;
+            s3 = peg$c33;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c52(s2);
+            s1 = peg$c55(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5171,18 +5212,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c182) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseTasteExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c184(s2);
+        s1 = peg$c187(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5205,7 +5246,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c185(s2);
+        s1 = peg$c188(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5217,10 +5258,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c186();
+        s1 = peg$c189();
       }
       s0 = s1;
     }
@@ -5239,11 +5280,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5274,11 +5315,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5306,7 +5347,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c187(s1, s2);
+        s1 = peg$c190(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5331,11 +5372,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5366,11 +5407,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5398,7 +5439,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c187(s1, s2);
+        s1 = peg$c190(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5433,7 +5474,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c188(s1, s5);
+              s1 = peg$c191(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5476,11 +5517,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c189;
+          s3 = peg$c192;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -5490,11 +5531,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c39;
+                  s7 = peg$c42;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c40); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c43); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -5502,7 +5543,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c191(s1, s5, s9);
+                      s1 = peg$c194(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5564,7 +5605,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5594,7 +5635,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5615,7 +5656,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5646,7 +5687,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5676,7 +5717,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5697,7 +5738,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5728,7 +5769,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c192(s1, s5, s7);
+              s4 = peg$c195(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5758,7 +5799,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c192(s1, s5, s7);
+                s4 = peg$c195(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5779,7 +5820,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5805,17 +5846,17 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c6); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c67) {
-        s1 = peg$c67;
+      if (input.substr(peg$currPos, 2) === peg$c70) {
+        s1 = peg$c70;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -5828,16 +5869,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c69) {
-        s1 = peg$c69;
+      if (input.substr(peg$currPos, 2) === peg$c72) {
+        s1 = peg$c72;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
       }
       s0 = s1;
     }
@@ -5862,7 +5903,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5892,7 +5933,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5913,7 +5954,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5931,43 +5972,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c71) {
-      s1 = peg$c71;
+    if (input.substr(peg$currPos, 2) === peg$c74) {
+      s1 = peg$c74;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
+      if (peg$silentFails === 0) { peg$fail(peg$c75); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c73;
+        s1 = peg$c76;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c75) {
-          s1 = peg$c75;
+        if (input.substr(peg$currPos, 2) === peg$c78) {
+          s1 = peg$c78;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c77;
+            s1 = peg$c80;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c81); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -5991,7 +6032,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6021,7 +6062,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6042,7 +6083,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6061,24 +6102,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c193;
+      s1 = peg$c196;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c197); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c195;
+        s1 = peg$c198;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -6102,7 +6143,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6132,7 +6173,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6153,7 +6194,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6172,24 +6213,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c53;
+      s1 = peg$c56;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c197;
+        s1 = peg$c200;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -6201,11 +6242,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c49;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6213,7 +6254,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c199(s3);
+          s1 = peg$c202(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6243,11 +6284,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c39;
+          s3 = peg$c42;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6255,7 +6296,7 @@ function peg$parse(input, options) {
             s5 = peg$parseCastType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81(s1, s5);
+              s1 = peg$c84(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6304,7 +6345,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c45(s1, s2);
+              s1 = peg$c48(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6336,11 +6377,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -6364,28 +6405,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c200) {
-      s0 = peg$c200;
+    if (input.substr(peg$currPos, 3) === peg$c203) {
+      s0 = peg$c203;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c201); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c202) {
-        s0 = peg$c202;
+      if (input.substr(peg$currPos, 5) === peg$c205) {
+        s0 = peg$c205;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c203); }
+        if (peg$silentFails === 0) { peg$fail(peg$c206); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c204) {
-          s0 = peg$c204;
+        if (input.substr(peg$currPos, 6) === peg$c207) {
+          s0 = peg$c207;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -6406,36 +6447,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c202) {
-      s1 = peg$c202;
+    if (input.substr(peg$currPos, 5) === peg$c205) {
+      s1 = peg$c205;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c203); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c30;
+              s5 = peg$c33;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c34); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c52(s4);
+              s1 = peg$c55(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6465,22 +6506,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c204) {
-      s1 = peg$c204;
+    if (input.substr(peg$currPos, 6) === peg$c207) {
+      s1 = peg$c207;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6490,17 +6531,17 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c30;
+                  s7 = peg$c33;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c34); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parseMethods();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c206(s5, s8);
+                    s1 = peg$c209(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6554,15 +6595,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c207(s1);
+      s1 = peg$c210(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90();
+        s1 = peg$c93();
       }
       s0 = s1;
     }
@@ -6577,11 +6618,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c102;
+        s2 = peg$c105;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6589,7 +6630,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFunction();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c36(s4);
+            s1 = peg$c39(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6631,11 +6672,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c28;
+            s4 = peg$c31;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -6645,15 +6686,15 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c30;
+                    s8 = peg$c33;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c208(s2, s6);
+                    s1 = peg$c211(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6702,11 +6743,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6714,7 +6755,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c209(s1, s7);
+              s4 = peg$c212(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6738,11 +6779,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6750,7 +6791,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c209(s1, s7);
+                s4 = peg$c212(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6786,7 +6827,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c210();
+        s1 = peg$c213();
       }
       s0 = s1;
     }
@@ -6808,7 +6849,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s1, s2);
+        s1 = peg$c48(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6830,7 +6871,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c45(s1, s2);
+          s1 = peg$c48(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6843,15 +6884,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s1 = peg$c102;
+          s1 = peg$c105;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c106); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c211();
+          s1 = peg$c214();
         }
         s0 = s1;
       }
@@ -6865,17 +6906,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c102;
+      s1 = peg$c105;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c103); }
+      if (peg$silentFails === 0) { peg$fail(peg$c106); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c212(s2);
+        s1 = peg$c215(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6888,33 +6929,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c102;
+        s1 = peg$c105;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c213;
+          s2 = peg$c216;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+          if (peg$silentFails === 0) { peg$fail(peg$c217); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c215;
+              s4 = peg$c218;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c216); }
+              if (peg$silentFails === 0) { peg$fail(peg$c219); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c217(s3);
+              s1 = peg$c220(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6942,11 +6983,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c213;
+      s1 = peg$c216;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -6954,11 +6995,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c39;
+            s4 = peg$c42;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c40); }
+            if (peg$silentFails === 0) { peg$fail(peg$c43); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -6966,15 +7007,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c215;
+                  s7 = peg$c218;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c219); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c218(s2, s6);
+                  s1 = peg$c221(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7007,21 +7048,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c213;
+        s1 = peg$c216;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c214); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c39;
+            s3 = peg$c42;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c40); }
+            if (peg$silentFails === 0) { peg$fail(peg$c43); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -7029,15 +7070,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c215;
+                  s6 = peg$c218;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c219); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c219(s5);
+                  s1 = peg$c222(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7066,11 +7107,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c213;
+          s1 = peg$c216;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+          if (peg$silentFails === 0) { peg$fail(peg$c217); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -7078,25 +7119,25 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c39;
+                s4 = peg$c42;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c40); }
+                if (peg$silentFails === 0) { peg$fail(peg$c43); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c215;
+                    s6 = peg$c218;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c219); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c220(s2);
+                    s1 = peg$c223(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7125,25 +7166,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c213;
+            s1 = peg$c216;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c214); }
+            if (peg$silentFails === 0) { peg$fail(peg$c217); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c215;
+                s3 = peg$c218;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                if (peg$silentFails === 0) { peg$fail(peg$c219); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c221(s2);
+                s1 = peg$c224(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7160,21 +7201,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c102;
+              s1 = peg$c105;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c103); }
+              if (peg$silentFails === 0) { peg$fail(peg$c106); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c102;
+                s3 = peg$c105;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -7187,7 +7228,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c222(s3);
+                  s1 = peg$c225(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7216,11 +7257,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c28;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7230,15 +7271,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c30;
+                s5 = peg$c33;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c34); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c52(s3);
+                s1 = peg$c55(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7304,7 +7345,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c60(s1);
+      s1 = peg$c63(s1);
     }
     s0 = s1;
 
@@ -7329,7 +7370,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223(s1);
+        s1 = peg$c226(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7361,7 +7402,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s1);
+        s1 = peg$c227(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7376,7 +7417,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s1);
+        s1 = peg$c227(s1);
       }
       s0 = s1;
     }
@@ -7402,7 +7443,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c225(s1);
+        s1 = peg$c228(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7417,7 +7458,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c225(s1);
+        s1 = peg$c228(s1);
       }
       s0 = s1;
     }
@@ -7432,7 +7473,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c226(s1);
+      s1 = peg$c229(s1);
     }
     s0 = s1;
 
@@ -7446,7 +7487,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c227(s1);
+      s1 = peg$c230(s1);
     }
     s0 = s1;
 
@@ -7457,30 +7498,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c228) {
-      s1 = peg$c228;
+    if (input.substr(peg$currPos, 4) === peg$c231) {
+      s1 = peg$c231;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c230();
+      s1 = peg$c233();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c231) {
-        s1 = peg$c231;
+      if (input.substr(peg$currPos, 5) === peg$c234) {
+        s1 = peg$c234;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c232); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233();
+        s1 = peg$c236();
       }
       s0 = s1;
     }
@@ -7492,16 +7533,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c234) {
-      s1 = peg$c234;
+    if (input.substr(peg$currPos, 4) === peg$c237) {
+      s1 = peg$c237;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c236();
+      s1 = peg$c239();
     }
     s0 = s1;
 
@@ -7515,7 +7556,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeExternal();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c237(s1);
+      s1 = peg$c240(s1);
     }
     s0 = s1;
 
@@ -7548,11 +7589,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7562,15 +7603,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c30;
+                  s7 = peg$c33;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c34); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c238(s5);
+                  s1 = peg$c241(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7613,11 +7654,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c28;
+            s3 = peg$c31;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -7627,15 +7668,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c30;
+                    s7 = peg$c33;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c239(s5);
+                    s1 = peg$c242(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7683,7 +7724,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c239(s1);
+              s1 = peg$c242(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7715,16 +7756,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c234) {
-      s1 = peg$c234;
+    if (input.substr(peg$currPos, 4) === peg$c237) {
+      s1 = peg$c237;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c243();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7746,11 +7787,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c28;
+                  s5 = peg$c31;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse__();
@@ -7760,15 +7801,15 @@ function peg$parse(input, options) {
                       s8 = peg$parse__();
                       if (s8 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 41) {
-                          s9 = peg$c30;
+                          s9 = peg$c33;
                           peg$currPos++;
                         } else {
                           s9 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c34); }
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c241(s1, s7);
+                          s1 = peg$c244(s1, s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7811,17 +7852,17 @@ function peg$parse(input, options) {
           s1 = peg$parseIdentifierName();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c242(s1);
+            s1 = peg$c245(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 40) {
-              s1 = peg$c28;
+              s1 = peg$c31;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c29); }
+              if (peg$silentFails === 0) { peg$fail(peg$c32); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parse__();
@@ -7829,15 +7870,15 @@ function peg$parse(input, options) {
                 s3 = peg$parseTypeUnion();
                 if (s3 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s4 = peg$c30;
+                    s4 = peg$c33;
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s4 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c243(s3);
+                    s1 = peg$c246(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7870,7 +7911,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c244(s1);
+      s1 = peg$c247(s1);
     }
     s0 = s1;
 
@@ -7895,7 +7936,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245(s1, s2);
+        s1 = peg$c248(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7916,11 +7957,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c43;
+        s2 = peg$c46;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7928,7 +7969,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c239(s4);
+            s1 = peg$c242(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7955,11 +7996,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c246;
+      s1 = peg$c249;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7969,15 +8010,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c248;
+              s5 = peg$c251;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c252); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c250(s3);
+              s1 = peg$c253(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8002,11 +8043,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c213;
+        s1 = peg$c216;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c214); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -8016,15 +8057,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c215;
+                s5 = peg$c218;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                if (peg$silentFails === 0) { peg$fail(peg$c219); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c251(s3);
+                s1 = peg$c254(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -8048,12 +8089,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c252) {
-          s1 = peg$c252;
+        if (input.substr(peg$currPos, 2) === peg$c255) {
+          s1 = peg$c255;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+          if (peg$silentFails === 0) { peg$fail(peg$c256); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -8062,16 +8103,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c254) {
-                  s5 = peg$c254;
+                if (input.substr(peg$currPos, 2) === peg$c257) {
+                  s5 = peg$c257;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c255); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c258); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c256(s3);
+                  s1 = peg$c259(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8095,12 +8136,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c257) {
-            s1 = peg$c257;
+          if (input.substr(peg$currPos, 2) === peg$c260) {
+            s1 = peg$c260;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c258); }
+            if (peg$silentFails === 0) { peg$fail(peg$c261); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -8110,11 +8151,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c43;
+                    s5 = peg$c46;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c47); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -8123,16 +8164,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c259) {
-                            s9 = peg$c259;
+                          if (input.substr(peg$currPos, 2) === peg$c262) {
+                            s9 = peg$c262;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c260); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c263); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c261(s3, s7);
+                            s1 = peg$c264(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8192,92 +8233,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c262) {
-      s1 = peg$c262;
+    if (input.substr(peg$currPos, 5) === peg$c265) {
+      s1 = peg$c265;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c264) {
-        s1 = peg$c264;
+      if (input.substr(peg$currPos, 6) === peg$c267) {
+        s1 = peg$c267;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c266) {
-          s1 = peg$c266;
+        if (input.substr(peg$currPos, 6) === peg$c269) {
+          s1 = peg$c269;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c267); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c268) {
-            s1 = peg$c268;
+          if (input.substr(peg$currPos, 6) === peg$c271) {
+            s1 = peg$c271;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c270) {
-              s1 = peg$c270;
+            if (input.substr(peg$currPos, 4) === peg$c273) {
+              s1 = peg$c273;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c271); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c272) {
-                s1 = peg$c272;
+              if (input.substr(peg$currPos, 5) === peg$c275) {
+                s1 = peg$c275;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c273); }
+                if (peg$silentFails === 0) { peg$fail(peg$c276); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c274) {
-                  s1 = peg$c274;
+                if (input.substr(peg$currPos, 5) === peg$c277) {
+                  s1 = peg$c277;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c275); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c278); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c276) {
-                    s1 = peg$c276;
+                  if (input.substr(peg$currPos, 5) === peg$c279) {
+                    s1 = peg$c279;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c277); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c280); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c278) {
-                      s1 = peg$c278;
+                    if (input.substr(peg$currPos, 7) === peg$c281) {
+                      s1 = peg$c281;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c282); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c280) {
-                        s1 = peg$c280;
+                      if (input.substr(peg$currPos, 4) === peg$c283) {
+                        s1 = peg$c283;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c284); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c282) {
-                          s1 = peg$c282;
+                        if (input.substr(peg$currPos, 6) === peg$c285) {
+                          s1 = peg$c285;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c286); }
                         }
                       }
                     }
@@ -8291,7 +8332,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c284();
+      s1 = peg$c287();
     }
     s0 = s1;
 
@@ -8302,52 +8343,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c285) {
-      s1 = peg$c285;
+    if (input.substr(peg$currPos, 8) === peg$c288) {
+      s1 = peg$c288;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c289); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c287) {
-        s1 = peg$c287;
+      if (input.substr(peg$currPos, 4) === peg$c290) {
+        s1 = peg$c290;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c291); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c289) {
-          s1 = peg$c289;
+        if (input.substr(peg$currPos, 5) === peg$c292) {
+          s1 = peg$c292;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+          if (peg$silentFails === 0) { peg$fail(peg$c293); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c291) {
-            s1 = peg$c291;
+          if (input.substr(peg$currPos, 7) === peg$c294) {
+            s1 = peg$c294;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c292); }
+            if (peg$silentFails === 0) { peg$fail(peg$c295); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c293) {
-              s1 = peg$c293;
+            if (input.substr(peg$currPos, 2) === peg$c296) {
+              s1 = peg$c296;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c294); }
+              if (peg$silentFails === 0) { peg$fail(peg$c297); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c295) {
-                s1 = peg$c295;
+              if (input.substr(peg$currPos, 3) === peg$c298) {
+                s1 = peg$c298;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c296); }
+                if (peg$silentFails === 0) { peg$fail(peg$c299); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -8358,12 +8399,12 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c297) {
-                    s1 = peg$c297;
+                  if (input.substr(peg$currPos, 5) === peg$c300) {
+                    s1 = peg$c300;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c301); }
                   }
                 }
               }
@@ -8374,7 +8415,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c284();
+      s1 = peg$c287();
     }
     s0 = s1;
 
@@ -8395,7 +8436,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245(s1, s2);
+        s1 = peg$c248(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8416,11 +8457,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c43;
+        s2 = peg$c46;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8428,7 +8469,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c239(s4);
+            s1 = peg$c242(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8459,11 +8500,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c39;
+          s3 = peg$c42;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8471,7 +8512,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c299(s1, s5);
+              s1 = peg$c302(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8512,29 +8553,9 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c300) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c303) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c302();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c303) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c304); }
@@ -8548,20 +8569,40 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseInToken() {
+  function peg$parseOrToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c69) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c306) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c306); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c307();
+      s1 = peg$c308();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseInToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c72) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c310();
     }
     s0 = s1;
 
@@ -8572,29 +8613,9 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c200) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c203) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c308); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c309();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseByToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c310) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c311); }
@@ -8608,15 +8629,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseByToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c313) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c315();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c313.test(input.charAt(peg$currPos))) {
+    if (peg$c316.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
 
     return s0;
@@ -8627,12 +8668,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c315.test(input.charAt(peg$currPos))) {
+      if (peg$c318.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c316); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
     }
 
@@ -8646,7 +8687,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c317(s1);
+      s1 = peg$c320(s1);
     }
     s0 = s1;
 
@@ -8701,7 +8742,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c318();
+          s1 = peg$c321();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8718,31 +8759,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c319;
+        s1 = peg$c322;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c321;
+          s1 = peg$c324;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c323(s2);
+            s1 = peg$c326(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8763,7 +8804,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c64();
+            s1 = peg$c67();
           }
           s0 = s1;
         }
@@ -8804,12 +8845,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c300) {
-                s3 = peg$c300;
+              if (input.substr(peg$currPos, 3) === peg$c303) {
+                s3 = peg$c303;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                if (peg$silentFails === 0) { peg$fail(peg$c327); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -8854,44 +8895,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c325) {
-      s0 = peg$c325;
+    if (input.substr(peg$currPos, 7) === peg$c328) {
+      s0 = peg$c328;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+      if (peg$silentFails === 0) { peg$fail(peg$c329); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c327) {
-        s0 = peg$c327;
+      if (input.substr(peg$currPos, 6) === peg$c330) {
+        s0 = peg$c330;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c331); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c329) {
-          s0 = peg$c329;
+        if (input.substr(peg$currPos, 4) === peg$c332) {
+          s0 = peg$c332;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c330); }
+          if (peg$silentFails === 0) { peg$fail(peg$c333); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c331) {
-            s0 = peg$c331;
+          if (input.substr(peg$currPos, 3) === peg$c334) {
+            s0 = peg$c334;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c332); }
+            if (peg$silentFails === 0) { peg$fail(peg$c335); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c333;
+              s0 = peg$c336;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c334); }
+              if (peg$silentFails === 0) { peg$fail(peg$c337); }
             }
           }
         }
@@ -8904,44 +8945,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c335) {
-      s0 = peg$c335;
+    if (input.substr(peg$currPos, 7) === peg$c338) {
+      s0 = peg$c338;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c337) {
-        s0 = peg$c337;
+      if (input.substr(peg$currPos, 6) === peg$c340) {
+        s0 = peg$c340;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c338); }
+        if (peg$silentFails === 0) { peg$fail(peg$c341); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c339) {
-          s0 = peg$c339;
+        if (input.substr(peg$currPos, 4) === peg$c342) {
+          s0 = peg$c342;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c340); }
+          if (peg$silentFails === 0) { peg$fail(peg$c343); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c341) {
-            s0 = peg$c341;
+          if (input.substr(peg$currPos, 3) === peg$c344) {
+            s0 = peg$c344;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c342); }
+            if (peg$silentFails === 0) { peg$fail(peg$c345); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c343;
+              s0 = peg$c346;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c347); }
             }
           }
         }
@@ -8954,44 +8995,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c345) {
-      s0 = peg$c345;
+    if (input.substr(peg$currPos, 5) === peg$c348) {
+      s0 = peg$c348;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c347) {
-        s0 = peg$c347;
+      if (input.substr(peg$currPos, 3) === peg$c350) {
+        s0 = peg$c350;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c348); }
+        if (peg$silentFails === 0) { peg$fail(peg$c351); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c349) {
-          s0 = peg$c349;
+        if (input.substr(peg$currPos, 2) === peg$c352) {
+          s0 = peg$c352;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c350); }
+          if (peg$silentFails === 0) { peg$fail(peg$c353); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c351;
+            s0 = peg$c354;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c352); }
+            if (peg$silentFails === 0) { peg$fail(peg$c355); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c353) {
-              s0 = peg$c353;
+            if (input.substr(peg$currPos, 4) === peg$c356) {
+              s0 = peg$c356;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c354); }
+              if (peg$silentFails === 0) { peg$fail(peg$c357); }
             }
           }
         }
@@ -9004,28 +9045,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c355) {
-      s0 = peg$c355;
+    if (input.substr(peg$currPos, 4) === peg$c358) {
+      s0 = peg$c358;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c357) {
-        s0 = peg$c357;
+      if (input.substr(peg$currPos, 3) === peg$c360) {
+        s0 = peg$c360;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c358); }
+        if (peg$silentFails === 0) { peg$fail(peg$c361); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c359;
+          s0 = peg$c362;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          if (peg$silentFails === 0) { peg$fail(peg$c363); }
         }
       }
     }
@@ -9036,44 +9077,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c361) {
-      s0 = peg$c361;
+    if (input.substr(peg$currPos, 5) === peg$c364) {
+      s0 = peg$c364;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c362); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c363) {
-        s0 = peg$c363;
+      if (input.substr(peg$currPos, 4) === peg$c366) {
+        s0 = peg$c366;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c364); }
+        if (peg$silentFails === 0) { peg$fail(peg$c367); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c365) {
-          s0 = peg$c365;
+        if (input.substr(peg$currPos, 3) === peg$c368) {
+          s0 = peg$c368;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c366); }
+          if (peg$silentFails === 0) { peg$fail(peg$c369); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c367) {
-            s0 = peg$c367;
+          if (input.substr(peg$currPos, 2) === peg$c370) {
+            s0 = peg$c370;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c368); }
+            if (peg$silentFails === 0) { peg$fail(peg$c371); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c369;
+              s0 = peg$c372;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c370); }
+              if (peg$silentFails === 0) { peg$fail(peg$c373); }
             }
           }
         }
@@ -9087,16 +9128,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c327) {
-      s1 = peg$c327;
+    if (input.substr(peg$currPos, 6) === peg$c330) {
+      s1 = peg$c330;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c331); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371();
+      s1 = peg$c374();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9108,7 +9149,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c372(s1);
+            s1 = peg$c375(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9131,16 +9172,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c337) {
-      s1 = peg$c337;
+    if (input.substr(peg$currPos, 6) === peg$c340) {
+      s1 = peg$c340;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c373();
+      s1 = peg$c376();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9152,7 +9193,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c374(s1);
+            s1 = peg$c377(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9175,16 +9216,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c353) {
-      s1 = peg$c353;
+    if (input.substr(peg$currPos, 4) === peg$c356) {
+      s1 = peg$c356;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375();
+      s1 = peg$c378();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9196,7 +9237,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c376(s1);
+            s1 = peg$c379(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9219,16 +9260,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c357) {
-      s1 = peg$c357;
+    if (input.substr(peg$currPos, 3) === peg$c360) {
+      s1 = peg$c360;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377();
+      s1 = peg$c380();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9240,7 +9281,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c378(s1);
+            s1 = peg$c381(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9263,16 +9304,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c363) {
-      s1 = peg$c363;
+    if (input.substr(peg$currPos, 4) === peg$c366) {
+      s1 = peg$c366;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379();
+      s1 = peg$c382();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9284,7 +9325,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c380(s1);
+            s1 = peg$c383(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9310,37 +9351,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c102;
+        s2 = peg$c105;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c102;
+            s4 = peg$c105;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c103); }
+            if (peg$silentFails === 0) { peg$fail(peg$c106); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c102;
+                s6 = peg$c105;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c64();
+                  s1 = peg$c67();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9384,11 +9425,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c39;
+        s4 = peg$c42;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -9398,11 +9439,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c39;
+              s7 = peg$c42;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+              if (peg$silentFails === 0) { peg$fail(peg$c43); }
             }
           }
           peg$silentFails--;
@@ -9474,7 +9515,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c381(s1, s2);
+        s1 = peg$c384(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9495,12 +9536,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c382) {
-            s3 = peg$c382;
+          if (input.substr(peg$currPos, 2) === peg$c385) {
+            s3 = peg$c385;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c383); }
+            if (peg$silentFails === 0) { peg$fail(peg$c386); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -9513,7 +9554,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c384(s1, s2, s4, s5);
+                s1 = peg$c387(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9537,12 +9578,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c382) {
-          s1 = peg$c382;
+        if (input.substr(peg$currPos, 2) === peg$c385) {
+          s1 = peg$c385;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c383); }
+          if (peg$silentFails === 0) { peg$fail(peg$c386); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -9555,7 +9596,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c385(s2, s3);
+              s1 = peg$c388(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9580,16 +9621,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c382) {
-                s3 = peg$c382;
+              if (input.substr(peg$currPos, 2) === peg$c385) {
+                s3 = peg$c385;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                if (peg$silentFails === 0) { peg$fail(peg$c386); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c386(s1, s2);
+                s1 = peg$c389(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9605,16 +9646,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c382) {
-              s1 = peg$c382;
+            if (input.substr(peg$currPos, 2) === peg$c385) {
+              s1 = peg$c385;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c383); }
+              if (peg$silentFails === 0) { peg$fail(peg$c386); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c387();
+              s1 = peg$c390();
             }
             s0 = s1;
           }
@@ -9641,17 +9682,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c39;
+      s1 = peg$c42;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c40); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s2);
+        s1 = peg$c391(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9672,15 +9713,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c39;
+        s2 = peg$c42;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c389(s1);
+        s1 = peg$c392(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9701,17 +9742,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c197;
+        s2 = peg$c200;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c390(s1, s3);
+          s1 = peg$c393(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9736,17 +9777,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c197;
+        s2 = peg$c200;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s1, s3);
+          s1 = peg$c394(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9771,7 +9812,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c392(s1);
+      s1 = peg$c395(s1);
     }
     s0 = s1;
 
@@ -9794,22 +9835,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c315.test(input.charAt(peg$currPos))) {
+    if (peg$c318.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c315.test(input.charAt(peg$currPos))) {
+        if (peg$c318.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c316); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
       }
     } else {
@@ -9817,7 +9858,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -9829,17 +9870,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9858,33 +9899,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c315.test(input.charAt(peg$currPos))) {
+      if (peg$c318.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c316); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c315.test(input.charAt(peg$currPos))) {
+          if (peg$c318.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c316); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
         }
       } else {
@@ -9892,30 +9933,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c102;
+          s3 = peg$c105;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c106); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c315.test(input.charAt(peg$currPos))) {
+          if (peg$c318.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c316); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c315.test(input.charAt(peg$currPos))) {
+              if (peg$c318.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
             }
           } else {
@@ -9928,7 +9969,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c393();
+              s1 = peg$c396();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9953,41 +9994,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c195;
+        s1 = peg$c198;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c102;
+          s2 = peg$c105;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c106); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c315.test(input.charAt(peg$currPos))) {
+          if (peg$c318.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c316); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c315.test(input.charAt(peg$currPos))) {
+              if (peg$c318.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
             }
           } else {
@@ -10000,7 +10041,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c393();
+              s1 = peg$c396();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10027,20 +10068,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c394) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c397) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c396.test(input.charAt(peg$currPos))) {
+      if (peg$c399.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c397); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -10082,7 +10123,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -10092,12 +10133,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c398.test(input.charAt(peg$currPos))) {
+    if (peg$c401.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c399); }
+      if (peg$silentFails === 0) { peg$fail(peg$c402); }
     }
 
     return s0;
@@ -10108,11 +10149,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10123,15 +10164,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c403;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c402(s2);
+          s1 = peg$c405(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10148,11 +10189,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c403;
+        s1 = peg$c406;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c404); }
+        if (peg$silentFails === 0) { peg$fail(peg$c407); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -10163,15 +10204,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c403;
+            s3 = peg$c406;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c404); }
+            if (peg$silentFails === 0) { peg$fail(peg$c407); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c402(s2);
+            s1 = peg$c405(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10197,11 +10238,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c400;
+      s2 = peg$c403;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10219,11 +10260,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10236,17 +10277,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c321;
+        s1 = peg$c324;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c406(s2);
+          s1 = peg$c409(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10275,7 +10316,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c407(s1, s2);
+        s1 = peg$c410(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10293,16 +10334,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c408.test(input.charAt(peg$currPos))) {
+    if (peg$c411.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c412); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -10317,12 +10358,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c315.test(input.charAt(peg$currPos))) {
+      if (peg$c318.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c316); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
     }
 
@@ -10334,11 +10375,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c321;
+      s1 = peg$c324;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -10347,7 +10388,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c406(s2);
+        s1 = peg$c409(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10368,11 +10409,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c403;
+      s2 = peg$c406;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c407); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10390,11 +10431,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10407,17 +10448,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c321;
+        s1 = peg$c324;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c406(s2);
+          s1 = peg$c409(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10437,11 +10478,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c410;
+      s1 = peg$c413;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c414); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -10449,7 +10490,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c412();
+          s1 = peg$c415();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10477,110 +10518,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c403;
+      s0 = peg$c406;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c407); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c400;
+        s0 = peg$c403;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c401); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c321;
+          s0 = peg$c324;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c413;
+            s1 = peg$c416;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c414); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c415();
+            s1 = peg$c418();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c416;
+              s1 = peg$c419;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c417); }
+              if (peg$silentFails === 0) { peg$fail(peg$c420); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c418();
+              s1 = peg$c421();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c419;
+                s1 = peg$c422;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c421();
+                s1 = peg$c424();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c422;
+                  s1 = peg$c425;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c424();
+                  s1 = peg$c427();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c425;
+                    s1 = peg$c428;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c429); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c427();
+                    s1 = peg$c430();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c428;
+                      s1 = peg$c431;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c432); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c430();
+                      s1 = peg$c433();
                     }
                     s0 = s1;
                   }
@@ -10608,30 +10649,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c431();
+      s1 = peg$c434();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c53;
+        s1 = peg$c56;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c432();
+        s1 = peg$c435();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c396.test(input.charAt(peg$currPos))) {
+        if (peg$c399.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c397); }
+          if (peg$silentFails === 0) { peg$fail(peg$c400); }
         }
       }
     }
@@ -10644,11 +10685,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c433;
+      s1 = peg$c436;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c434); }
+      if (peg$silentFails === 0) { peg$fail(peg$c437); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -10680,7 +10721,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c435(s2);
+        s1 = peg$c438(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10693,19 +10734,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c433;
+        s1 = peg$c436;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+        if (peg$silentFails === 0) { peg$fail(peg$c437); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c246;
+          s2 = peg$c249;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+          if (peg$silentFails === 0) { peg$fail(peg$c250); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -10764,15 +10805,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c248;
+              s4 = peg$c251;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c252); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c435(s3);
+              s1 = peg$c438(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10800,25 +10841,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c197;
+      s1 = peg$c200;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c201); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c197;
+          s3 = peg$c200;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c201); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c436(s2);
+          s1 = peg$c439(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10841,39 +10882,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c437.test(input.charAt(peg$currPos))) {
+    if (peg$c440.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c438); }
+      if (peg$silentFails === 0) { peg$fail(peg$c441); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c439) {
-        s2 = peg$c439;
+      if (input.substr(peg$currPos, 2) === peg$c442) {
+        s2 = peg$c442;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c440); }
+        if (peg$silentFails === 0) { peg$fail(peg$c443); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c437.test(input.charAt(peg$currPos))) {
+        if (peg$c440.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c438); }
+          if (peg$silentFails === 0) { peg$fail(peg$c441); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c439) {
-            s2 = peg$c439;
+          if (input.substr(peg$currPos, 2) === peg$c442) {
+            s2 = peg$c442;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c440); }
+            if (peg$silentFails === 0) { peg$fail(peg$c443); }
           }
         }
       }
@@ -10882,7 +10923,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -10892,12 +10933,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c441.test(input.charAt(peg$currPos))) {
+    if (peg$c444.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+      if (peg$silentFails === 0) { peg$fail(peg$c445); }
     }
 
     return s0;
@@ -10955,7 +10996,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
 
     return s0;
@@ -10966,51 +11007,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c444;
+      s0 = peg$c447;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c445); }
+      if (peg$silentFails === 0) { peg$fail(peg$c448); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c446;
+        s0 = peg$c449;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c447); }
+        if (peg$silentFails === 0) { peg$fail(peg$c450); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c448;
+          s0 = peg$c451;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c449); }
+          if (peg$silentFails === 0) { peg$fail(peg$c452); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c450;
+            s0 = peg$c453;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c451); }
+            if (peg$silentFails === 0) { peg$fail(peg$c454); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c452;
+              s0 = peg$c455;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c453); }
+              if (peg$silentFails === 0) { peg$fail(peg$c456); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c454;
+                s0 = peg$c457;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c455); }
+                if (peg$silentFails === 0) { peg$fail(peg$c458); }
               }
             }
           }
@@ -11019,7 +11060,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+      if (peg$silentFails === 0) { peg$fail(peg$c446); }
     }
 
     return s0;
@@ -11028,12 +11069,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c456.test(input.charAt(peg$currPos))) {
+    if (peg$c459.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c457); }
+      if (peg$silentFails === 0) { peg$fail(peg$c460); }
     }
 
     return s0;
@@ -11046,7 +11087,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
 
     return s0;
@@ -11056,12 +11097,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c463) {
-      s1 = peg$c463;
+    if (input.substr(peg$currPos, 2) === peg$c466) {
+      s1 = peg$c466;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11179,7 +11220,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -452,40 +452,95 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchBranch",
-			pos:  position{line: 56, col: 1, offset: 1753},
-			expr: &actionExpr{
-				pos: position{line: 57, col: 5, offset: 1770},
-				run: (*parser).callonSwitchBranch1,
-				expr: &seqExpr{
-					pos: position{line: 57, col: 5, offset: 1770},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 57, col: 5, offset: 1770},
-							label: "filter",
-							expr: &ruleRefExpr{
-								pos:  position{line: 57, col: 12, offset: 1777},
-								name: "SearchBoolean",
+			pos:  position{line: 55, col: 1, offset: 1752},
+			expr: &choiceExpr{
+				pos: position{line: 56, col: 5, offset: 1769},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 56, col: 5, offset: 1769},
+						run: (*parser).callonSwitchBranch2,
+						expr: &seqExpr{
+							pos: position{line: 56, col: 5, offset: 1769},
+							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 56, col: 5, offset: 1769},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 56, col: 8, offset: 1772},
+									name: "CaseToken",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 56, col: 18, offset: 1782},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 56, col: 20, offset: 1784},
+									label: "filter",
+									expr: &ruleRefExpr{
+										pos:  position{line: 56, col: 27, offset: 1791},
+										name: "SearchBoolean",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 56, col: 41, offset: 1805},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 56, col: 44, offset: 1808},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 56, col: 49, offset: 1813},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 56, col: 52, offset: 1816},
+									label: "proc",
+									expr: &ruleRefExpr{
+										pos:  position{line: 56, col: 57, offset: 1821},
+										name: "Sequential",
+									},
+								},
 							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 57, col: 26, offset: 1791},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 57, col: 29, offset: 1794},
-							val:        "=>",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 57, col: 34, offset: 1799},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 57, col: 37, offset: 1802},
-							label: "proc",
-							expr: &ruleRefExpr{
-								pos:  position{line: 57, col: 42, offset: 1807},
-								name: "Sequential",
+					},
+					&actionExpr{
+						pos: position{line: 59, col: 5, offset: 1917},
+						run: (*parser).callonSwitchBranch14,
+						expr: &seqExpr{
+							pos: position{line: 59, col: 5, offset: 1917},
+							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 59, col: 5, offset: 1917},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 59, col: 8, offset: 1920},
+									name: "DefaultToken",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 59, col: 21, offset: 1933},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 59, col: 24, offset: 1936},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 59, col: 29, offset: 1941},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 59, col: 32, offset: 1944},
+									label: "proc",
+									expr: &ruleRefExpr{
+										pos:  position{line: 59, col: 37, offset: 1949},
+										name: "Sequential",
+									},
+								},
 							},
 						},
 					},
@@ -494,32 +549,32 @@ var g = &grammar{
 		},
 		{
 			name: "Switch",
-			pos:  position{line: 61, col: 1, offset: 1896},
+			pos:  position{line: 63, col: 1, offset: 2108},
 			expr: &choiceExpr{
-				pos: position{line: 62, col: 5, offset: 1907},
+				pos: position{line: 64, col: 5, offset: 2119},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 62, col: 5, offset: 1907},
+						pos: position{line: 64, col: 5, offset: 2119},
 						run: (*parser).callonSwitch2,
 						expr: &seqExpr{
-							pos: position{line: 62, col: 5, offset: 1907},
+							pos: position{line: 64, col: 5, offset: 2119},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 62, col: 5, offset: 1907},
+									pos:   position{line: 64, col: 5, offset: 2119},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 62, col: 11, offset: 1913},
+										pos:  position{line: 64, col: 11, offset: 2125},
 										name: "SwitchBranch",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 62, col: 24, offset: 1926},
+									pos:   position{line: 64, col: 24, offset: 2138},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 62, col: 29, offset: 1931},
+										pos: position{line: 64, col: 29, offset: 2143},
 										expr: &ruleRefExpr{
-											pos:  position{line: 62, col: 29, offset: 1931},
-											name: "SwitchTail",
+											pos:  position{line: 64, col: 29, offset: 2143},
+											name: "SwitchBranch",
 										},
 									},
 								},
@@ -527,46 +582,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 65, col: 5, offset: 2030},
+						pos: position{line: 67, col: 5, offset: 2244},
 						run: (*parser).callonSwitch9,
 						expr: &labeledExpr{
-							pos:   position{line: 65, col: 5, offset: 2030},
+							pos:   position{line: 67, col: 5, offset: 2244},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 65, col: 11, offset: 2036},
-								name: "SwitchBranch",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SwitchTail",
-			pos:  position{line: 69, col: 1, offset: 2097},
-			expr: &actionExpr{
-				pos: position{line: 70, col: 5, offset: 2112},
-				run: (*parser).callonSwitchTail1,
-				expr: &seqExpr{
-					pos: position{line: 70, col: 5, offset: 2112},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 70, col: 5, offset: 2112},
-							name: "__",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 70, col: 8, offset: 2115},
-							name: "CaseToken",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 70, col: 18, offset: 2125},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 70, col: 21, offset: 2128},
-							label: "ch",
-							expr: &ruleRefExpr{
-								pos:  position{line: 70, col: 24, offset: 2131},
+								pos:  position{line: 67, col: 11, offset: 2250},
 								name: "SwitchBranch",
 							},
 						},
@@ -576,66 +598,75 @@ var g = &grammar{
 		},
 		{
 			name: "CaseToken",
-			pos:  position{line: 72, col: 1, offset: 2164},
+			pos:  position{line: 71, col: 1, offset: 2311},
 			expr: &litMatcher{
-				pos:        position{line: 72, col: 13, offset: 2176},
+				pos:        position{line: 71, col: 13, offset: 2323},
 				val:        "case",
-				ignoreCase: false,
+				ignoreCase: true,
+			},
+		},
+		{
+			name: "DefaultToken",
+			pos:  position{line: 72, col: 1, offset: 2331},
+			expr: &litMatcher{
+				pos:        position{line: 72, col: 16, offset: 2346},
+				val:        "default",
+				ignoreCase: true,
 			},
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 74, col: 1, offset: 2184},
+			pos:  position{line: 74, col: 1, offset: 2358},
 			expr: &choiceExpr{
-				pos: position{line: 75, col: 5, offset: 2198},
+				pos: position{line: 75, col: 5, offset: 2372},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 75, col: 5, offset: 2198},
+						pos: position{line: 75, col: 5, offset: 2372},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 75, col: 5, offset: 2198},
+							pos: position{line: 75, col: 5, offset: 2372},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 75, col: 5, offset: 2198},
+									pos:        position{line: 75, col: 5, offset: 2372},
 									val:        "split",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 13, offset: 2206},
+									pos:  position{line: 75, col: 13, offset: 2380},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 16, offset: 2209},
+									pos:        position{line: 75, col: 16, offset: 2383},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 20, offset: 2213},
+									pos:  position{line: 75, col: 20, offset: 2387},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 23, offset: 2216},
+									pos:        position{line: 75, col: 23, offset: 2390},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 28, offset: 2221},
+									pos:  position{line: 75, col: 28, offset: 2395},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 75, col: 31, offset: 2224},
+									pos:   position{line: 75, col: 31, offset: 2398},
 									label: "procArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 75, col: 41, offset: 2234},
+										pos:  position{line: 75, col: 41, offset: 2408},
 										name: "Parallel",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 50, offset: 2243},
+									pos:  position{line: 75, col: 50, offset: 2417},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 53, offset: 2246},
+									pos:        position{line: 75, col: 53, offset: 2420},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -643,51 +674,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 78, col: 5, offset: 2345},
+						pos: position{line: 78, col: 5, offset: 2519},
 						run: (*parser).callonOperation14,
 						expr: &seqExpr{
-							pos: position{line: 78, col: 5, offset: 2345},
+							pos: position{line: 78, col: 5, offset: 2519},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 78, col: 5, offset: 2345},
+									pos:        position{line: 78, col: 5, offset: 2519},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 14, offset: 2354},
+									pos:  position{line: 78, col: 14, offset: 2528},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 78, col: 17, offset: 2357},
+									pos:        position{line: 78, col: 17, offset: 2531},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 21, offset: 2361},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 78, col: 24, offset: 2364},
-									name: "CaseToken",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 78, col: 34, offset: 2374},
+									pos:  position{line: 78, col: 21, offset: 2535},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 78, col: 37, offset: 2377},
+									pos:   position{line: 78, col: 24, offset: 2538},
 									label: "caseArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 78, col: 47, offset: 2387},
+										pos:  position{line: 78, col: 34, offset: 2548},
 										name: "Switch",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 54, offset: 2394},
+									pos:  position{line: 78, col: 41, offset: 2555},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 78, col: 57, offset: 2397},
+									pos:        position{line: 78, col: 44, offset: 2558},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -695,27 +718,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 81, col: 5, offset: 2494},
+						pos:  position{line: 81, col: 5, offset: 2655},
 						name: "Operator",
 					},
 					&actionExpr{
-						pos: position{line: 82, col: 5, offset: 2507},
-						run: (*parser).callonOperation27,
+						pos: position{line: 82, col: 5, offset: 2668},
+						run: (*parser).callonOperation25,
 						expr: &seqExpr{
-							pos: position{line: 82, col: 5, offset: 2507},
+							pos: position{line: 82, col: 5, offset: 2668},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 82, col: 5, offset: 2507},
+									pos:   position{line: 82, col: 5, offset: 2668},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 7, offset: 2509},
+										pos:  position{line: 82, col: 7, offset: 2670},
 										name: "Function",
 									},
 								},
 								&andExpr{
-									pos: position{line: 82, col: 16, offset: 2518},
+									pos: position{line: 82, col: 16, offset: 2679},
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 17, offset: 2519},
+										pos:  position{line: 82, col: 17, offset: 2680},
 										name: "EndOfOp",
 									},
 								},
@@ -723,23 +746,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 83, col: 5, offset: 2549},
-						run: (*parser).callonOperation33,
+						pos: position{line: 83, col: 5, offset: 2710},
+						run: (*parser).callonOperation31,
 						expr: &seqExpr{
-							pos: position{line: 83, col: 5, offset: 2549},
+							pos: position{line: 83, col: 5, offset: 2710},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 83, col: 5, offset: 2549},
+									pos:   position{line: 83, col: 5, offset: 2710},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 7, offset: 2551},
+										pos:  position{line: 83, col: 7, offset: 2712},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 83, col: 19, offset: 2563},
+									pos: position{line: 83, col: 19, offset: 2724},
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 20, offset: 2564},
+										pos:  position{line: 83, col: 20, offset: 2725},
 										name: "EndOfOp",
 									},
 								},
@@ -747,23 +770,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 84, col: 5, offset: 2595},
-						run: (*parser).callonOperation39,
+						pos: position{line: 84, col: 5, offset: 2756},
+						run: (*parser).callonOperation37,
 						expr: &seqExpr{
-							pos: position{line: 84, col: 5, offset: 2595},
+							pos: position{line: 84, col: 5, offset: 2756},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 84, col: 5, offset: 2595},
+									pos:   position{line: 84, col: 5, offset: 2756},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 10, offset: 2600},
+										pos:  position{line: 84, col: 10, offset: 2761},
 										name: "SearchBoolean",
 									},
 								},
 								&notExpr{
-									pos: position{line: 84, col: 24, offset: 2614},
+									pos: position{line: 84, col: 24, offset: 2775},
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 25, offset: 2615},
+										pos:  position{line: 84, col: 25, offset: 2776},
 										name: "AggGuard",
 									},
 								},
@@ -775,34 +798,34 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 88, col: 1, offset: 2710},
+			pos:  position{line: 88, col: 1, offset: 2871},
 			expr: &seqExpr{
-				pos: position{line: 88, col: 11, offset: 2720},
+				pos: position{line: 88, col: 11, offset: 2881},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 88, col: 11, offset: 2720},
+						pos:  position{line: 88, col: 11, offset: 2881},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 88, col: 15, offset: 2724},
+						pos: position{line: 88, col: 15, offset: 2885},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 88, col: 15, offset: 2724},
+								pos:        position{line: 88, col: 15, offset: 2885},
 								val:        "|",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 88, col: 21, offset: 2730},
+								pos:        position{line: 88, col: 21, offset: 2891},
 								val:        "=>",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 88, col: 28, offset: 2737},
+								pos:        position{line: 88, col: 28, offset: 2898},
 								val:        ")",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 88, col: 34, offset: 2743},
+								pos:  position{line: 88, col: 34, offset: 2904},
 								name: "EOF",
 							},
 						},
@@ -812,49 +835,49 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 90, col: 1, offset: 2749},
+			pos:  position{line: 90, col: 1, offset: 2910},
 			expr: &seqExpr{
-				pos: position{line: 90, col: 13, offset: 2761},
+				pos: position{line: 90, col: 13, offset: 2922},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 90, col: 13, offset: 2761},
+						pos:  position{line: 90, col: 13, offset: 2922},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 90, col: 17, offset: 2765},
+						pos: position{line: 90, col: 17, offset: 2926},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 90, col: 18, offset: 2766},
+								pos: position{line: 90, col: 18, offset: 2927},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 90, col: 18, offset: 2766},
+										pos: position{line: 90, col: 18, offset: 2927},
 										expr: &litMatcher{
-											pos:        position{line: 90, col: 19, offset: 2767},
+											pos:        position{line: 90, col: 19, offset: 2928},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 90, col: 24, offset: 2772},
+										pos:  position{line: 90, col: 24, offset: 2933},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 90, col: 38, offset: 2786},
+								pos:  position{line: 90, col: 38, offset: 2947},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 90, col: 57, offset: 2805},
+								pos:  position{line: 90, col: 57, offset: 2966},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 90, col: 82, offset: 2830},
+								pos:        position{line: 90, col: 82, offset: 2991},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 90, col: 88, offset: 2836},
+								pos:        position{line: 90, col: 88, offset: 2997},
 								val:        "(",
 								ignoreCase: false,
 							},
@@ -865,46 +888,46 @@ var g = &grammar{
 		},
 		{
 			name: "AggGuard",
-			pos:  position{line: 92, col: 1, offset: 2842},
+			pos:  position{line: 92, col: 1, offset: 3003},
 			expr: &choiceExpr{
-				pos: position{line: 92, col: 12, offset: 2853},
+				pos: position{line: 92, col: 12, offset: 3014},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 92, col: 13, offset: 2854},
+						pos: position{line: 92, col: 13, offset: 3015},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 13, offset: 2854},
+								pos:  position{line: 92, col: 13, offset: 3015},
 								name: "_",
 							},
 							&choiceExpr{
-								pos: position{line: 92, col: 16, offset: 2857},
+								pos: position{line: 92, col: 16, offset: 3018},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 92, col: 16, offset: 2857},
+										pos:  position{line: 92, col: 16, offset: 3018},
 										name: "ByToken",
 									},
 									&litMatcher{
-										pos:        position{line: 92, col: 26, offset: 2867},
+										pos:        position{line: 92, col: 26, offset: 3028},
 										val:        "-with",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 35, offset: 2876},
+								pos:  position{line: 92, col: 35, offset: 3037},
 								name: "EOT",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 92, col: 43, offset: 2884},
+						pos: position{line: 92, col: 43, offset: 3045},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 43, offset: 2884},
+								pos:  position{line: 92, col: 43, offset: 3045},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 92, col: 46, offset: 2887},
+								pos:        position{line: 92, col: 46, offset: 3048},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -915,28 +938,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 94, col: 1, offset: 2893},
+			pos:  position{line: 94, col: 1, offset: 3054},
 			expr: &actionExpr{
-				pos: position{line: 95, col: 5, offset: 2911},
+				pos: position{line: 95, col: 5, offset: 3072},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 95, col: 5, offset: 2911},
+					pos: position{line: 95, col: 5, offset: 3072},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 95, col: 5, offset: 2911},
+							pos:   position{line: 95, col: 5, offset: 3072},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 95, col: 11, offset: 2917},
+								pos:  position{line: 95, col: 11, offset: 3078},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 95, col: 21, offset: 2927},
+							pos:   position{line: 95, col: 21, offset: 3088},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 95, col: 26, offset: 2932},
+								pos: position{line: 95, col: 26, offset: 3093},
 								expr: &ruleRefExpr{
-									pos:  position{line: 95, col: 26, offset: 2932},
+									pos:  position{line: 95, col: 26, offset: 3093},
 									name: "SearchOrTerm",
 								},
 							},
@@ -947,30 +970,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 99, col: 1, offset: 3006},
+			pos:  position{line: 99, col: 1, offset: 3167},
 			expr: &actionExpr{
-				pos: position{line: 99, col: 16, offset: 3021},
+				pos: position{line: 99, col: 16, offset: 3182},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 99, col: 16, offset: 3021},
+					pos: position{line: 99, col: 16, offset: 3182},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 16, offset: 3021},
+							pos:  position{line: 99, col: 16, offset: 3182},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 18, offset: 3023},
+							pos:  position{line: 99, col: 18, offset: 3184},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 26, offset: 3031},
+							pos:  position{line: 99, col: 26, offset: 3192},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 99, col: 28, offset: 3033},
+							pos:   position{line: 99, col: 28, offset: 3194},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 99, col: 30, offset: 3035},
+								pos:  position{line: 99, col: 30, offset: 3196},
 								name: "SearchAnd",
 							},
 						},
@@ -980,61 +1003,61 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 101, col: 1, offset: 3085},
+			pos:  position{line: 101, col: 1, offset: 3246},
 			expr: &actionExpr{
-				pos: position{line: 102, col: 5, offset: 3099},
+				pos: position{line: 102, col: 5, offset: 3260},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 102, col: 5, offset: 3099},
+					pos: position{line: 102, col: 5, offset: 3260},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 102, col: 5, offset: 3099},
+							pos:   position{line: 102, col: 5, offset: 3260},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 102, col: 11, offset: 3105},
+								pos:  position{line: 102, col: 11, offset: 3266},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 103, col: 5, offset: 3122},
+							pos:   position{line: 103, col: 5, offset: 3283},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 103, col: 10, offset: 3127},
+								pos: position{line: 103, col: 10, offset: 3288},
 								expr: &actionExpr{
-									pos: position{line: 103, col: 11, offset: 3128},
+									pos: position{line: 103, col: 11, offset: 3289},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 103, col: 11, offset: 3128},
+										pos: position{line: 103, col: 11, offset: 3289},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 103, col: 11, offset: 3128},
+												pos:  position{line: 103, col: 11, offset: 3289},
 												name: "__",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 103, col: 14, offset: 3131},
+												pos: position{line: 103, col: 14, offset: 3292},
 												expr: &seqExpr{
-													pos: position{line: 103, col: 15, offset: 3132},
+													pos: position{line: 103, col: 15, offset: 3293},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 103, col: 15, offset: 3132},
+															pos:  position{line: 103, col: 15, offset: 3293},
 															name: "AndToken",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 103, col: 24, offset: 3141},
+															pos:  position{line: 103, col: 24, offset: 3302},
 															name: "_",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 103, col: 28, offset: 3145},
+												pos:  position{line: 103, col: 28, offset: 3306},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 103, col: 31, offset: 3148},
+												pos:   position{line: 103, col: 31, offset: 3309},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 103, col: 36, offset: 3153},
+													pos:  position{line: 103, col: 36, offset: 3314},
 													name: "SearchFactor",
 												},
 											},
@@ -1049,42 +1072,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 107, col: 1, offset: 3269},
+			pos:  position{line: 107, col: 1, offset: 3430},
 			expr: &choiceExpr{
-				pos: position{line: 108, col: 5, offset: 3286},
+				pos: position{line: 108, col: 5, offset: 3447},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 108, col: 5, offset: 3286},
+						pos: position{line: 108, col: 5, offset: 3447},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 108, col: 5, offset: 3286},
+							pos: position{line: 108, col: 5, offset: 3447},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 108, col: 6, offset: 3287},
+									pos: position{line: 108, col: 6, offset: 3448},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 108, col: 6, offset: 3287},
+											pos: position{line: 108, col: 6, offset: 3448},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 6, offset: 3287},
+													pos:  position{line: 108, col: 6, offset: 3448},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 15, offset: 3296},
+													pos:  position{line: 108, col: 15, offset: 3457},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 108, col: 19, offset: 3300},
+											pos: position{line: 108, col: 19, offset: 3461},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 108, col: 19, offset: 3300},
+													pos:        position{line: 108, col: 19, offset: 3461},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 23, offset: 3304},
+													pos:  position{line: 108, col: 23, offset: 3465},
 													name: "__",
 												},
 											},
@@ -1092,10 +1115,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 108, col: 27, offset: 3308},
+									pos:   position{line: 108, col: 27, offset: 3469},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 108, col: 29, offset: 3310},
+										pos:  position{line: 108, col: 29, offset: 3471},
 										name: "SearchFactor",
 									},
 								},
@@ -1103,42 +1126,42 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 111, col: 5, offset: 3426},
+						pos:  position{line: 111, col: 5, offset: 3587},
 						name: "ShortCut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 112, col: 5, offset: 3439},
+						pos:  position{line: 112, col: 5, offset: 3600},
 						name: "SearchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 113, col: 5, offset: 3454},
+						pos: position{line: 113, col: 5, offset: 3615},
 						run: (*parser).callonSearchFactor15,
 						expr: &seqExpr{
-							pos: position{line: 113, col: 5, offset: 3454},
+							pos: position{line: 113, col: 5, offset: 3615},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 113, col: 5, offset: 3454},
+									pos:        position{line: 113, col: 5, offset: 3615},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 113, col: 9, offset: 3458},
+									pos:  position{line: 113, col: 9, offset: 3619},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 113, col: 12, offset: 3461},
+									pos:   position{line: 113, col: 12, offset: 3622},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 17, offset: 3466},
+										pos:  position{line: 113, col: 17, offset: 3627},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 113, col: 31, offset: 3480},
+									pos:  position{line: 113, col: 31, offset: 3641},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 113, col: 34, offset: 3483},
+									pos:        position{line: 113, col: 34, offset: 3644},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1150,42 +1173,42 @@ var g = &grammar{
 		},
 		{
 			name: "ShortCut",
-			pos:  position{line: 115, col: 1, offset: 3509},
+			pos:  position{line: 115, col: 1, offset: 3670},
 			expr: &choiceExpr{
-				pos: position{line: 116, col: 5, offset: 3522},
+				pos: position{line: 116, col: 5, offset: 3683},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 116, col: 5, offset: 3522},
+						pos: position{line: 116, col: 5, offset: 3683},
 						run: (*parser).callonShortCut2,
 						expr: &seqExpr{
-							pos: position{line: 116, col: 5, offset: 3522},
+							pos: position{line: 116, col: 5, offset: 3683},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 116, col: 5, offset: 3522},
+									pos:        position{line: 116, col: 5, offset: 3683},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 116, col: 9, offset: 3526},
+									pos:  position{line: 116, col: 9, offset: 3687},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 12, offset: 3529},
+									pos:   position{line: 116, col: 12, offset: 3690},
 									label: "compareOp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 22, offset: 3539},
+										pos:  position{line: 116, col: 22, offset: 3700},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 116, col: 36, offset: 3553},
+									pos:  position{line: 116, col: 36, offset: 3714},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 39, offset: 3556},
+									pos:   position{line: 116, col: 39, offset: 3717},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 41, offset: 3558},
+										pos:  position{line: 116, col: 41, offset: 3719},
 										name: "SearchValue",
 									},
 								},
@@ -1193,47 +1216,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 143, col: 5, offset: 4279},
+						pos: position{line: 143, col: 5, offset: 4440},
 						run: (*parser).callonShortCut11,
 						expr: &seqExpr{
-							pos: position{line: 143, col: 5, offset: 4279},
+							pos: position{line: 143, col: 5, offset: 4440},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 143, col: 5, offset: 4279},
+									pos:   position{line: 143, col: 5, offset: 4440},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 7, offset: 4281},
+										pos:  position{line: 143, col: 7, offset: 4442},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 12, offset: 4286},
+									pos:  position{line: 143, col: 12, offset: 4447},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 15, offset: 4289},
+									pos:   position{line: 143, col: 15, offset: 4450},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 20, offset: 4294},
+										pos:  position{line: 143, col: 20, offset: 4455},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 34, offset: 4308},
+									pos:  position{line: 143, col: 34, offset: 4469},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 37, offset: 4311},
+									pos:   position{line: 143, col: 37, offset: 4472},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 39, offset: 4313},
+										pos:  position{line: 143, col: 39, offset: 4474},
 										name: "GlobbySearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 143, col: 57, offset: 4331},
+									pos: position{line: 143, col: 57, offset: 4492},
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 58, offset: 4332},
+										pos:  position{line: 143, col: 58, offset: 4493},
 										name: "ExprGuard",
 									},
 								},
@@ -1241,33 +1264,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 146, col: 5, offset: 4450},
+						pos: position{line: 146, col: 5, offset: 4611},
 						run: (*parser).callonShortCut23,
 						expr: &seqExpr{
-							pos: position{line: 146, col: 5, offset: 4450},
+							pos: position{line: 146, col: 5, offset: 4611},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 146, col: 5, offset: 4450},
+									pos:   position{line: 146, col: 5, offset: 4611},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 7, offset: 4452},
+										pos:  position{line: 146, col: 7, offset: 4613},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 19, offset: 4464},
+									pos:  position{line: 146, col: 19, offset: 4625},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 21, offset: 4466},
+									pos:  position{line: 146, col: 21, offset: 4627},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 29, offset: 4474},
+									pos:  position{line: 146, col: 29, offset: 4635},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 146, col: 31, offset: 4476},
+									pos:        position{line: 146, col: 31, offset: 4637},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1275,39 +1298,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 173, col: 5, offset: 5190},
+						pos: position{line: 173, col: 5, offset: 5351},
 						run: (*parser).callonShortCut31,
 						expr: &seqExpr{
-							pos: position{line: 173, col: 5, offset: 5190},
+							pos: position{line: 173, col: 5, offset: 5351},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 173, col: 5, offset: 5190},
+									pos: position{line: 173, col: 5, offset: 5351},
 									expr: &seqExpr{
-										pos: position{line: 173, col: 7, offset: 5192},
+										pos: position{line: 173, col: 7, offset: 5353},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 173, col: 7, offset: 5192},
+												pos:  position{line: 173, col: 7, offset: 5353},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 173, col: 19, offset: 5204},
+												pos:  position{line: 173, col: 19, offset: 5365},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 173, col: 24, offset: 5209},
+									pos:   position{line: 173, col: 24, offset: 5370},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 173, col: 26, offset: 5211},
+										pos:  position{line: 173, col: 26, offset: 5372},
 										name: "GlobbySearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 173, col: 44, offset: 5229},
+									pos: position{line: 173, col: 44, offset: 5390},
 									expr: &ruleRefExpr{
-										pos:  position{line: 173, col: 45, offset: 5230},
+										pos:  position{line: 173, col: 45, offset: 5391},
 										name: "ExprGuard",
 									},
 								},
@@ -1315,20 +1338,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 5345},
+						pos: position{line: 176, col: 5, offset: 5506},
 						run: (*parser).callonShortCut41,
 						expr: &seqExpr{
-							pos: position{line: 176, col: 5, offset: 5345},
+							pos: position{line: 176, col: 5, offset: 5506},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 176, col: 5, offset: 5345},
+									pos:        position{line: 176, col: 5, offset: 5506},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 176, col: 9, offset: 5349},
+									pos: position{line: 176, col: 9, offset: 5510},
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 10, offset: 5350},
+										pos:  position{line: 176, col: 10, offset: 5511},
 										name: "ExprGuard",
 									},
 								},
@@ -1340,22 +1363,22 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 180, col: 1, offset: 5460},
+			pos:  position{line: 180, col: 1, offset: 5621},
 			expr: &choiceExpr{
-				pos: position{line: 181, col: 5, offset: 5476},
+				pos: position{line: 181, col: 5, offset: 5637},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 181, col: 5, offset: 5476},
+						pos:  position{line: 181, col: 5, offset: 5637},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 182, col: 5, offset: 5488},
+						pos: position{line: 182, col: 5, offset: 5649},
 						run: (*parser).callonSearchValue3,
 						expr: &labeledExpr{
-							pos:   position{line: 182, col: 5, offset: 5488},
+							pos:   position{line: 182, col: 5, offset: 5649},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 182, col: 7, offset: 5490},
+								pos:  position{line: 182, col: 7, offset: 5651},
 								name: "KeyWord",
 							},
 						},
@@ -1365,22 +1388,22 @@ var g = &grammar{
 		},
 		{
 			name: "GlobbySearchValue",
-			pos:  position{line: 186, col: 1, offset: 5595},
+			pos:  position{line: 186, col: 1, offset: 5756},
 			expr: &choiceExpr{
-				pos: position{line: 187, col: 5, offset: 5617},
+				pos: position{line: 187, col: 5, offset: 5778},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 187, col: 5, offset: 5617},
+						pos:  position{line: 187, col: 5, offset: 5778},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 188, col: 5, offset: 5629},
+						pos: position{line: 188, col: 5, offset: 5790},
 						run: (*parser).callonGlobbySearchValue3,
 						expr: &labeledExpr{
-							pos:   position{line: 188, col: 5, offset: 5629},
+							pos:   position{line: 188, col: 5, offset: 5790},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 7, offset: 5631},
+								pos:  position{line: 188, col: 7, offset: 5792},
 								name: "SearchGlob",
 							},
 						},
@@ -1390,31 +1413,31 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGlob",
-			pos:  position{line: 198, col: 1, offset: 5917},
+			pos:  position{line: 198, col: 1, offset: 6078},
 			expr: &actionExpr{
-				pos: position{line: 199, col: 5, offset: 5932},
+				pos: position{line: 199, col: 5, offset: 6093},
 				run: (*parser).callonSearchGlob1,
 				expr: &seqExpr{
-					pos: position{line: 199, col: 5, offset: 5932},
+					pos: position{line: 199, col: 5, offset: 6093},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 199, col: 5, offset: 5932},
+							pos:   position{line: 199, col: 5, offset: 6093},
 							label: "head",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 199, col: 10, offset: 5937},
+								pos: position{line: 199, col: 10, offset: 6098},
 								expr: &ruleRefExpr{
-									pos:  position{line: 199, col: 10, offset: 5937},
+									pos:  position{line: 199, col: 10, offset: 6098},
 									name: "GlobPart",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 199, col: 20, offset: 5947},
+							pos:   position{line: 199, col: 20, offset: 6108},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 199, col: 25, offset: 5952},
+								pos: position{line: 199, col: 25, offset: 6113},
 								expr: &litMatcher{
-									pos:        position{line: 199, col: 26, offset: 5953},
+									pos:        position{line: 199, col: 26, offset: 6114},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1426,29 +1449,29 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPart",
-			pos:  position{line: 203, col: 1, offset: 6020},
+			pos:  position{line: 203, col: 1, offset: 6181},
 			expr: &choiceExpr{
-				pos: position{line: 204, col: 5, offset: 6033},
+				pos: position{line: 204, col: 5, offset: 6194},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 204, col: 5, offset: 6033},
+						pos: position{line: 204, col: 5, offset: 6194},
 						run: (*parser).callonGlobPart2,
 						expr: &seqExpr{
-							pos: position{line: 204, col: 5, offset: 6033},
+							pos: position{line: 204, col: 5, offset: 6194},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 204, col: 5, offset: 6033},
+									pos:   position{line: 204, col: 5, offset: 6194},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 204, col: 7, offset: 6035},
+										pos:  position{line: 204, col: 7, offset: 6196},
 										name: "Stars",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 204, col: 13, offset: 6041},
+									pos:   position{line: 204, col: 13, offset: 6202},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 204, col: 15, offset: 6043},
+										pos:  position{line: 204, col: 15, offset: 6204},
 										name: "KeyWord",
 									},
 								},
@@ -1456,7 +1479,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 5, offset: 6093},
+						pos:  position{line: 205, col: 5, offset: 6254},
 						name: "KeyWord",
 					},
 				},
@@ -1464,14 +1487,14 @@ var g = &grammar{
 		},
 		{
 			name: "Stars",
-			pos:  position{line: 207, col: 1, offset: 6102},
+			pos:  position{line: 207, col: 1, offset: 6263},
 			expr: &actionExpr{
-				pos: position{line: 207, col: 9, offset: 6110},
+				pos: position{line: 207, col: 9, offset: 6271},
 				run: (*parser).callonStars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 207, col: 9, offset: 6110},
+					pos: position{line: 207, col: 9, offset: 6271},
 					expr: &litMatcher{
-						pos:        position{line: 207, col: 9, offset: 6110},
+						pos:        position{line: 207, col: 9, offset: 6271},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -1480,36 +1503,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGuard",
-			pos:  position{line: 209, col: 1, offset: 6147},
+			pos:  position{line: 209, col: 1, offset: 6308},
 			expr: &choiceExpr{
-				pos: position{line: 210, col: 5, offset: 6163},
+				pos: position{line: 210, col: 5, offset: 6324},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 210, col: 5, offset: 6163},
+						pos:  position{line: 210, col: 5, offset: 6324},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 211, col: 5, offset: 6176},
+						pos:  position{line: 211, col: 5, offset: 6337},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 212, col: 5, offset: 6188},
+						pos:  position{line: 212, col: 5, offset: 6349},
 						name: "NotToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 213, col: 5, offset: 6201},
+						pos:  position{line: 213, col: 5, offset: 6362},
 						name: "InToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 214, col: 5, offset: 6213},
+						pos:  position{line: 214, col: 5, offset: 6374},
 						name: "ByToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 215, col: 5, offset: 6225},
+						pos:  position{line: 215, col: 5, offset: 6386},
 						name: "CaseToken",
 					},
+					&ruleRefExpr{
+						pos:  position{line: 216, col: 5, offset: 6400},
+						name: "DefaultToken",
+					},
 					&litMatcher{
-						pos:        position{line: 216, col: 5, offset: 6239},
+						pos:        position{line: 217, col: 5, offset: 6417},
 						val:        "type(",
 						ignoreCase: false,
 					},
@@ -1518,53 +1545,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 220, col: 1, offset: 6296},
+			pos:  position{line: 221, col: 1, offset: 6474},
 			expr: &ruleRefExpr{
-				pos:  position{line: 220, col: 14, offset: 6309},
+				pos:  position{line: 221, col: 14, offset: 6487},
 				name: "SearchExprRelative",
 			},
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 222, col: 1, offset: 6329},
+			pos:  position{line: 223, col: 1, offset: 6507},
 			expr: &actionExpr{
-				pos: position{line: 222, col: 14, offset: 6342},
+				pos: position{line: 223, col: 14, offset: 6520},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 222, col: 15, offset: 6343},
+					pos: position{line: 223, col: 15, offset: 6521},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 222, col: 15, offset: 6343},
+							pos:        position{line: 223, col: 15, offset: 6521},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 21, offset: 6349},
+							pos:        position{line: 223, col: 21, offset: 6527},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 28, offset: 6356},
+							pos:        position{line: 223, col: 28, offset: 6534},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 35, offset: 6363},
+							pos:        position{line: 223, col: 35, offset: 6541},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 42, offset: 6370},
+							pos:        position{line: 223, col: 42, offset: 6548},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 48, offset: 6376},
+							pos:        position{line: 223, col: 48, offset: 6554},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 222, col: 55, offset: 6383},
+							pos:        position{line: 223, col: 55, offset: 6561},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1574,53 +1601,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprRelative",
-			pos:  position{line: 224, col: 1, offset: 6420},
+			pos:  position{line: 225, col: 1, offset: 6598},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 5, offset: 6443},
+				pos: position{line: 226, col: 5, offset: 6621},
 				run: (*parser).callonSearchExprRelative1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 5, offset: 6443},
+					pos: position{line: 226, col: 5, offset: 6621},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 225, col: 5, offset: 6443},
+							pos:   position{line: 226, col: 5, offset: 6621},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 11, offset: 6449},
+								pos:  position{line: 226, col: 11, offset: 6627},
 								name: "SearchExprAdd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 6467},
+							pos:   position{line: 227, col: 5, offset: 6645},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 226, col: 10, offset: 6472},
+								pos: position{line: 227, col: 10, offset: 6650},
 								expr: &actionExpr{
-									pos: position{line: 226, col: 11, offset: 6473},
+									pos: position{line: 227, col: 11, offset: 6651},
 									run: (*parser).callonSearchExprRelative7,
 									expr: &seqExpr{
-										pos: position{line: 226, col: 11, offset: 6473},
+										pos: position{line: 227, col: 11, offset: 6651},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 226, col: 11, offset: 6473},
+												pos:  position{line: 227, col: 11, offset: 6651},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 226, col: 14, offset: 6476},
+												pos:   position{line: 227, col: 14, offset: 6654},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 226, col: 17, offset: 6479},
+													pos:  position{line: 227, col: 17, offset: 6657},
 													name: "Comparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 226, col: 28, offset: 6490},
+												pos:  position{line: 227, col: 28, offset: 6668},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 226, col: 31, offset: 6493},
+												pos:   position{line: 227, col: 31, offset: 6671},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 226, col: 36, offset: 6498},
+													pos:  position{line: 227, col: 36, offset: 6676},
 													name: "SearchExprAdd",
 												},
 											},
@@ -1635,53 +1662,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprAdd",
-			pos:  position{line: 230, col: 1, offset: 6615},
+			pos:  position{line: 231, col: 1, offset: 6793},
 			expr: &actionExpr{
-				pos: position{line: 231, col: 5, offset: 6633},
+				pos: position{line: 232, col: 5, offset: 6811},
 				run: (*parser).callonSearchExprAdd1,
 				expr: &seqExpr{
-					pos: position{line: 231, col: 5, offset: 6633},
+					pos: position{line: 232, col: 5, offset: 6811},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 231, col: 5, offset: 6633},
+							pos:   position{line: 232, col: 5, offset: 6811},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 11, offset: 6639},
+								pos:  position{line: 232, col: 11, offset: 6817},
 								name: "SearchExprMul",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 5, offset: 6657},
+							pos:   position{line: 233, col: 5, offset: 6835},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 232, col: 10, offset: 6662},
+								pos: position{line: 233, col: 10, offset: 6840},
 								expr: &actionExpr{
-									pos: position{line: 232, col: 11, offset: 6663},
+									pos: position{line: 233, col: 11, offset: 6841},
 									run: (*parser).callonSearchExprAdd7,
 									expr: &seqExpr{
-										pos: position{line: 232, col: 11, offset: 6663},
+										pos: position{line: 233, col: 11, offset: 6841},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 232, col: 11, offset: 6663},
+												pos:  position{line: 233, col: 11, offset: 6841},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 232, col: 14, offset: 6666},
+												pos:   position{line: 233, col: 14, offset: 6844},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 232, col: 17, offset: 6669},
+													pos:  position{line: 233, col: 17, offset: 6847},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 232, col: 34, offset: 6686},
+												pos:  position{line: 233, col: 34, offset: 6864},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 232, col: 37, offset: 6689},
+												pos:   position{line: 233, col: 37, offset: 6867},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 232, col: 42, offset: 6694},
+													pos:  position{line: 233, col: 42, offset: 6872},
 													name: "SearchExprMul",
 												},
 											},
@@ -1696,53 +1723,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprMul",
-			pos:  position{line: 236, col: 1, offset: 6811},
+			pos:  position{line: 237, col: 1, offset: 6989},
 			expr: &actionExpr{
-				pos: position{line: 237, col: 5, offset: 6829},
+				pos: position{line: 238, col: 5, offset: 7007},
 				run: (*parser).callonSearchExprMul1,
 				expr: &seqExpr{
-					pos: position{line: 237, col: 5, offset: 6829},
+					pos: position{line: 238, col: 5, offset: 7007},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 237, col: 5, offset: 6829},
+							pos:   position{line: 238, col: 5, offset: 7007},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 237, col: 11, offset: 6835},
+								pos:  position{line: 238, col: 11, offset: 7013},
 								name: "SearchExprCast",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 238, col: 5, offset: 6854},
+							pos:   position{line: 239, col: 5, offset: 7032},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 238, col: 10, offset: 6859},
+								pos: position{line: 239, col: 10, offset: 7037},
 								expr: &actionExpr{
-									pos: position{line: 238, col: 11, offset: 6860},
+									pos: position{line: 239, col: 11, offset: 7038},
 									run: (*parser).callonSearchExprMul7,
 									expr: &seqExpr{
-										pos: position{line: 238, col: 11, offset: 6860},
+										pos: position{line: 239, col: 11, offset: 7038},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 238, col: 11, offset: 6860},
+												pos:  position{line: 239, col: 11, offset: 7038},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 238, col: 14, offset: 6863},
+												pos:   position{line: 239, col: 14, offset: 7041},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 238, col: 17, offset: 6866},
+													pos:  position{line: 239, col: 17, offset: 7044},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 238, col: 40, offset: 6889},
+												pos:  position{line: 239, col: 40, offset: 7067},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 238, col: 43, offset: 6892},
+												pos:   position{line: 239, col: 43, offset: 7070},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 238, col: 48, offset: 6897},
+													pos:  position{line: 239, col: 48, offset: 7075},
 													name: "SearchExprCast",
 												},
 											},
@@ -1757,42 +1784,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprCast",
-			pos:  position{line: 242, col: 1, offset: 7015},
+			pos:  position{line: 243, col: 1, offset: 7193},
 			expr: &choiceExpr{
-				pos: position{line: 243, col: 5, offset: 7034},
+				pos: position{line: 244, col: 5, offset: 7212},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 243, col: 5, offset: 7034},
+						pos: position{line: 244, col: 5, offset: 7212},
 						run: (*parser).callonSearchExprCast2,
 						expr: &seqExpr{
-							pos: position{line: 243, col: 5, offset: 7034},
+							pos: position{line: 244, col: 5, offset: 7212},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 243, col: 5, offset: 7034},
+									pos:   position{line: 244, col: 5, offset: 7212},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 243, col: 7, offset: 7036},
+										pos:  position{line: 244, col: 7, offset: 7214},
 										name: "SearchExprFunc",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 243, col: 22, offset: 7051},
+									pos:  position{line: 244, col: 22, offset: 7229},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 243, col: 25, offset: 7054},
+									pos:        position{line: 244, col: 25, offset: 7232},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 243, col: 29, offset: 7058},
+									pos:  position{line: 244, col: 29, offset: 7236},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 243, col: 32, offset: 7061},
+									pos:   position{line: 244, col: 32, offset: 7239},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 243, col: 36, offset: 7065},
+										pos:  position{line: 244, col: 36, offset: 7243},
 										name: "CastType",
 									},
 								},
@@ -1800,7 +1827,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 246, col: 5, offset: 7169},
+						pos:  position{line: 247, col: 5, offset: 7347},
 						name: "SearchExprFunc",
 					},
 				},
@@ -1808,39 +1835,39 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprFunc",
-			pos:  position{line: 248, col: 1, offset: 7185},
+			pos:  position{line: 249, col: 1, offset: 7363},
 			expr: &choiceExpr{
-				pos: position{line: 249, col: 5, offset: 7204},
+				pos: position{line: 250, col: 5, offset: 7382},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 249, col: 5, offset: 7204},
+						pos:  position{line: 250, col: 5, offset: 7382},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 250, col: 5, offset: 7218},
+						pos:  position{line: 251, col: 5, offset: 7396},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 251, col: 5, offset: 7234},
+						pos: position{line: 252, col: 5, offset: 7412},
 						run: (*parser).callonSearchExprFunc4,
 						expr: &seqExpr{
-							pos: position{line: 251, col: 5, offset: 7234},
+							pos: position{line: 252, col: 5, offset: 7412},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 251, col: 5, offset: 7234},
+									pos:   position{line: 252, col: 5, offset: 7412},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 251, col: 11, offset: 7240},
+										pos:  position{line: 252, col: 11, offset: 7418},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 251, col: 20, offset: 7249},
+									pos:   position{line: 252, col: 20, offset: 7427},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 251, col: 25, offset: 7254},
+										pos: position{line: 252, col: 25, offset: 7432},
 										expr: &ruleRefExpr{
-											pos:  position{line: 251, col: 26, offset: 7255},
+											pos:  position{line: 252, col: 26, offset: 7433},
 											name: "Deref",
 										},
 									},
@@ -1849,11 +1876,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 254, col: 5, offset: 7327},
+						pos:  position{line: 255, col: 5, offset: 7505},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 7339},
+						pos:  position{line: 256, col: 5, offset: 7517},
 						name: "DerefExpr",
 					},
 				},
@@ -1861,41 +1888,41 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 259, col: 1, offset: 7376},
+			pos:  position{line: 260, col: 1, offset: 7554},
 			expr: &choiceExpr{
-				pos: position{line: 260, col: 5, offset: 7392},
+				pos: position{line: 261, col: 5, offset: 7570},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 260, col: 5, offset: 7392},
+						pos: position{line: 261, col: 5, offset: 7570},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 260, col: 5, offset: 7392},
+							pos: position{line: 261, col: 5, offset: 7570},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 260, col: 5, offset: 7392},
+									pos:  position{line: 261, col: 5, offset: 7570},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 260, col: 15, offset: 7402},
+									pos:   position{line: 261, col: 15, offset: 7580},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 260, col: 21, offset: 7408},
+										pos:  position{line: 261, col: 21, offset: 7586},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 260, col: 30, offset: 7417},
+									pos:   position{line: 261, col: 30, offset: 7595},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 260, col: 35, offset: 7422},
+										pos:  position{line: 261, col: 35, offset: 7600},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 260, col: 47, offset: 7434},
+									pos:   position{line: 261, col: 47, offset: 7612},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 260, col: 53, offset: 7440},
+										pos:  position{line: 261, col: 53, offset: 7618},
 										name: "LimitArg",
 									},
 								},
@@ -1903,45 +1930,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 263, col: 5, offset: 7589},
+						pos: position{line: 264, col: 5, offset: 7767},
 						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 263, col: 5, offset: 7589},
+							pos: position{line: 264, col: 5, offset: 7767},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 263, col: 5, offset: 7589},
+									pos:  position{line: 264, col: 5, offset: 7767},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 263, col: 15, offset: 7599},
+									pos:   position{line: 264, col: 15, offset: 7777},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 263, col: 21, offset: 7605},
+										pos:  position{line: 264, col: 21, offset: 7783},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 263, col: 30, offset: 7614},
+									pos:   position{line: 264, col: 30, offset: 7792},
 									label: "reducers",
 									expr: &ruleRefExpr{
-										pos:  position{line: 263, col: 39, offset: 7623},
+										pos:  position{line: 264, col: 39, offset: 7801},
 										name: "Reducers",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 263, col: 48, offset: 7632},
+									pos:   position{line: 264, col: 48, offset: 7810},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 263, col: 53, offset: 7637},
+										pos: position{line: 264, col: 53, offset: 7815},
 										expr: &seqExpr{
-											pos: position{line: 263, col: 54, offset: 7638},
+											pos: position{line: 264, col: 54, offset: 7816},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 263, col: 54, offset: 7638},
+													pos:  position{line: 264, col: 54, offset: 7816},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 263, col: 56, offset: 7640},
+													pos:  position{line: 264, col: 56, offset: 7818},
 													name: "GroupByKeys",
 												},
 											},
@@ -1949,10 +1976,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 263, col: 70, offset: 7654},
+									pos:   position{line: 264, col: 70, offset: 7832},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 263, col: 76, offset: 7660},
+										pos:  position{line: 264, col: 76, offset: 7838},
 										name: "LimitArg",
 									},
 								},
@@ -1964,26 +1991,26 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 271, col: 1, offset: 7901},
+			pos:  position{line: 272, col: 1, offset: 8079},
 			expr: &choiceExpr{
-				pos: position{line: 271, col: 13, offset: 7913},
+				pos: position{line: 272, col: 13, offset: 8091},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 271, col: 13, offset: 7913},
+						pos: position{line: 272, col: 13, offset: 8091},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 271, col: 13, offset: 7913},
+								pos:        position{line: 272, col: 13, offset: 8091},
 								val:        "summarize",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 271, col: 25, offset: 7925},
+								pos:  position{line: 272, col: 25, offset: 8103},
 								name: "_",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 271, col: 29, offset: 7929},
+						pos:        position{line: 272, col: 29, offset: 8107},
 						val:        "",
 						ignoreCase: false,
 					},
@@ -1992,45 +2019,45 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 273, col: 1, offset: 7933},
+			pos:  position{line: 274, col: 1, offset: 8111},
 			expr: &choiceExpr{
-				pos: position{line: 274, col: 5, offset: 7946},
+				pos: position{line: 275, col: 5, offset: 8124},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 274, col: 5, offset: 7946},
+						pos: position{line: 275, col: 5, offset: 8124},
 						run: (*parser).callonEveryDur2,
 						expr: &seqExpr{
-							pos: position{line: 274, col: 5, offset: 7946},
+							pos: position{line: 275, col: 5, offset: 8124},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 274, col: 5, offset: 7946},
+									pos:        position{line: 275, col: 5, offset: 8124},
 									val:        "every",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 274, col: 14, offset: 7955},
+									pos:  position{line: 275, col: 14, offset: 8133},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 274, col: 16, offset: 7957},
+									pos:   position{line: 275, col: 16, offset: 8135},
 									label: "dur",
 									expr: &ruleRefExpr{
-										pos:  position{line: 274, col: 20, offset: 7961},
+										pos:  position{line: 275, col: 20, offset: 8139},
 										name: "Duration",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 274, col: 29, offset: 7970},
+									pos:  position{line: 275, col: 29, offset: 8148},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 275, col: 5, offset: 7996},
+						pos: position{line: 276, col: 5, offset: 8174},
 						run: (*parser).callonEveryDur9,
 						expr: &litMatcher{
-							pos:        position{line: 275, col: 5, offset: 7996},
+							pos:        position{line: 276, col: 5, offset: 8174},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2040,26 +2067,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 277, col: 1, offset: 8021},
+			pos:  position{line: 278, col: 1, offset: 8199},
 			expr: &actionExpr{
-				pos: position{line: 278, col: 5, offset: 8037},
+				pos: position{line: 279, col: 5, offset: 8215},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 278, col: 5, offset: 8037},
+					pos: position{line: 279, col: 5, offset: 8215},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 278, col: 5, offset: 8037},
+							pos:  position{line: 279, col: 5, offset: 8215},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 278, col: 13, offset: 8045},
+							pos:  position{line: 279, col: 13, offset: 8223},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 278, col: 15, offset: 8047},
+							pos:   position{line: 279, col: 15, offset: 8225},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 278, col: 23, offset: 8055},
+								pos:  position{line: 279, col: 23, offset: 8233},
 								name: "FlexAssignments",
 							},
 						},
@@ -2069,43 +2096,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 280, col: 1, offset: 8096},
+			pos:  position{line: 281, col: 1, offset: 8274},
 			expr: &choiceExpr{
-				pos: position{line: 281, col: 5, offset: 8109},
+				pos: position{line: 282, col: 5, offset: 8287},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 281, col: 5, offset: 8109},
+						pos: position{line: 282, col: 5, offset: 8287},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 281, col: 5, offset: 8109},
+							pos: position{line: 282, col: 5, offset: 8287},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 281, col: 5, offset: 8109},
+									pos:  position{line: 282, col: 5, offset: 8287},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 281, col: 7, offset: 8111},
+									pos:        position{line: 282, col: 7, offset: 8289},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 281, col: 14, offset: 8118},
+									pos:  position{line: 282, col: 14, offset: 8296},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 281, col: 16, offset: 8120},
+									pos:        position{line: 282, col: 16, offset: 8298},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 281, col: 25, offset: 8129},
+									pos:  position{line: 282, col: 25, offset: 8307},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 281, col: 27, offset: 8131},
+									pos:   position{line: 282, col: 27, offset: 8309},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 281, col: 33, offset: 8137},
+										pos:  position{line: 282, col: 33, offset: 8315},
 										name: "UInt",
 									},
 								},
@@ -2113,10 +2140,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 282, col: 5, offset: 8168},
+						pos: position{line: 283, col: 5, offset: 8346},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 282, col: 5, offset: 8168},
+							pos:        position{line: 283, col: 5, offset: 8346},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2126,22 +2153,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 287, col: 1, offset: 8428},
+			pos:  position{line: 288, col: 1, offset: 8606},
 			expr: &choiceExpr{
-				pos: position{line: 288, col: 5, offset: 8447},
+				pos: position{line: 289, col: 5, offset: 8625},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 288, col: 5, offset: 8447},
+						pos:  position{line: 289, col: 5, offset: 8625},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 289, col: 5, offset: 8462},
+						pos: position{line: 290, col: 5, offset: 8640},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 289, col: 5, offset: 8462},
+							pos:   position{line: 290, col: 5, offset: 8640},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 10, offset: 8467},
+								pos:  position{line: 290, col: 10, offset: 8645},
 								name: "Expr",
 							},
 						},
@@ -2151,50 +2178,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 291, col: 1, offset: 8557},
+			pos:  position{line: 292, col: 1, offset: 8735},
 			expr: &actionExpr{
-				pos: position{line: 292, col: 5, offset: 8577},
+				pos: position{line: 293, col: 5, offset: 8755},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 292, col: 5, offset: 8577},
+					pos: position{line: 293, col: 5, offset: 8755},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 292, col: 5, offset: 8577},
+							pos:   position{line: 293, col: 5, offset: 8755},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 292, col: 11, offset: 8583},
+								pos:  position{line: 293, col: 11, offset: 8761},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 26, offset: 8598},
+							pos:   position{line: 293, col: 26, offset: 8776},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 292, col: 31, offset: 8603},
+								pos: position{line: 293, col: 31, offset: 8781},
 								expr: &actionExpr{
-									pos: position{line: 292, col: 32, offset: 8604},
+									pos: position{line: 293, col: 32, offset: 8782},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 292, col: 32, offset: 8604},
+										pos: position{line: 293, col: 32, offset: 8782},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 292, col: 32, offset: 8604},
+												pos:  position{line: 293, col: 32, offset: 8782},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 292, col: 35, offset: 8607},
+												pos:        position{line: 293, col: 35, offset: 8785},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 292, col: 39, offset: 8611},
+												pos:  position{line: 293, col: 39, offset: 8789},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 292, col: 42, offset: 8614},
+												pos:   position{line: 293, col: 42, offset: 8792},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 292, col: 47, offset: 8619},
+													pos:  position{line: 293, col: 47, offset: 8797},
 													name: "FlexAssignment",
 												},
 											},
@@ -2209,42 +2236,42 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 296, col: 1, offset: 8741},
+			pos:  position{line: 297, col: 1, offset: 8919},
 			expr: &choiceExpr{
-				pos: position{line: 297, col: 5, offset: 8763},
+				pos: position{line: 298, col: 5, offset: 8941},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 297, col: 5, offset: 8763},
+						pos: position{line: 298, col: 5, offset: 8941},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 297, col: 5, offset: 8763},
+							pos: position{line: 298, col: 5, offset: 8941},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 297, col: 5, offset: 8763},
+									pos:   position{line: 298, col: 5, offset: 8941},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 297, col: 10, offset: 8768},
+										pos:  position{line: 298, col: 10, offset: 8946},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 297, col: 15, offset: 8773},
+									pos:  position{line: 298, col: 15, offset: 8951},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 297, col: 18, offset: 8776},
+									pos:        position{line: 298, col: 18, offset: 8954},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 297, col: 22, offset: 8780},
+									pos:  position{line: 298, col: 22, offset: 8958},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 297, col: 25, offset: 8783},
+									pos:   position{line: 298, col: 25, offset: 8961},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 297, col: 33, offset: 8791},
+										pos:  position{line: 298, col: 33, offset: 8969},
 										name: "Reducer",
 									},
 								},
@@ -2252,13 +2279,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 300, col: 5, offset: 8901},
+						pos: position{line: 301, col: 5, offset: 9079},
 						run: (*parser).callonReducerAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 300, col: 5, offset: 8901},
+							pos:   position{line: 301, col: 5, offset: 9079},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 13, offset: 8909},
+								pos:  position{line: 301, col: 13, offset: 9087},
 								name: "Reducer",
 							},
 						},
@@ -2268,72 +2295,72 @@ var g = &grammar{
 		},
 		{
 			name: "Reducer",
-			pos:  position{line: 304, col: 1, offset: 9015},
+			pos:  position{line: 305, col: 1, offset: 9193},
 			expr: &actionExpr{
-				pos: position{line: 305, col: 5, offset: 9027},
+				pos: position{line: 306, col: 5, offset: 9205},
 				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 305, col: 5, offset: 9027},
+					pos: position{line: 306, col: 5, offset: 9205},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 305, col: 5, offset: 9027},
+							pos: position{line: 306, col: 5, offset: 9205},
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 6, offset: 9028},
+								pos:  position{line: 306, col: 6, offset: 9206},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 16, offset: 9038},
+							pos:   position{line: 306, col: 16, offset: 9216},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 19, offset: 9041},
+								pos:  position{line: 306, col: 19, offset: 9219},
 								name: "ReducerName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 31, offset: 9053},
+							pos:  position{line: 306, col: 31, offset: 9231},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 305, col: 34, offset: 9056},
+							pos:        position{line: 306, col: 34, offset: 9234},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 38, offset: 9060},
+							pos:  position{line: 306, col: 38, offset: 9238},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 41, offset: 9063},
+							pos:   position{line: 306, col: 41, offset: 9241},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 305, col: 46, offset: 9068},
+								pos: position{line: 306, col: 46, offset: 9246},
 								expr: &ruleRefExpr{
-									pos:  position{line: 305, col: 46, offset: 9068},
+									pos:  position{line: 306, col: 46, offset: 9246},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 53, offset: 9075},
+							pos:  position{line: 306, col: 53, offset: 9253},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 305, col: 56, offset: 9078},
+							pos:        position{line: 306, col: 56, offset: 9256},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 305, col: 60, offset: 9082},
+							pos: position{line: 306, col: 60, offset: 9260},
 							expr: &seqExpr{
-								pos: position{line: 305, col: 62, offset: 9084},
+								pos: position{line: 306, col: 62, offset: 9262},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 305, col: 62, offset: 9084},
+										pos:  position{line: 306, col: 62, offset: 9262},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 305, col: 65, offset: 9087},
+										pos:        position{line: 306, col: 65, offset: 9265},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2341,12 +2368,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 70, offset: 9092},
+							pos:   position{line: 306, col: 70, offset: 9270},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 305, col: 76, offset: 9098},
+								pos: position{line: 306, col: 76, offset: 9276},
 								expr: &ruleRefExpr{
-									pos:  position{line: 305, col: 76, offset: 9098},
+									pos:  position{line: 306, col: 76, offset: 9276},
 									name: "WhereClause",
 								},
 							},
@@ -2357,20 +2384,20 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerName",
-			pos:  position{line: 313, col: 1, offset: 9294},
+			pos:  position{line: 314, col: 1, offset: 9472},
 			expr: &choiceExpr{
-				pos: position{line: 314, col: 5, offset: 9310},
+				pos: position{line: 315, col: 5, offset: 9488},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 314, col: 5, offset: 9310},
+						pos:  position{line: 315, col: 5, offset: 9488},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 315, col: 5, offset: 9329},
+						pos:  position{line: 316, col: 5, offset: 9507},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 316, col: 5, offset: 9342},
+						pos:  position{line: 317, col: 5, offset: 9520},
 						name: "OrToken",
 					},
 				},
@@ -2378,31 +2405,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 318, col: 1, offset: 9351},
+			pos:  position{line: 319, col: 1, offset: 9529},
 			expr: &actionExpr{
-				pos: position{line: 318, col: 15, offset: 9365},
+				pos: position{line: 319, col: 15, offset: 9543},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 318, col: 15, offset: 9365},
+					pos: position{line: 319, col: 15, offset: 9543},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 318, col: 15, offset: 9365},
+							pos:  position{line: 319, col: 15, offset: 9543},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 318, col: 17, offset: 9367},
+							pos:        position{line: 319, col: 17, offset: 9545},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 318, col: 25, offset: 9375},
+							pos:  position{line: 319, col: 25, offset: 9553},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 318, col: 27, offset: 9377},
+							pos:   position{line: 319, col: 27, offset: 9555},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 318, col: 32, offset: 9382},
+								pos:  position{line: 319, col: 32, offset: 9560},
 								name: "SearchBoolean",
 							},
 						},
@@ -2412,44 +2439,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 320, col: 1, offset: 9418},
+			pos:  position{line: 321, col: 1, offset: 9596},
 			expr: &actionExpr{
-				pos: position{line: 321, col: 5, offset: 9431},
+				pos: position{line: 322, col: 5, offset: 9609},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 321, col: 5, offset: 9431},
+					pos: position{line: 322, col: 5, offset: 9609},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 321, col: 5, offset: 9431},
+							pos:   position{line: 322, col: 5, offset: 9609},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 321, col: 11, offset: 9437},
+								pos:  position{line: 322, col: 11, offset: 9615},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 321, col: 29, offset: 9455},
+							pos:   position{line: 322, col: 29, offset: 9633},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 321, col: 34, offset: 9460},
+								pos: position{line: 322, col: 34, offset: 9638},
 								expr: &seqExpr{
-									pos: position{line: 321, col: 35, offset: 9461},
+									pos: position{line: 322, col: 35, offset: 9639},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 321, col: 35, offset: 9461},
+											pos:  position{line: 322, col: 35, offset: 9639},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 321, col: 38, offset: 9464},
+											pos:        position{line: 322, col: 38, offset: 9642},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 321, col: 42, offset: 9468},
+											pos:  position{line: 322, col: 42, offset: 9646},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 321, col: 45, offset: 9471},
+											pos:  position{line: 322, col: 45, offset: 9649},
 											name: "ReducerAssignment",
 										},
 									},
@@ -2462,68 +2489,68 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 329, col: 1, offset: 9676},
+			pos:  position{line: 330, col: 1, offset: 9854},
 			expr: &choiceExpr{
-				pos: position{line: 330, col: 5, offset: 9689},
+				pos: position{line: 331, col: 5, offset: 9867},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 330, col: 5, offset: 9689},
+						pos:  position{line: 331, col: 5, offset: 9867},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 9702},
+						pos:  position{line: 332, col: 5, offset: 9880},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 332, col: 5, offset: 9714},
+						pos:  position{line: 333, col: 5, offset: 9892},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 9726},
+						pos:  position{line: 334, col: 5, offset: 9904},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 9739},
+						pos:  position{line: 335, col: 5, offset: 9917},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 9752},
+						pos:  position{line: 336, col: 5, offset: 9930},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 9765},
+						pos:  position{line: 337, col: 5, offset: 9943},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 9778},
+						pos:  position{line: 338, col: 5, offset: 9956},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 9793},
+						pos:  position{line: 339, col: 5, offset: 9971},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 9806},
+						pos:  position{line: 340, col: 5, offset: 9984},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 9818},
+						pos:  position{line: 341, col: 5, offset: 9996},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 341, col: 5, offset: 9833},
+						pos:  position{line: 342, col: 5, offset: 10011},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 342, col: 5, offset: 9846},
+						pos:  position{line: 343, col: 5, offset: 10024},
 						name: "ShapeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 343, col: 5, offset: 9860},
+						pos:  position{line: 344, col: 5, offset: 10038},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 344, col: 5, offset: 9873},
+						pos:  position{line: 345, col: 5, offset: 10051},
 						name: "TasteProc",
 					},
 				},
@@ -2531,46 +2558,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 346, col: 1, offset: 9884},
+			pos:  position{line: 347, col: 1, offset: 10062},
 			expr: &actionExpr{
-				pos: position{line: 347, col: 5, offset: 9897},
+				pos: position{line: 348, col: 5, offset: 10075},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 347, col: 5, offset: 9897},
+					pos: position{line: 348, col: 5, offset: 10075},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 347, col: 5, offset: 9897},
+							pos:        position{line: 348, col: 5, offset: 10075},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 347, col: 13, offset: 9905},
+							pos:   position{line: 348, col: 13, offset: 10083},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 347, col: 18, offset: 9910},
+								pos:  position{line: 348, col: 18, offset: 10088},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 347, col: 27, offset: 9919},
+							pos:   position{line: 348, col: 27, offset: 10097},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 347, col: 32, offset: 9924},
+								pos: position{line: 348, col: 32, offset: 10102},
 								expr: &actionExpr{
-									pos: position{line: 347, col: 33, offset: 9925},
+									pos: position{line: 348, col: 33, offset: 10103},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 347, col: 33, offset: 9925},
+										pos: position{line: 348, col: 33, offset: 10103},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 347, col: 33, offset: 9925},
+												pos:  position{line: 348, col: 33, offset: 10103},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 347, col: 35, offset: 9927},
+												pos:   position{line: 348, col: 35, offset: 10105},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 347, col: 37, offset: 9929},
+													pos:  position{line: 348, col: 37, offset: 10107},
 													name: "Exprs",
 												},
 											},
@@ -2585,30 +2612,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 361, col: 1, offset: 10348},
+			pos:  position{line: 362, col: 1, offset: 10526},
 			expr: &actionExpr{
-				pos: position{line: 361, col: 12, offset: 10359},
+				pos: position{line: 362, col: 12, offset: 10537},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 361, col: 12, offset: 10359},
+					pos:   position{line: 362, col: 12, offset: 10537},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 361, col: 17, offset: 10364},
+						pos: position{line: 362, col: 17, offset: 10542},
 						expr: &actionExpr{
-							pos: position{line: 361, col: 18, offset: 10365},
+							pos: position{line: 362, col: 18, offset: 10543},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 361, col: 18, offset: 10365},
+								pos: position{line: 362, col: 18, offset: 10543},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 361, col: 18, offset: 10365},
+										pos:  position{line: 362, col: 18, offset: 10543},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 361, col: 20, offset: 10367},
+										pos:   position{line: 362, col: 20, offset: 10545},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 361, col: 22, offset: 10369},
+											pos:  position{line: 362, col: 22, offset: 10547},
 											name: "SortArg",
 										},
 									},
@@ -2621,50 +2648,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 363, col: 1, offset: 10425},
+			pos:  position{line: 364, col: 1, offset: 10603},
 			expr: &choiceExpr{
-				pos: position{line: 364, col: 5, offset: 10437},
+				pos: position{line: 365, col: 5, offset: 10615},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 364, col: 5, offset: 10437},
+						pos: position{line: 365, col: 5, offset: 10615},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 364, col: 5, offset: 10437},
+							pos:        position{line: 365, col: 5, offset: 10615},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 365, col: 5, offset: 10512},
+						pos: position{line: 366, col: 5, offset: 10690},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 365, col: 5, offset: 10512},
+							pos: position{line: 366, col: 5, offset: 10690},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 365, col: 5, offset: 10512},
+									pos:        position{line: 366, col: 5, offset: 10690},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 365, col: 14, offset: 10521},
+									pos:  position{line: 366, col: 14, offset: 10699},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 365, col: 16, offset: 10523},
+									pos:   position{line: 366, col: 16, offset: 10701},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 365, col: 23, offset: 10530},
+										pos: position{line: 366, col: 23, offset: 10708},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 365, col: 24, offset: 10531},
+											pos: position{line: 366, col: 24, offset: 10709},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 365, col: 24, offset: 10531},
+													pos:        position{line: 366, col: 24, offset: 10709},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 365, col: 34, offset: 10541},
+													pos:        position{line: 366, col: 34, offset: 10719},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2680,38 +2707,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 367, col: 1, offset: 10655},
+			pos:  position{line: 368, col: 1, offset: 10833},
 			expr: &actionExpr{
-				pos: position{line: 368, col: 5, offset: 10667},
+				pos: position{line: 369, col: 5, offset: 10845},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 368, col: 5, offset: 10667},
+					pos: position{line: 369, col: 5, offset: 10845},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 368, col: 5, offset: 10667},
+							pos:        position{line: 369, col: 5, offset: 10845},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 368, col: 12, offset: 10674},
+							pos:   position{line: 369, col: 12, offset: 10852},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 368, col: 18, offset: 10680},
+								pos: position{line: 369, col: 18, offset: 10858},
 								expr: &actionExpr{
-									pos: position{line: 368, col: 19, offset: 10681},
+									pos: position{line: 369, col: 19, offset: 10859},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 368, col: 19, offset: 10681},
+										pos: position{line: 369, col: 19, offset: 10859},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 368, col: 19, offset: 10681},
+												pos:  position{line: 369, col: 19, offset: 10859},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 368, col: 21, offset: 10683},
+												pos:   position{line: 369, col: 21, offset: 10861},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 368, col: 23, offset: 10685},
+													pos:  position{line: 369, col: 23, offset: 10863},
 													name: "UInt",
 												},
 											},
@@ -2721,19 +2748,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 368, col: 47, offset: 10709},
+							pos:   position{line: 369, col: 47, offset: 10887},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 368, col: 53, offset: 10715},
+								pos: position{line: 369, col: 53, offset: 10893},
 								expr: &seqExpr{
-									pos: position{line: 368, col: 54, offset: 10716},
+									pos: position{line: 369, col: 54, offset: 10894},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 368, col: 54, offset: 10716},
+											pos:  position{line: 369, col: 54, offset: 10894},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 368, col: 56, offset: 10718},
+											pos:        position{line: 369, col: 56, offset: 10896},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2742,25 +2769,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 368, col: 67, offset: 10729},
+							pos:   position{line: 369, col: 67, offset: 10907},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 368, col: 74, offset: 10736},
+								pos: position{line: 369, col: 74, offset: 10914},
 								expr: &actionExpr{
-									pos: position{line: 368, col: 75, offset: 10737},
+									pos: position{line: 369, col: 75, offset: 10915},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 368, col: 75, offset: 10737},
+										pos: position{line: 369, col: 75, offset: 10915},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 368, col: 75, offset: 10737},
+												pos:  position{line: 369, col: 75, offset: 10915},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 368, col: 77, offset: 10739},
+												pos:   position{line: 369, col: 77, offset: 10917},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 368, col: 79, offset: 10741},
+													pos:  position{line: 369, col: 79, offset: 10919},
 													name: "FieldExprs",
 												},
 											},
@@ -2775,27 +2802,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 382, col: 1, offset: 11092},
+			pos:  position{line: 383, col: 1, offset: 11270},
 			expr: &actionExpr{
-				pos: position{line: 383, col: 5, offset: 11104},
+				pos: position{line: 384, col: 5, offset: 11282},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 383, col: 5, offset: 11104},
+					pos: position{line: 384, col: 5, offset: 11282},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 383, col: 5, offset: 11104},
+							pos:        position{line: 384, col: 5, offset: 11282},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 383, col: 12, offset: 11111},
+							pos:  position{line: 384, col: 12, offset: 11289},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 383, col: 14, offset: 11113},
+							pos:   position{line: 384, col: 14, offset: 11291},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 383, col: 22, offset: 11121},
+								pos:  position{line: 384, col: 22, offset: 11299},
 								name: "FlexAssignments",
 							},
 						},
@@ -2805,27 +2832,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 387, col: 1, offset: 11223},
+			pos:  position{line: 388, col: 1, offset: 11401},
 			expr: &actionExpr{
-				pos: position{line: 388, col: 5, offset: 11236},
+				pos: position{line: 389, col: 5, offset: 11414},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 388, col: 5, offset: 11236},
+					pos: position{line: 389, col: 5, offset: 11414},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 388, col: 5, offset: 11236},
+							pos:        position{line: 389, col: 5, offset: 11414},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 388, col: 13, offset: 11244},
+							pos:  position{line: 389, col: 13, offset: 11422},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 388, col: 15, offset: 11246},
+							pos:   position{line: 389, col: 15, offset: 11424},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 388, col: 23, offset: 11254},
+								pos:  position{line: 389, col: 23, offset: 11432},
 								name: "FlexAssignments",
 							},
 						},
@@ -2835,27 +2862,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 392, col: 1, offset: 11357},
+			pos:  position{line: 393, col: 1, offset: 11535},
 			expr: &actionExpr{
-				pos: position{line: 393, col: 5, offset: 11370},
+				pos: position{line: 394, col: 5, offset: 11548},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 393, col: 5, offset: 11370},
+					pos: position{line: 394, col: 5, offset: 11548},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 393, col: 5, offset: 11370},
+							pos:        position{line: 394, col: 5, offset: 11548},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 393, col: 13, offset: 11378},
+							pos:  position{line: 394, col: 13, offset: 11556},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 393, col: 15, offset: 11380},
+							pos:   position{line: 394, col: 15, offset: 11558},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 393, col: 23, offset: 11388},
+								pos:  position{line: 394, col: 23, offset: 11566},
 								name: "FieldExprs",
 							},
 						},
@@ -2865,30 +2892,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 397, col: 1, offset: 11486},
+			pos:  position{line: 398, col: 1, offset: 11664},
 			expr: &choiceExpr{
-				pos: position{line: 398, col: 5, offset: 11499},
+				pos: position{line: 399, col: 5, offset: 11677},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 398, col: 5, offset: 11499},
+						pos: position{line: 399, col: 5, offset: 11677},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 398, col: 5, offset: 11499},
+							pos: position{line: 399, col: 5, offset: 11677},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 398, col: 5, offset: 11499},
+									pos:        position{line: 399, col: 5, offset: 11677},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 398, col: 13, offset: 11507},
+									pos:  position{line: 399, col: 13, offset: 11685},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 398, col: 15, offset: 11509},
+									pos:   position{line: 399, col: 15, offset: 11687},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 398, col: 21, offset: 11515},
+										pos:  position{line: 399, col: 21, offset: 11693},
 										name: "UInt",
 									},
 								},
@@ -2896,10 +2923,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 399, col: 5, offset: 11597},
+						pos: position{line: 400, col: 5, offset: 11775},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 399, col: 5, offset: 11597},
+							pos:        position{line: 400, col: 5, offset: 11775},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2909,30 +2936,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 401, col: 1, offset: 11675},
+			pos:  position{line: 402, col: 1, offset: 11853},
 			expr: &choiceExpr{
-				pos: position{line: 402, col: 5, offset: 11688},
+				pos: position{line: 403, col: 5, offset: 11866},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 402, col: 5, offset: 11688},
+						pos: position{line: 403, col: 5, offset: 11866},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 402, col: 5, offset: 11688},
+							pos: position{line: 403, col: 5, offset: 11866},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 402, col: 5, offset: 11688},
+									pos:        position{line: 403, col: 5, offset: 11866},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 402, col: 13, offset: 11696},
+									pos:  position{line: 403, col: 13, offset: 11874},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 402, col: 15, offset: 11698},
+									pos:   position{line: 403, col: 15, offset: 11876},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 402, col: 21, offset: 11704},
+										pos:  position{line: 403, col: 21, offset: 11882},
 										name: "UInt",
 									},
 								},
@@ -2940,10 +2967,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 403, col: 5, offset: 11786},
+						pos: position{line: 404, col: 5, offset: 11964},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 403, col: 5, offset: 11786},
+							pos:        position{line: 404, col: 5, offset: 11964},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2953,27 +2980,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 405, col: 1, offset: 11864},
+			pos:  position{line: 406, col: 1, offset: 12042},
 			expr: &actionExpr{
-				pos: position{line: 406, col: 5, offset: 11879},
+				pos: position{line: 407, col: 5, offset: 12057},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 406, col: 5, offset: 11879},
+					pos: position{line: 407, col: 5, offset: 12057},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 406, col: 5, offset: 11879},
+							pos:        position{line: 407, col: 5, offset: 12057},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 406, col: 15, offset: 11889},
+							pos:  position{line: 407, col: 15, offset: 12067},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 406, col: 17, offset: 11891},
+							pos:   position{line: 407, col: 17, offset: 12069},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 406, col: 20, offset: 11894},
+								pos:  position{line: 407, col: 20, offset: 12072},
 								name: "Filter",
 							},
 						},
@@ -2983,15 +3010,15 @@ var g = &grammar{
 		},
 		{
 			name: "Filter",
-			pos:  position{line: 410, col: 1, offset: 11931},
+			pos:  position{line: 411, col: 1, offset: 12109},
 			expr: &actionExpr{
-				pos: position{line: 411, col: 5, offset: 11942},
+				pos: position{line: 412, col: 5, offset: 12120},
 				run: (*parser).callonFilter1,
 				expr: &labeledExpr{
-					pos:   position{line: 411, col: 5, offset: 11942},
+					pos:   position{line: 412, col: 5, offset: 12120},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 411, col: 10, offset: 11947},
+						pos:  position{line: 412, col: 10, offset: 12125},
 						name: "SearchBoolean",
 					},
 				},
@@ -2999,27 +3026,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 415, col: 1, offset: 12047},
+			pos:  position{line: 416, col: 1, offset: 12225},
 			expr: &choiceExpr{
-				pos: position{line: 416, col: 5, offset: 12060},
+				pos: position{line: 417, col: 5, offset: 12238},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 416, col: 5, offset: 12060},
+						pos: position{line: 417, col: 5, offset: 12238},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 416, col: 5, offset: 12060},
+							pos: position{line: 417, col: 5, offset: 12238},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 416, col: 5, offset: 12060},
+									pos:        position{line: 417, col: 5, offset: 12238},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 416, col: 13, offset: 12068},
+									pos:  position{line: 417, col: 13, offset: 12246},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 416, col: 15, offset: 12070},
+									pos:        position{line: 417, col: 15, offset: 12248},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -3027,10 +3054,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 419, col: 5, offset: 12161},
+						pos: position{line: 420, col: 5, offset: 12339},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 419, col: 5, offset: 12161},
+							pos:        position{line: 420, col: 5, offset: 12339},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -3040,27 +3067,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 423, col: 1, offset: 12253},
+			pos:  position{line: 424, col: 1, offset: 12431},
 			expr: &actionExpr{
-				pos: position{line: 424, col: 5, offset: 12265},
+				pos: position{line: 425, col: 5, offset: 12443},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 424, col: 5, offset: 12265},
+					pos: position{line: 425, col: 5, offset: 12443},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 424, col: 5, offset: 12265},
+							pos:        position{line: 425, col: 5, offset: 12443},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 424, col: 12, offset: 12272},
+							pos:  position{line: 425, col: 12, offset: 12450},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 424, col: 14, offset: 12274},
+							pos:   position{line: 425, col: 14, offset: 12452},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 424, col: 22, offset: 12282},
+								pos:  position{line: 425, col: 22, offset: 12460},
 								name: "FlexAssignments",
 							},
 						},
@@ -3070,59 +3097,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 428, col: 1, offset: 12385},
+			pos:  position{line: 429, col: 1, offset: 12563},
 			expr: &actionExpr{
-				pos: position{line: 429, col: 5, offset: 12400},
+				pos: position{line: 430, col: 5, offset: 12578},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 429, col: 5, offset: 12400},
+					pos: position{line: 430, col: 5, offset: 12578},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 429, col: 5, offset: 12400},
+							pos:        position{line: 430, col: 5, offset: 12578},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 429, col: 15, offset: 12410},
+							pos:  position{line: 430, col: 15, offset: 12588},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 429, col: 17, offset: 12412},
+							pos:   position{line: 430, col: 17, offset: 12590},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 429, col: 23, offset: 12418},
+								pos:  position{line: 430, col: 23, offset: 12596},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 429, col: 34, offset: 12429},
+							pos:   position{line: 430, col: 34, offset: 12607},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 429, col: 39, offset: 12434},
+								pos: position{line: 430, col: 39, offset: 12612},
 								expr: &actionExpr{
-									pos: position{line: 429, col: 40, offset: 12435},
+									pos: position{line: 430, col: 40, offset: 12613},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 429, col: 40, offset: 12435},
+										pos: position{line: 430, col: 40, offset: 12613},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 429, col: 40, offset: 12435},
+												pos:  position{line: 430, col: 40, offset: 12613},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 429, col: 43, offset: 12438},
+												pos:        position{line: 430, col: 43, offset: 12616},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 429, col: 47, offset: 12442},
+												pos:  position{line: 430, col: 47, offset: 12620},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 429, col: 50, offset: 12445},
+												pos:   position{line: 430, col: 50, offset: 12623},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 429, col: 53, offset: 12448},
+													pos:  position{line: 430, col: 53, offset: 12626},
 													name: "Assignment",
 												},
 											},
@@ -3137,29 +3164,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 437, col: 1, offset: 12859},
+			pos:  position{line: 438, col: 1, offset: 13037},
 			expr: &actionExpr{
-				pos: position{line: 438, col: 5, offset: 12872},
+				pos: position{line: 439, col: 5, offset: 13050},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 438, col: 5, offset: 12872},
+					pos: position{line: 439, col: 5, offset: 13050},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 438, col: 5, offset: 12872},
+							pos:        position{line: 439, col: 5, offset: 13050},
 							val:        "fuse",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 438, col: 13, offset: 12880},
+							pos: position{line: 439, col: 13, offset: 13058},
 							expr: &seqExpr{
-								pos: position{line: 438, col: 15, offset: 12882},
+								pos: position{line: 439, col: 15, offset: 13060},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 438, col: 15, offset: 12882},
+										pos:  position{line: 439, col: 15, offset: 13060},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 438, col: 18, offset: 12885},
+										pos:        position{line: 439, col: 18, offset: 13063},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -3172,12 +3199,12 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeProc",
-			pos:  position{line: 442, col: 1, offset: 12958},
+			pos:  position{line: 443, col: 1, offset: 13136},
 			expr: &actionExpr{
-				pos: position{line: 443, col: 5, offset: 12972},
+				pos: position{line: 444, col: 5, offset: 13150},
 				run: (*parser).callonShapeProc1,
 				expr: &litMatcher{
-					pos:        position{line: 443, col: 5, offset: 12972},
+					pos:        position{line: 444, col: 5, offset: 13150},
 					val:        "shape",
 					ignoreCase: true,
 				},
@@ -3185,76 +3212,76 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 447, col: 1, offset: 13050},
+			pos:  position{line: 448, col: 1, offset: 13228},
 			expr: &choiceExpr{
-				pos: position{line: 448, col: 5, offset: 13063},
+				pos: position{line: 449, col: 5, offset: 13241},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 13063},
+						pos: position{line: 449, col: 5, offset: 13241},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 448, col: 5, offset: 13063},
+							pos: position{line: 449, col: 5, offset: 13241},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 448, col: 5, offset: 13063},
+									pos:   position{line: 449, col: 5, offset: 13241},
 									label: "kind",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 10, offset: 13068},
+										pos:  position{line: 449, col: 10, offset: 13246},
 										name: "JoinKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 448, col: 19, offset: 13077},
+									pos:        position{line: 449, col: 19, offset: 13255},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 27, offset: 13085},
+									pos:  position{line: 449, col: 27, offset: 13263},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 29, offset: 13087},
+									pos:   position{line: 449, col: 29, offset: 13265},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 37, offset: 13095},
+										pos:  position{line: 449, col: 37, offset: 13273},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 45, offset: 13103},
+									pos:  position{line: 449, col: 45, offset: 13281},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 448, col: 48, offset: 13106},
+									pos:        position{line: 449, col: 48, offset: 13284},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 52, offset: 13110},
+									pos:  position{line: 449, col: 52, offset: 13288},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 55, offset: 13113},
+									pos:   position{line: 449, col: 55, offset: 13291},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 64, offset: 13122},
+										pos:  position{line: 449, col: 64, offset: 13300},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 72, offset: 13130},
+									pos:   position{line: 449, col: 72, offset: 13308},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 448, col: 80, offset: 13138},
+										pos: position{line: 449, col: 80, offset: 13316},
 										expr: &seqExpr{
-											pos: position{line: 448, col: 81, offset: 13139},
+											pos: position{line: 449, col: 81, offset: 13317},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 448, col: 81, offset: 13139},
+													pos:  position{line: 449, col: 81, offset: 13317},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 448, col: 83, offset: 13141},
+													pos:  position{line: 449, col: 83, offset: 13319},
 													name: "FlexAssignments",
 												},
 											},
@@ -3265,50 +3292,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 455, col: 5, offset: 13413},
+						pos: position{line: 456, col: 5, offset: 13591},
 						run: (*parser).callonJoinProc20,
 						expr: &seqExpr{
-							pos: position{line: 455, col: 5, offset: 13413},
+							pos: position{line: 456, col: 5, offset: 13591},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 455, col: 5, offset: 13413},
+									pos:   position{line: 456, col: 5, offset: 13591},
 									label: "kind",
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 10, offset: 13418},
+										pos:  position{line: 456, col: 10, offset: 13596},
 										name: "JoinKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 455, col: 20, offset: 13428},
+									pos:        position{line: 456, col: 20, offset: 13606},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 28, offset: 13436},
+									pos:  position{line: 456, col: 28, offset: 13614},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 455, col: 30, offset: 13438},
+									pos:   position{line: 456, col: 30, offset: 13616},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 34, offset: 13442},
+										pos:  position{line: 456, col: 34, offset: 13620},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 455, col: 42, offset: 13450},
+									pos:   position{line: 456, col: 42, offset: 13628},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 455, col: 50, offset: 13458},
+										pos: position{line: 456, col: 50, offset: 13636},
 										expr: &seqExpr{
-											pos: position{line: 455, col: 51, offset: 13459},
+											pos: position{line: 456, col: 51, offset: 13637},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 455, col: 51, offset: 13459},
+													pos:  position{line: 456, col: 51, offset: 13637},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 455, col: 53, offset: 13461},
+													pos:  position{line: 456, col: 53, offset: 13639},
 													name: "FlexAssignments",
 												},
 											},
@@ -3323,69 +3350,69 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKind",
-			pos:  position{line: 463, col: 1, offset: 13721},
+			pos:  position{line: 464, col: 1, offset: 13899},
 			expr: &choiceExpr{
-				pos: position{line: 464, col: 5, offset: 13734},
+				pos: position{line: 465, col: 5, offset: 13912},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 13734},
+						pos: position{line: 465, col: 5, offset: 13912},
 						run: (*parser).callonJoinKind2,
 						expr: &seqExpr{
-							pos: position{line: 464, col: 5, offset: 13734},
+							pos: position{line: 465, col: 5, offset: 13912},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 464, col: 5, offset: 13734},
+									pos:        position{line: 465, col: 5, offset: 13912},
 									val:        "inner",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 464, col: 14, offset: 13743},
+									pos:  position{line: 465, col: 14, offset: 13921},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 465, col: 5, offset: 13773},
+						pos: position{line: 466, col: 5, offset: 13951},
 						run: (*parser).callonJoinKind6,
 						expr: &seqExpr{
-							pos: position{line: 465, col: 5, offset: 13773},
+							pos: position{line: 466, col: 5, offset: 13951},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 465, col: 5, offset: 13773},
+									pos:        position{line: 466, col: 5, offset: 13951},
 									val:        "left",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 465, col: 14, offset: 13782},
+									pos:  position{line: 466, col: 14, offset: 13960},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 466, col: 5, offset: 13811},
+						pos: position{line: 467, col: 5, offset: 13989},
 						run: (*parser).callonJoinKind10,
 						expr: &seqExpr{
-							pos: position{line: 466, col: 5, offset: 13811},
+							pos: position{line: 467, col: 5, offset: 13989},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 466, col: 5, offset: 13811},
+									pos:        position{line: 467, col: 5, offset: 13989},
 									val:        "right",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 466, col: 14, offset: 13820},
+									pos:  position{line: 467, col: 14, offset: 13998},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 467, col: 5, offset: 13850},
+						pos: position{line: 468, col: 5, offset: 14028},
 						run: (*parser).callonJoinKind14,
 						expr: &litMatcher{
-							pos:        position{line: 467, col: 5, offset: 13850},
+							pos:        position{line: 468, col: 5, offset: 14028},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3395,35 +3422,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 469, col: 1, offset: 13886},
+			pos:  position{line: 470, col: 1, offset: 14064},
 			expr: &choiceExpr{
-				pos: position{line: 470, col: 5, offset: 13898},
+				pos: position{line: 471, col: 5, offset: 14076},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 470, col: 5, offset: 13898},
+						pos:  position{line: 471, col: 5, offset: 14076},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 471, col: 5, offset: 13907},
+						pos: position{line: 472, col: 5, offset: 14085},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 471, col: 5, offset: 13907},
+							pos: position{line: 472, col: 5, offset: 14085},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 471, col: 5, offset: 13907},
+									pos:        position{line: 472, col: 5, offset: 14085},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 471, col: 9, offset: 13911},
+									pos:   position{line: 472, col: 9, offset: 14089},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 471, col: 14, offset: 13916},
+										pos:  position{line: 472, col: 14, offset: 14094},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 471, col: 19, offset: 13921},
+									pos:        position{line: 472, col: 19, offset: 14099},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3435,23 +3462,23 @@ var g = &grammar{
 		},
 		{
 			name: "TasteProc",
-			pos:  position{line: 473, col: 1, offset: 13947},
+			pos:  position{line: 474, col: 1, offset: 14125},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 5, offset: 13961},
+				pos: position{line: 475, col: 5, offset: 14139},
 				run: (*parser).callonTasteProc1,
 				expr: &seqExpr{
-					pos: position{line: 474, col: 5, offset: 13961},
+					pos: position{line: 475, col: 5, offset: 14139},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 474, col: 5, offset: 13961},
+							pos:        position{line: 475, col: 5, offset: 14139},
 							val:        "taste",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 14, offset: 13970},
+							pos:   position{line: 475, col: 14, offset: 14148},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 16, offset: 13972},
+								pos:  position{line: 475, col: 16, offset: 14150},
 								name: "TasteExpr",
 							},
 						},
@@ -3461,25 +3488,25 @@ var g = &grammar{
 		},
 		{
 			name: "TasteExpr",
-			pos:  position{line: 511, col: 1, offset: 15302},
+			pos:  position{line: 512, col: 1, offset: 15480},
 			expr: &choiceExpr{
-				pos: position{line: 512, col: 5, offset: 15316},
+				pos: position{line: 513, col: 5, offset: 15494},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 512, col: 5, offset: 15316},
+						pos: position{line: 513, col: 5, offset: 15494},
 						run: (*parser).callonTasteExpr2,
 						expr: &seqExpr{
-							pos: position{line: 512, col: 5, offset: 15316},
+							pos: position{line: 513, col: 5, offset: 15494},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 512, col: 5, offset: 15316},
+									pos:  position{line: 513, col: 5, offset: 15494},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 512, col: 7, offset: 15318},
+									pos:   position{line: 513, col: 7, offset: 15496},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 512, col: 12, offset: 15323},
+										pos:  position{line: 513, col: 12, offset: 15501},
 										name: "Lval",
 									},
 								},
@@ -3487,10 +3514,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 15352},
+						pos: position{line: 514, col: 5, offset: 15530},
 						run: (*parser).callonTasteExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 513, col: 5, offset: 15352},
+							pos:        position{line: 514, col: 5, offset: 15530},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3500,60 +3527,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 515, col: 1, offset: 15414},
+			pos:  position{line: 516, col: 1, offset: 15592},
 			expr: &ruleRefExpr{
-				pos:  position{line: 515, col: 8, offset: 15421},
+				pos:  position{line: 516, col: 8, offset: 15599},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 517, col: 1, offset: 15432},
+			pos:  position{line: 518, col: 1, offset: 15610},
 			expr: &ruleRefExpr{
-				pos:  position{line: 517, col: 13, offset: 15444},
+				pos:  position{line: 518, col: 13, offset: 15622},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 519, col: 1, offset: 15450},
+			pos:  position{line: 520, col: 1, offset: 15628},
 			expr: &actionExpr{
-				pos: position{line: 520, col: 5, offset: 15465},
+				pos: position{line: 521, col: 5, offset: 15643},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 520, col: 5, offset: 15465},
+					pos: position{line: 521, col: 5, offset: 15643},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 520, col: 5, offset: 15465},
+							pos:   position{line: 521, col: 5, offset: 15643},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 11, offset: 15471},
+								pos:  position{line: 521, col: 11, offset: 15649},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 21, offset: 15481},
+							pos:   position{line: 521, col: 21, offset: 15659},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 520, col: 26, offset: 15486},
+								pos: position{line: 521, col: 26, offset: 15664},
 								expr: &seqExpr{
-									pos: position{line: 520, col: 27, offset: 15487},
+									pos: position{line: 521, col: 27, offset: 15665},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 27, offset: 15487},
+											pos:  position{line: 521, col: 27, offset: 15665},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 520, col: 30, offset: 15490},
+											pos:        position{line: 521, col: 30, offset: 15668},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 34, offset: 15494},
+											pos:  position{line: 521, col: 34, offset: 15672},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 37, offset: 15497},
+											pos:  position{line: 521, col: 37, offset: 15675},
 											name: "FieldExpr",
 										},
 									},
@@ -3566,44 +3593,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 530, col: 1, offset: 15696},
+			pos:  position{line: 531, col: 1, offset: 15874},
 			expr: &actionExpr{
-				pos: position{line: 531, col: 5, offset: 15706},
+				pos: position{line: 532, col: 5, offset: 15884},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 531, col: 5, offset: 15706},
+					pos: position{line: 532, col: 5, offset: 15884},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 531, col: 5, offset: 15706},
+							pos:   position{line: 532, col: 5, offset: 15884},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 531, col: 11, offset: 15712},
+								pos:  position{line: 532, col: 11, offset: 15890},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 531, col: 16, offset: 15717},
+							pos:   position{line: 532, col: 16, offset: 15895},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 531, col: 21, offset: 15722},
+								pos: position{line: 532, col: 21, offset: 15900},
 								expr: &seqExpr{
-									pos: position{line: 531, col: 22, offset: 15723},
+									pos: position{line: 532, col: 22, offset: 15901},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 531, col: 22, offset: 15723},
+											pos:  position{line: 532, col: 22, offset: 15901},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 531, col: 25, offset: 15726},
+											pos:        position{line: 532, col: 25, offset: 15904},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 531, col: 29, offset: 15730},
+											pos:  position{line: 532, col: 29, offset: 15908},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 531, col: 32, offset: 15733},
+											pos:  position{line: 532, col: 32, offset: 15911},
 											name: "Expr",
 										},
 									},
@@ -3616,39 +3643,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 541, col: 1, offset: 15927},
+			pos:  position{line: 542, col: 1, offset: 16105},
 			expr: &actionExpr{
-				pos: position{line: 542, col: 5, offset: 15942},
+				pos: position{line: 543, col: 5, offset: 16120},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 542, col: 5, offset: 15942},
+					pos: position{line: 543, col: 5, offset: 16120},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 542, col: 5, offset: 15942},
+							pos:   position{line: 543, col: 5, offset: 16120},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 542, col: 9, offset: 15946},
+								pos:  position{line: 543, col: 9, offset: 16124},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 542, col: 14, offset: 15951},
+							pos:  position{line: 543, col: 14, offset: 16129},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 542, col: 17, offset: 15954},
+							pos:        position{line: 543, col: 17, offset: 16132},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 542, col: 21, offset: 15958},
+							pos:  position{line: 543, col: 21, offset: 16136},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 542, col: 24, offset: 15961},
+							pos:   position{line: 543, col: 24, offset: 16139},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 542, col: 28, offset: 15965},
+								pos:  position{line: 543, col: 28, offset: 16143},
 								name: "Expr",
 							},
 						},
@@ -3658,71 +3685,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 544, col: 1, offset: 16054},
+			pos:  position{line: 545, col: 1, offset: 16232},
 			expr: &ruleRefExpr{
-				pos:  position{line: 544, col: 8, offset: 16061},
+				pos:  position{line: 545, col: 8, offset: 16239},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 546, col: 1, offset: 16078},
+			pos:  position{line: 547, col: 1, offset: 16256},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 16098},
+				pos: position{line: 548, col: 5, offset: 16276},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 16098},
+						pos: position{line: 548, col: 5, offset: 16276},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 16098},
+							pos: position{line: 548, col: 5, offset: 16276},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 547, col: 5, offset: 16098},
+									pos:   position{line: 548, col: 5, offset: 16276},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 15, offset: 16108},
+										pos:  position{line: 548, col: 15, offset: 16286},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 29, offset: 16122},
+									pos:  position{line: 548, col: 29, offset: 16300},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 547, col: 32, offset: 16125},
+									pos:        position{line: 548, col: 32, offset: 16303},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 36, offset: 16129},
+									pos:  position{line: 548, col: 36, offset: 16307},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 547, col: 39, offset: 16132},
+									pos:   position{line: 548, col: 39, offset: 16310},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 50, offset: 16143},
+										pos:  position{line: 548, col: 50, offset: 16321},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 55, offset: 16148},
+									pos:  position{line: 548, col: 55, offset: 16326},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 547, col: 58, offset: 16151},
+									pos:        position{line: 548, col: 58, offset: 16329},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 62, offset: 16155},
+									pos:  position{line: 548, col: 62, offset: 16333},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 547, col: 65, offset: 16158},
+									pos:   position{line: 548, col: 65, offset: 16336},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 76, offset: 16169},
+										pos:  position{line: 548, col: 76, offset: 16347},
 										name: "Expr",
 									},
 								},
@@ -3730,7 +3757,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 550, col: 5, offset: 16316},
+						pos:  position{line: 551, col: 5, offset: 16494},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -3738,53 +3765,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 552, col: 1, offset: 16331},
+			pos:  position{line: 553, col: 1, offset: 16509},
 			expr: &actionExpr{
-				pos: position{line: 553, col: 5, offset: 16349},
+				pos: position{line: 554, col: 5, offset: 16527},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 553, col: 5, offset: 16349},
+					pos: position{line: 554, col: 5, offset: 16527},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 553, col: 5, offset: 16349},
+							pos:   position{line: 554, col: 5, offset: 16527},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 553, col: 11, offset: 16355},
+								pos:  position{line: 554, col: 11, offset: 16533},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 554, col: 5, offset: 16374},
+							pos:   position{line: 555, col: 5, offset: 16552},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 554, col: 10, offset: 16379},
+								pos: position{line: 555, col: 10, offset: 16557},
 								expr: &actionExpr{
-									pos: position{line: 554, col: 11, offset: 16380},
+									pos: position{line: 555, col: 11, offset: 16558},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 554, col: 11, offset: 16380},
+										pos: position{line: 555, col: 11, offset: 16558},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 554, col: 11, offset: 16380},
+												pos:  position{line: 555, col: 11, offset: 16558},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 554, col: 14, offset: 16383},
+												pos:   position{line: 555, col: 14, offset: 16561},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 554, col: 17, offset: 16386},
+													pos:  position{line: 555, col: 17, offset: 16564},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 554, col: 25, offset: 16394},
+												pos:  position{line: 555, col: 25, offset: 16572},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 554, col: 28, offset: 16397},
+												pos:   position{line: 555, col: 28, offset: 16575},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 554, col: 33, offset: 16402},
+													pos:  position{line: 555, col: 33, offset: 16580},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -3799,53 +3826,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 558, col: 1, offset: 16520},
+			pos:  position{line: 559, col: 1, offset: 16698},
 			expr: &actionExpr{
-				pos: position{line: 559, col: 5, offset: 16539},
+				pos: position{line: 560, col: 5, offset: 16717},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 559, col: 5, offset: 16539},
+					pos: position{line: 560, col: 5, offset: 16717},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 559, col: 5, offset: 16539},
+							pos:   position{line: 560, col: 5, offset: 16717},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 559, col: 11, offset: 16545},
+								pos:  position{line: 560, col: 11, offset: 16723},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 560, col: 5, offset: 16569},
+							pos:   position{line: 561, col: 5, offset: 16747},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 560, col: 10, offset: 16574},
+								pos: position{line: 561, col: 10, offset: 16752},
 								expr: &actionExpr{
-									pos: position{line: 560, col: 11, offset: 16575},
+									pos: position{line: 561, col: 11, offset: 16753},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 560, col: 11, offset: 16575},
+										pos: position{line: 561, col: 11, offset: 16753},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 560, col: 11, offset: 16575},
+												pos:  position{line: 561, col: 11, offset: 16753},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 560, col: 14, offset: 16578},
+												pos:   position{line: 561, col: 14, offset: 16756},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 560, col: 17, offset: 16581},
+													pos:  position{line: 561, col: 17, offset: 16759},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 560, col: 26, offset: 16590},
+												pos:  position{line: 561, col: 26, offset: 16768},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 560, col: 29, offset: 16593},
+												pos:   position{line: 561, col: 29, offset: 16771},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 560, col: 34, offset: 16598},
+													pos:  position{line: 561, col: 34, offset: 16776},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -3860,53 +3887,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 564, col: 1, offset: 16721},
+			pos:  position{line: 565, col: 1, offset: 16899},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 5, offset: 16745},
+				pos: position{line: 566, col: 5, offset: 16923},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 565, col: 5, offset: 16745},
+					pos: position{line: 566, col: 5, offset: 16923},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 565, col: 5, offset: 16745},
+							pos:   position{line: 566, col: 5, offset: 16923},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 565, col: 11, offset: 16751},
+								pos:  position{line: 566, col: 11, offset: 16929},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 566, col: 5, offset: 16768},
+							pos:   position{line: 567, col: 5, offset: 16946},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 566, col: 10, offset: 16773},
+								pos: position{line: 567, col: 10, offset: 16951},
 								expr: &actionExpr{
-									pos: position{line: 566, col: 11, offset: 16774},
+									pos: position{line: 567, col: 11, offset: 16952},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 566, col: 11, offset: 16774},
+										pos: position{line: 567, col: 11, offset: 16952},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 566, col: 11, offset: 16774},
+												pos:  position{line: 567, col: 11, offset: 16952},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 566, col: 14, offset: 16777},
+												pos:   position{line: 567, col: 14, offset: 16955},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 566, col: 19, offset: 16782},
+													pos:  position{line: 567, col: 19, offset: 16960},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 566, col: 38, offset: 16801},
+												pos:  position{line: 567, col: 38, offset: 16979},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 566, col: 41, offset: 16804},
+												pos:   position{line: 567, col: 41, offset: 16982},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 566, col: 46, offset: 16809},
+													pos:  position{line: 567, col: 46, offset: 16987},
 													name: "RelativeExpr",
 												},
 											},
@@ -3921,20 +3948,20 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 570, col: 1, offset: 16927},
+			pos:  position{line: 571, col: 1, offset: 17105},
 			expr: &actionExpr{
-				pos: position{line: 571, col: 5, offset: 16948},
+				pos: position{line: 572, col: 5, offset: 17126},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 571, col: 6, offset: 16949},
+					pos: position{line: 572, col: 6, offset: 17127},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 571, col: 6, offset: 16949},
+							pos:        position{line: 572, col: 6, offset: 17127},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 571, col: 12, offset: 16955},
+							pos:        position{line: 572, col: 12, offset: 17133},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3944,19 +3971,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 573, col: 1, offset: 16993},
+			pos:  position{line: 574, col: 1, offset: 17171},
 			expr: &choiceExpr{
-				pos: position{line: 574, col: 5, offset: 17016},
+				pos: position{line: 575, col: 5, offset: 17194},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 574, col: 5, offset: 17016},
+						pos:  position{line: 575, col: 5, offset: 17194},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 575, col: 5, offset: 17037},
+						pos: position{line: 576, col: 5, offset: 17215},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 575, col: 5, offset: 17037},
+							pos:        position{line: 576, col: 5, offset: 17215},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3966,53 +3993,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 577, col: 1, offset: 17074},
+			pos:  position{line: 578, col: 1, offset: 17252},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 17091},
+				pos: position{line: 579, col: 5, offset: 17269},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 17091},
+					pos: position{line: 579, col: 5, offset: 17269},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 578, col: 5, offset: 17091},
+							pos:   position{line: 579, col: 5, offset: 17269},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 11, offset: 17097},
+								pos:  position{line: 579, col: 11, offset: 17275},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 579, col: 5, offset: 17114},
+							pos:   position{line: 580, col: 5, offset: 17292},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 579, col: 10, offset: 17119},
+								pos: position{line: 580, col: 10, offset: 17297},
 								expr: &actionExpr{
-									pos: position{line: 579, col: 11, offset: 17120},
+									pos: position{line: 580, col: 11, offset: 17298},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 579, col: 11, offset: 17120},
+										pos: position{line: 580, col: 11, offset: 17298},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 579, col: 11, offset: 17120},
+												pos:  position{line: 580, col: 11, offset: 17298},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 579, col: 14, offset: 17123},
+												pos:   position{line: 580, col: 14, offset: 17301},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 579, col: 17, offset: 17126},
+													pos:  position{line: 580, col: 17, offset: 17304},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 579, col: 34, offset: 17143},
+												pos:  position{line: 580, col: 34, offset: 17321},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 579, col: 37, offset: 17146},
+												pos:   position{line: 580, col: 37, offset: 17324},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 579, col: 42, offset: 17151},
+													pos:  position{line: 580, col: 42, offset: 17329},
 													name: "AdditiveExpr",
 												},
 											},
@@ -4027,30 +4054,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 583, col: 1, offset: 17267},
+			pos:  position{line: 584, col: 1, offset: 17445},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 20, offset: 17286},
+				pos: position{line: 584, col: 20, offset: 17464},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 583, col: 21, offset: 17287},
+					pos: position{line: 584, col: 21, offset: 17465},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 583, col: 21, offset: 17287},
+							pos:        position{line: 584, col: 21, offset: 17465},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 583, col: 28, offset: 17294},
+							pos:        position{line: 584, col: 28, offset: 17472},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 583, col: 34, offset: 17300},
+							pos:        position{line: 584, col: 34, offset: 17478},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 583, col: 41, offset: 17307},
+							pos:        position{line: 584, col: 41, offset: 17485},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -4060,53 +4087,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 585, col: 1, offset: 17344},
+			pos:  position{line: 586, col: 1, offset: 17522},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 5, offset: 17361},
+				pos: position{line: 587, col: 5, offset: 17539},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 586, col: 5, offset: 17361},
+					pos: position{line: 587, col: 5, offset: 17539},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 586, col: 5, offset: 17361},
+							pos:   position{line: 587, col: 5, offset: 17539},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 586, col: 11, offset: 17367},
+								pos:  position{line: 587, col: 11, offset: 17545},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 587, col: 5, offset: 17390},
+							pos:   position{line: 588, col: 5, offset: 17568},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 587, col: 10, offset: 17395},
+								pos: position{line: 588, col: 10, offset: 17573},
 								expr: &actionExpr{
-									pos: position{line: 587, col: 11, offset: 17396},
+									pos: position{line: 588, col: 11, offset: 17574},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 587, col: 11, offset: 17396},
+										pos: position{line: 588, col: 11, offset: 17574},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 587, col: 11, offset: 17396},
+												pos:  position{line: 588, col: 11, offset: 17574},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 587, col: 14, offset: 17399},
+												pos:   position{line: 588, col: 14, offset: 17577},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 587, col: 17, offset: 17402},
+													pos:  position{line: 588, col: 17, offset: 17580},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 587, col: 34, offset: 17419},
+												pos:  position{line: 588, col: 34, offset: 17597},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 587, col: 37, offset: 17422},
+												pos:   position{line: 588, col: 37, offset: 17600},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 587, col: 42, offset: 17427},
+													pos:  position{line: 588, col: 42, offset: 17605},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -4121,20 +4148,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 591, col: 1, offset: 17549},
+			pos:  position{line: 592, col: 1, offset: 17727},
 			expr: &actionExpr{
-				pos: position{line: 591, col: 20, offset: 17568},
+				pos: position{line: 592, col: 20, offset: 17746},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 591, col: 21, offset: 17569},
+					pos: position{line: 592, col: 21, offset: 17747},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 591, col: 21, offset: 17569},
+							pos:        position{line: 592, col: 21, offset: 17747},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 591, col: 27, offset: 17575},
+							pos:        position{line: 592, col: 27, offset: 17753},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -4144,53 +4171,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 593, col: 1, offset: 17612},
+			pos:  position{line: 594, col: 1, offset: 17790},
 			expr: &actionExpr{
-				pos: position{line: 594, col: 5, offset: 17635},
+				pos: position{line: 595, col: 5, offset: 17813},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 594, col: 5, offset: 17635},
+					pos: position{line: 595, col: 5, offset: 17813},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 594, col: 5, offset: 17635},
+							pos:   position{line: 595, col: 5, offset: 17813},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 594, col: 11, offset: 17641},
+								pos:  position{line: 595, col: 11, offset: 17819},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 5, offset: 17653},
+							pos:   position{line: 596, col: 5, offset: 17831},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 595, col: 10, offset: 17658},
+								pos: position{line: 596, col: 10, offset: 17836},
 								expr: &actionExpr{
-									pos: position{line: 595, col: 11, offset: 17659},
+									pos: position{line: 596, col: 11, offset: 17837},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 595, col: 11, offset: 17659},
+										pos: position{line: 596, col: 11, offset: 17837},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 595, col: 11, offset: 17659},
+												pos:  position{line: 596, col: 11, offset: 17837},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 595, col: 14, offset: 17662},
+												pos:   position{line: 596, col: 14, offset: 17840},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 595, col: 17, offset: 17665},
+													pos:  position{line: 596, col: 17, offset: 17843},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 595, col: 40, offset: 17688},
+												pos:  position{line: 596, col: 40, offset: 17866},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 595, col: 43, offset: 17691},
+												pos:   position{line: 596, col: 43, offset: 17869},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 595, col: 48, offset: 17696},
+													pos:  position{line: 596, col: 48, offset: 17874},
 													name: "NotExpr",
 												},
 											},
@@ -4205,20 +4232,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 599, col: 1, offset: 17807},
+			pos:  position{line: 600, col: 1, offset: 17985},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 26, offset: 17832},
+				pos: position{line: 600, col: 26, offset: 18010},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 599, col: 27, offset: 17833},
+					pos: position{line: 600, col: 27, offset: 18011},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 599, col: 27, offset: 17833},
+							pos:        position{line: 600, col: 27, offset: 18011},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 599, col: 33, offset: 17839},
+							pos:        position{line: 600, col: 33, offset: 18017},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4228,30 +4255,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 601, col: 1, offset: 17876},
+			pos:  position{line: 602, col: 1, offset: 18054},
 			expr: &choiceExpr{
-				pos: position{line: 602, col: 5, offset: 17888},
+				pos: position{line: 603, col: 5, offset: 18066},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 602, col: 5, offset: 17888},
+						pos: position{line: 603, col: 5, offset: 18066},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 602, col: 5, offset: 17888},
+							pos: position{line: 603, col: 5, offset: 18066},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 602, col: 5, offset: 17888},
+									pos:        position{line: 603, col: 5, offset: 18066},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 602, col: 9, offset: 17892},
+									pos:  position{line: 603, col: 9, offset: 18070},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 602, col: 12, offset: 17895},
+									pos:   position{line: 603, col: 12, offset: 18073},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 602, col: 14, offset: 17897},
+										pos:  position{line: 603, col: 14, offset: 18075},
 										name: "NotExpr",
 									},
 								},
@@ -4259,7 +4286,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 605, col: 5, offset: 18010},
+						pos:  position{line: 606, col: 5, offset: 18188},
 						name: "CastExpr",
 					},
 				},
@@ -4267,42 +4294,42 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 607, col: 1, offset: 18020},
+			pos:  position{line: 608, col: 1, offset: 18198},
 			expr: &choiceExpr{
-				pos: position{line: 608, col: 5, offset: 18033},
+				pos: position{line: 609, col: 5, offset: 18211},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 608, col: 5, offset: 18033},
+						pos: position{line: 609, col: 5, offset: 18211},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 608, col: 5, offset: 18033},
+							pos: position{line: 609, col: 5, offset: 18211},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 608, col: 5, offset: 18033},
+									pos:   position{line: 609, col: 5, offset: 18211},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 608, col: 7, offset: 18035},
+										pos:  position{line: 609, col: 7, offset: 18213},
 										name: "FuncExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 608, col: 16, offset: 18044},
+									pos:  position{line: 609, col: 16, offset: 18222},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 608, col: 19, offset: 18047},
+									pos:        position{line: 609, col: 19, offset: 18225},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 608, col: 23, offset: 18051},
+									pos:  position{line: 609, col: 23, offset: 18229},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 608, col: 26, offset: 18054},
+									pos:   position{line: 609, col: 26, offset: 18232},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 608, col: 30, offset: 18058},
+										pos:  position{line: 609, col: 30, offset: 18236},
 										name: "CastType",
 									},
 								},
@@ -4310,7 +4337,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 611, col: 5, offset: 18162},
+						pos:  position{line: 612, col: 5, offset: 18340},
 						name: "FuncExpr",
 					},
 				},
@@ -4318,43 +4345,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 613, col: 1, offset: 18172},
+			pos:  position{line: 614, col: 1, offset: 18350},
 			expr: &choiceExpr{
-				pos: position{line: 614, col: 5, offset: 18185},
+				pos: position{line: 615, col: 5, offset: 18363},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 614, col: 5, offset: 18185},
+						pos:  position{line: 615, col: 5, offset: 18363},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 615, col: 5, offset: 18200},
+						pos:  position{line: 616, col: 5, offset: 18378},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 616, col: 5, offset: 18214},
+						pos:  position{line: 617, col: 5, offset: 18392},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 617, col: 5, offset: 18230},
+						pos: position{line: 618, col: 5, offset: 18408},
 						run: (*parser).callonFuncExpr5,
 						expr: &seqExpr{
-							pos: position{line: 617, col: 5, offset: 18230},
+							pos: position{line: 618, col: 5, offset: 18408},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 617, col: 5, offset: 18230},
+									pos:   position{line: 618, col: 5, offset: 18408},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 617, col: 11, offset: 18236},
+										pos:  position{line: 618, col: 11, offset: 18414},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 617, col: 20, offset: 18245},
+									pos:   position{line: 618, col: 20, offset: 18423},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 617, col: 25, offset: 18250},
+										pos: position{line: 618, col: 25, offset: 18428},
 										expr: &ruleRefExpr{
-											pos:  position{line: 617, col: 26, offset: 18251},
+											pos:  position{line: 618, col: 26, offset: 18429},
 											name: "Deref",
 										},
 									},
@@ -4363,11 +4390,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 620, col: 5, offset: 18322},
+						pos:  position{line: 621, col: 5, offset: 18500},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 621, col: 5, offset: 18336},
+						pos:  position{line: 622, col: 5, offset: 18514},
 						name: "Primary",
 					},
 				},
@@ -4375,20 +4402,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 623, col: 1, offset: 18345},
+			pos:  position{line: 624, col: 1, offset: 18523},
 			expr: &seqExpr{
-				pos: position{line: 623, col: 13, offset: 18357},
+				pos: position{line: 624, col: 13, offset: 18535},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 623, col: 13, offset: 18357},
+						pos:  position{line: 624, col: 13, offset: 18535},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 623, col: 22, offset: 18366},
+						pos:  position{line: 624, col: 22, offset: 18544},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 623, col: 25, offset: 18369},
+						pos:        position{line: 624, col: 25, offset: 18547},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -4397,27 +4424,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 625, col: 1, offset: 18374},
+			pos:  position{line: 626, col: 1, offset: 18552},
 			expr: &choiceExpr{
-				pos: position{line: 626, col: 5, offset: 18387},
+				pos: position{line: 627, col: 5, offset: 18565},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 626, col: 5, offset: 18387},
+						pos:        position{line: 627, col: 5, offset: 18565},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 627, col: 5, offset: 18397},
+						pos:        position{line: 628, col: 5, offset: 18575},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 628, col: 5, offset: 18409},
+						pos:        position{line: 629, col: 5, offset: 18587},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 629, col: 5, offset: 18422},
+						pos:        position{line: 630, col: 5, offset: 18600},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -4426,37 +4453,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 631, col: 1, offset: 18430},
+			pos:  position{line: 632, col: 1, offset: 18608},
 			expr: &actionExpr{
-				pos: position{line: 632, col: 5, offset: 18444},
+				pos: position{line: 633, col: 5, offset: 18622},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 632, col: 5, offset: 18444},
+					pos: position{line: 633, col: 5, offset: 18622},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 632, col: 5, offset: 18444},
+							pos:        position{line: 633, col: 5, offset: 18622},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 632, col: 13, offset: 18452},
+							pos:  position{line: 633, col: 13, offset: 18630},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 632, col: 16, offset: 18455},
+							pos:        position{line: 633, col: 16, offset: 18633},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 632, col: 20, offset: 18459},
+							pos:   position{line: 633, col: 20, offset: 18637},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 632, col: 25, offset: 18464},
+								pos:  position{line: 633, col: 25, offset: 18642},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 632, col: 39, offset: 18478},
+							pos:        position{line: 633, col: 39, offset: 18656},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4466,53 +4493,53 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 634, col: 1, offset: 18504},
+			pos:  position{line: 635, col: 1, offset: 18682},
 			expr: &actionExpr{
-				pos: position{line: 635, col: 5, offset: 18519},
+				pos: position{line: 636, col: 5, offset: 18697},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 635, col: 5, offset: 18519},
+					pos: position{line: 636, col: 5, offset: 18697},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 635, col: 5, offset: 18519},
+							pos:        position{line: 636, col: 5, offset: 18697},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 635, col: 14, offset: 18528},
+							pos:  position{line: 636, col: 14, offset: 18706},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 635, col: 17, offset: 18531},
+							pos:        position{line: 636, col: 17, offset: 18709},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 635, col: 21, offset: 18535},
+							pos:  position{line: 636, col: 21, offset: 18713},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 635, col: 24, offset: 18538},
+							pos:   position{line: 636, col: 24, offset: 18716},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 29, offset: 18543},
+								pos:  position{line: 636, col: 29, offset: 18721},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 635, col: 42, offset: 18556},
+							pos:  position{line: 636, col: 42, offset: 18734},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 635, col: 45, offset: 18559},
+							pos:        position{line: 636, col: 45, offset: 18737},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 635, col: 49, offset: 18563},
+							pos:   position{line: 636, col: 49, offset: 18741},
 							label: "methods",
 							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 57, offset: 18571},
+								pos:  position{line: 636, col: 57, offset: 18749},
 								name: "Methods",
 							},
 						},
@@ -4522,30 +4549,30 @@ var g = &grammar{
 		},
 		{
 			name: "Methods",
-			pos:  position{line: 643, col: 1, offset: 18967},
+			pos:  position{line: 644, col: 1, offset: 19145},
 			expr: &choiceExpr{
-				pos: position{line: 644, col: 5, offset: 18979},
+				pos: position{line: 645, col: 5, offset: 19157},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 644, col: 5, offset: 18979},
+						pos: position{line: 645, col: 5, offset: 19157},
 						run: (*parser).callonMethods2,
 						expr: &labeledExpr{
-							pos:   position{line: 644, col: 5, offset: 18979},
+							pos:   position{line: 645, col: 5, offset: 19157},
 							label: "methods",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 644, col: 13, offset: 18987},
+								pos: position{line: 645, col: 13, offset: 19165},
 								expr: &ruleRefExpr{
-									pos:  position{line: 644, col: 13, offset: 18987},
+									pos:  position{line: 645, col: 13, offset: 19165},
 									name: "Method",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 645, col: 5, offset: 19023},
+						pos: position{line: 646, col: 5, offset: 19201},
 						run: (*parser).callonMethods6,
 						expr: &litMatcher{
-							pos:        position{line: 645, col: 5, offset: 19023},
+							pos:        position{line: 646, col: 5, offset: 19201},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4555,31 +4582,31 @@ var g = &grammar{
 		},
 		{
 			name: "Method",
-			pos:  position{line: 647, col: 1, offset: 19047},
+			pos:  position{line: 648, col: 1, offset: 19225},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 19058},
+				pos: position{line: 649, col: 5, offset: 19236},
 				run: (*parser).callonMethod1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 5, offset: 19058},
+					pos: position{line: 649, col: 5, offset: 19236},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 648, col: 5, offset: 19058},
+							pos:  position{line: 649, col: 5, offset: 19236},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 648, col: 8, offset: 19061},
+							pos:        position{line: 649, col: 8, offset: 19239},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 648, col: 12, offset: 19065},
+							pos:  position{line: 649, col: 12, offset: 19243},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 648, col: 15, offset: 19068},
+							pos:   position{line: 649, col: 15, offset: 19246},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 17, offset: 19070},
+								pos:  position{line: 649, col: 17, offset: 19248},
 								name: "Function",
 							},
 						},
@@ -4589,55 +4616,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 650, col: 1, offset: 19098},
+			pos:  position{line: 651, col: 1, offset: 19276},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 5, offset: 19111},
+				pos: position{line: 652, col: 5, offset: 19289},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 651, col: 5, offset: 19111},
+					pos: position{line: 652, col: 5, offset: 19289},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 651, col: 5, offset: 19111},
+							pos: position{line: 652, col: 5, offset: 19289},
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 6, offset: 19112},
+								pos:  position{line: 652, col: 6, offset: 19290},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 16, offset: 19122},
+							pos:   position{line: 652, col: 16, offset: 19300},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 19, offset: 19125},
+								pos:  position{line: 652, col: 19, offset: 19303},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 651, col: 34, offset: 19140},
+							pos:  position{line: 652, col: 34, offset: 19318},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 651, col: 37, offset: 19143},
+							pos:        position{line: 652, col: 37, offset: 19321},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 651, col: 41, offset: 19147},
+							pos:  position{line: 652, col: 41, offset: 19325},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 44, offset: 19150},
+							pos:   position{line: 652, col: 44, offset: 19328},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 49, offset: 19155},
+								pos:  position{line: 652, col: 49, offset: 19333},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 651, col: 62, offset: 19168},
+							pos:  position{line: 652, col: 62, offset: 19346},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 651, col: 65, offset: 19171},
+							pos:        position{line: 652, col: 65, offset: 19349},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4647,53 +4674,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 655, col: 1, offset: 19277},
+			pos:  position{line: 656, col: 1, offset: 19455},
 			expr: &choiceExpr{
-				pos: position{line: 656, col: 5, offset: 19294},
+				pos: position{line: 657, col: 5, offset: 19472},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 19294},
+						pos: position{line: 657, col: 5, offset: 19472},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 19294},
+							pos: position{line: 657, col: 5, offset: 19472},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 656, col: 5, offset: 19294},
+									pos:   position{line: 657, col: 5, offset: 19472},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 656, col: 11, offset: 19300},
+										pos:  position{line: 657, col: 11, offset: 19478},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 656, col: 16, offset: 19305},
+									pos:   position{line: 657, col: 16, offset: 19483},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 656, col: 21, offset: 19310},
+										pos: position{line: 657, col: 21, offset: 19488},
 										expr: &actionExpr{
-											pos: position{line: 656, col: 22, offset: 19311},
+											pos: position{line: 657, col: 22, offset: 19489},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 656, col: 22, offset: 19311},
+												pos: position{line: 657, col: 22, offset: 19489},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 656, col: 22, offset: 19311},
+														pos:  position{line: 657, col: 22, offset: 19489},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 656, col: 25, offset: 19314},
+														pos:        position{line: 657, col: 25, offset: 19492},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 656, col: 29, offset: 19318},
+														pos:  position{line: 657, col: 29, offset: 19496},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 656, col: 32, offset: 19321},
+														pos:   position{line: 657, col: 32, offset: 19499},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 656, col: 34, offset: 19323},
+															pos:  position{line: 657, col: 34, offset: 19501},
 															name: "Expr",
 														},
 													},
@@ -4706,10 +4733,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19435},
+						pos: position{line: 660, col: 5, offset: 19613},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 659, col: 5, offset: 19435},
+							pos:  position{line: 660, col: 5, offset: 19613},
 							name: "__",
 						},
 					},
@@ -4718,31 +4745,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 661, col: 1, offset: 19471},
+			pos:  position{line: 662, col: 1, offset: 19649},
 			expr: &choiceExpr{
-				pos: position{line: 662, col: 5, offset: 19485},
+				pos: position{line: 663, col: 5, offset: 19663},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 662, col: 5, offset: 19485},
+						pos: position{line: 663, col: 5, offset: 19663},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 662, col: 5, offset: 19485},
+							pos: position{line: 663, col: 5, offset: 19663},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 662, col: 5, offset: 19485},
+									pos:   position{line: 663, col: 5, offset: 19663},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 662, col: 11, offset: 19491},
+										pos:  position{line: 663, col: 11, offset: 19669},
 										name: "DotId",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 662, col: 17, offset: 19497},
+									pos:   position{line: 663, col: 17, offset: 19675},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 662, col: 22, offset: 19502},
+										pos: position{line: 663, col: 22, offset: 19680},
 										expr: &ruleRefExpr{
-											pos:  position{line: 662, col: 23, offset: 19503},
+											pos:  position{line: 663, col: 23, offset: 19681},
 											name: "Deref",
 										},
 									},
@@ -4751,26 +4778,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 665, col: 5, offset: 19574},
+						pos: position{line: 666, col: 5, offset: 19752},
 						run: (*parser).callonDerefExpr9,
 						expr: &seqExpr{
-							pos: position{line: 665, col: 5, offset: 19574},
+							pos: position{line: 666, col: 5, offset: 19752},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 665, col: 5, offset: 19574},
+									pos:   position{line: 666, col: 5, offset: 19752},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 665, col: 11, offset: 19580},
+										pos:  position{line: 666, col: 11, offset: 19758},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 665, col: 22, offset: 19591},
+									pos:   position{line: 666, col: 22, offset: 19769},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 665, col: 27, offset: 19596},
+										pos: position{line: 666, col: 27, offset: 19774},
 										expr: &ruleRefExpr{
-											pos:  position{line: 665, col: 28, offset: 19597},
+											pos:  position{line: 666, col: 28, offset: 19775},
 											name: "Deref",
 										},
 									},
@@ -4779,10 +4806,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 19668},
+						pos: position{line: 669, col: 5, offset: 19846},
 						run: (*parser).callonDerefExpr16,
 						expr: &litMatcher{
-							pos:        position{line: 668, col: 5, offset: 19668},
+							pos:        position{line: 669, col: 5, offset: 19846},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -4792,26 +4819,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotId",
-			pos:  position{line: 672, col: 1, offset: 19741},
+			pos:  position{line: 673, col: 1, offset: 19919},
 			expr: &choiceExpr{
-				pos: position{line: 673, col: 5, offset: 19751},
+				pos: position{line: 674, col: 5, offset: 19929},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19751},
+						pos: position{line: 674, col: 5, offset: 19929},
 						run: (*parser).callonDotId2,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 19751},
+							pos: position{line: 674, col: 5, offset: 19929},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 673, col: 5, offset: 19751},
+									pos:        position{line: 674, col: 5, offset: 19929},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 9, offset: 19755},
+									pos:   position{line: 674, col: 9, offset: 19933},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 15, offset: 19761},
+										pos:  position{line: 674, col: 15, offset: 19939},
 										name: "Identifier",
 									},
 								},
@@ -4819,31 +4846,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 682, col: 5, offset: 19985},
+						pos: position{line: 683, col: 5, offset: 20163},
 						run: (*parser).callonDotId7,
 						expr: &seqExpr{
-							pos: position{line: 682, col: 5, offset: 19985},
+							pos: position{line: 683, col: 5, offset: 20163},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 682, col: 5, offset: 19985},
+									pos:        position{line: 683, col: 5, offset: 20163},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 682, col: 9, offset: 19989},
+									pos:        position{line: 683, col: 9, offset: 20167},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 682, col: 13, offset: 19993},
+									pos:   position{line: 683, col: 13, offset: 20171},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 682, col: 18, offset: 19998},
+										pos:  position{line: 683, col: 18, offset: 20176},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 682, col: 23, offset: 20003},
+									pos:        position{line: 683, col: 23, offset: 20181},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4855,52 +4882,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 692, col: 1, offset: 20216},
+			pos:  position{line: 693, col: 1, offset: 20394},
 			expr: &choiceExpr{
-				pos: position{line: 693, col: 5, offset: 20226},
+				pos: position{line: 694, col: 5, offset: 20404},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 693, col: 5, offset: 20226},
+						pos: position{line: 694, col: 5, offset: 20404},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 693, col: 5, offset: 20226},
+							pos: position{line: 694, col: 5, offset: 20404},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 693, col: 5, offset: 20226},
+									pos:        position{line: 694, col: 5, offset: 20404},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 693, col: 9, offset: 20230},
+									pos:   position{line: 694, col: 9, offset: 20408},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 693, col: 14, offset: 20235},
+										pos:  position{line: 694, col: 14, offset: 20413},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 693, col: 27, offset: 20248},
+									pos:  position{line: 694, col: 27, offset: 20426},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 693, col: 30, offset: 20251},
+									pos:        position{line: 694, col: 30, offset: 20429},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 693, col: 34, offset: 20255},
+									pos:  position{line: 694, col: 34, offset: 20433},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 693, col: 37, offset: 20258},
+									pos:   position{line: 694, col: 37, offset: 20436},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 693, col: 40, offset: 20261},
+										pos:  position{line: 694, col: 40, offset: 20439},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 693, col: 53, offset: 20274},
+									pos:        position{line: 694, col: 53, offset: 20452},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4908,39 +4935,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 699, col: 5, offset: 20449},
+						pos: position{line: 700, col: 5, offset: 20627},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 699, col: 5, offset: 20449},
+							pos: position{line: 700, col: 5, offset: 20627},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 699, col: 5, offset: 20449},
+									pos:        position{line: 700, col: 5, offset: 20627},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 699, col: 9, offset: 20453},
+									pos:  position{line: 700, col: 9, offset: 20631},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 699, col: 12, offset: 20456},
+									pos:        position{line: 700, col: 12, offset: 20634},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 699, col: 16, offset: 20460},
+									pos:  position{line: 700, col: 16, offset: 20638},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 699, col: 19, offset: 20463},
+									pos:   position{line: 700, col: 19, offset: 20641},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 699, col: 22, offset: 20466},
+										pos:  position{line: 700, col: 22, offset: 20644},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 699, col: 35, offset: 20479},
+									pos:        position{line: 700, col: 35, offset: 20657},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4948,39 +4975,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 20654},
+						pos: position{line: 706, col: 5, offset: 20832},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 705, col: 5, offset: 20654},
+							pos: position{line: 706, col: 5, offset: 20832},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 705, col: 5, offset: 20654},
+									pos:        position{line: 706, col: 5, offset: 20832},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 705, col: 9, offset: 20658},
+									pos:   position{line: 706, col: 9, offset: 20836},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 705, col: 14, offset: 20663},
+										pos:  position{line: 706, col: 14, offset: 20841},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 705, col: 27, offset: 20676},
+									pos:  position{line: 706, col: 27, offset: 20854},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 705, col: 30, offset: 20679},
+									pos:        position{line: 706, col: 30, offset: 20857},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 705, col: 34, offset: 20683},
+									pos:  position{line: 706, col: 34, offset: 20861},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 705, col: 37, offset: 20686},
+									pos:        position{line: 706, col: 37, offset: 20864},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4988,26 +5015,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 711, col: 5, offset: 20863},
+						pos: position{line: 712, col: 5, offset: 21041},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 711, col: 5, offset: 20863},
+							pos: position{line: 712, col: 5, offset: 21041},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 711, col: 5, offset: 20863},
+									pos:        position{line: 712, col: 5, offset: 21041},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 711, col: 9, offset: 20867},
+									pos:   position{line: 712, col: 9, offset: 21045},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 711, col: 14, offset: 20872},
+										pos:  position{line: 712, col: 14, offset: 21050},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 711, col: 19, offset: 20877},
+									pos:        position{line: 712, col: 19, offset: 21055},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5015,29 +5042,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 20926},
+						pos: position{line: 713, col: 5, offset: 21104},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 20926},
+							pos: position{line: 713, col: 5, offset: 21104},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 712, col: 5, offset: 20926},
+									pos:        position{line: 713, col: 5, offset: 21104},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 712, col: 9, offset: 20930},
+									pos: position{line: 713, col: 9, offset: 21108},
 									expr: &litMatcher{
-										pos:        position{line: 712, col: 11, offset: 20932},
+										pos:        position{line: 713, col: 11, offset: 21110},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 16, offset: 20937},
+									pos:   position{line: 713, col: 16, offset: 21115},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 712, col: 19, offset: 20940},
+										pos:  position{line: 713, col: 19, offset: 21118},
 										name: "Identifier",
 									},
 								},
@@ -5049,43 +5076,43 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 714, col: 1, offset: 20991},
+			pos:  position{line: 715, col: 1, offset: 21169},
 			expr: &choiceExpr{
-				pos: position{line: 715, col: 5, offset: 21003},
+				pos: position{line: 716, col: 5, offset: 21181},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 715, col: 5, offset: 21003},
+						pos:  position{line: 716, col: 5, offset: 21181},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 716, col: 5, offset: 21015},
+						pos: position{line: 717, col: 5, offset: 21193},
 						run: (*parser).callonPrimary3,
 						expr: &seqExpr{
-							pos: position{line: 716, col: 5, offset: 21015},
+							pos: position{line: 717, col: 5, offset: 21193},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 716, col: 5, offset: 21015},
+									pos:        position{line: 717, col: 5, offset: 21193},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 716, col: 9, offset: 21019},
+									pos:  position{line: 717, col: 9, offset: 21197},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 12, offset: 21022},
+									pos:   position{line: 717, col: 12, offset: 21200},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 716, col: 17, offset: 21027},
+										pos:  position{line: 717, col: 17, offset: 21205},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 716, col: 22, offset: 21032},
+									pos:  position{line: 717, col: 22, offset: 21210},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 716, col: 25, offset: 21035},
+									pos:        position{line: 717, col: 25, offset: 21213},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5097,44 +5124,44 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 718, col: 1, offset: 21061},
+			pos:  position{line: 719, col: 1, offset: 21239},
 			expr: &choiceExpr{
-				pos: position{line: 719, col: 5, offset: 21073},
+				pos: position{line: 720, col: 5, offset: 21251},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 719, col: 5, offset: 21073},
+						pos:  position{line: 720, col: 5, offset: 21251},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 720, col: 5, offset: 21089},
+						pos:  position{line: 721, col: 5, offset: 21267},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 5, offset: 21107},
+						pos:  position{line: 722, col: 5, offset: 21285},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 722, col: 5, offset: 21125},
+						pos:  position{line: 723, col: 5, offset: 21303},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 723, col: 5, offset: 21143},
+						pos:  position{line: 724, col: 5, offset: 21321},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 724, col: 5, offset: 21162},
+						pos:  position{line: 725, col: 5, offset: 21340},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 725, col: 5, offset: 21179},
+						pos:  position{line: 726, col: 5, offset: 21357},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 726, col: 5, offset: 21198},
+						pos:  position{line: 727, col: 5, offset: 21376},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 727, col: 5, offset: 21217},
+						pos:  position{line: 728, col: 5, offset: 21395},
 						name: "NullLiteral",
 					},
 				},
@@ -5142,15 +5169,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 729, col: 1, offset: 21230},
+			pos:  position{line: 730, col: 1, offset: 21408},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 5, offset: 21248},
+				pos: position{line: 731, col: 5, offset: 21426},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 730, col: 5, offset: 21248},
+					pos:   position{line: 731, col: 5, offset: 21426},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 730, col: 7, offset: 21250},
+						pos:  position{line: 731, col: 7, offset: 21428},
 						name: "QuotedString",
 					},
 				},
@@ -5158,25 +5185,25 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpLiteral",
-			pos:  position{line: 734, col: 1, offset: 21360},
+			pos:  position{line: 735, col: 1, offset: 21538},
 			expr: &actionExpr{
-				pos: position{line: 735, col: 5, offset: 21378},
+				pos: position{line: 736, col: 5, offset: 21556},
 				run: (*parser).callonRegexpLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 735, col: 5, offset: 21378},
+					pos: position{line: 736, col: 5, offset: 21556},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 735, col: 5, offset: 21378},
+							pos:   position{line: 736, col: 5, offset: 21556},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 735, col: 7, offset: 21380},
+								pos:  position{line: 736, col: 7, offset: 21558},
 								name: "Regexp",
 							},
 						},
 						&notExpr{
-							pos: position{line: 735, col: 14, offset: 21387},
+							pos: position{line: 736, col: 14, offset: 21565},
 							expr: &ruleRefExpr{
-								pos:  position{line: 735, col: 15, offset: 21388},
+								pos:  position{line: 736, col: 15, offset: 21566},
 								name: "KeyWordStart",
 							},
 						},
@@ -5186,28 +5213,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 739, col: 1, offset: 21498},
+			pos:  position{line: 740, col: 1, offset: 21676},
 			expr: &choiceExpr{
-				pos: position{line: 740, col: 5, offset: 21516},
+				pos: position{line: 741, col: 5, offset: 21694},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 740, col: 5, offset: 21516},
+						pos: position{line: 741, col: 5, offset: 21694},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 740, col: 5, offset: 21516},
+							pos: position{line: 741, col: 5, offset: 21694},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 740, col: 5, offset: 21516},
+									pos:   position{line: 741, col: 5, offset: 21694},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 740, col: 7, offset: 21518},
+										pos:  position{line: 741, col: 7, offset: 21696},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 740, col: 14, offset: 21525},
+									pos: position{line: 741, col: 14, offset: 21703},
 									expr: &ruleRefExpr{
-										pos:  position{line: 740, col: 15, offset: 21526},
+										pos:  position{line: 741, col: 15, offset: 21704},
 										name: "IdentifierRest",
 									},
 								},
@@ -5215,13 +5242,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 743, col: 5, offset: 21638},
+						pos: position{line: 744, col: 5, offset: 21816},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 743, col: 5, offset: 21638},
+							pos:   position{line: 744, col: 5, offset: 21816},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 743, col: 7, offset: 21640},
+								pos:  position{line: 744, col: 7, offset: 21818},
 								name: "IP4Net",
 							},
 						},
@@ -5231,28 +5258,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 747, col: 1, offset: 21741},
+			pos:  position{line: 748, col: 1, offset: 21919},
 			expr: &choiceExpr{
-				pos: position{line: 748, col: 5, offset: 21760},
+				pos: position{line: 749, col: 5, offset: 21938},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 748, col: 5, offset: 21760},
+						pos: position{line: 749, col: 5, offset: 21938},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 748, col: 5, offset: 21760},
+							pos: position{line: 749, col: 5, offset: 21938},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 748, col: 5, offset: 21760},
+									pos:   position{line: 749, col: 5, offset: 21938},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 748, col: 7, offset: 21762},
+										pos:  position{line: 749, col: 7, offset: 21940},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 748, col: 11, offset: 21766},
+									pos: position{line: 749, col: 11, offset: 21944},
 									expr: &ruleRefExpr{
-										pos:  position{line: 748, col: 12, offset: 21767},
+										pos:  position{line: 749, col: 12, offset: 21945},
 										name: "IdentifierRest",
 									},
 								},
@@ -5260,13 +5287,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 751, col: 5, offset: 21878},
+						pos: position{line: 752, col: 5, offset: 22056},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 751, col: 5, offset: 21878},
+							pos:   position{line: 752, col: 5, offset: 22056},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 751, col: 7, offset: 21880},
+								pos:  position{line: 752, col: 7, offset: 22058},
 								name: "IP",
 							},
 						},
@@ -5276,15 +5303,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 755, col: 1, offset: 21976},
+			pos:  position{line: 756, col: 1, offset: 22154},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 21993},
+				pos: position{line: 757, col: 5, offset: 22171},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 756, col: 5, offset: 21993},
+					pos:   position{line: 757, col: 5, offset: 22171},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 756, col: 7, offset: 21995},
+						pos:  position{line: 757, col: 7, offset: 22173},
 						name: "FloatString",
 					},
 				},
@@ -5292,15 +5319,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 760, col: 1, offset: 22105},
+			pos:  position{line: 761, col: 1, offset: 22283},
 			expr: &actionExpr{
-				pos: position{line: 761, col: 5, offset: 22124},
+				pos: position{line: 762, col: 5, offset: 22302},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 761, col: 5, offset: 22124},
+					pos:   position{line: 762, col: 5, offset: 22302},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 761, col: 7, offset: 22126},
+						pos:  position{line: 762, col: 7, offset: 22304},
 						name: "IntString",
 					},
 				},
@@ -5308,24 +5335,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 765, col: 1, offset: 22232},
+			pos:  position{line: 766, col: 1, offset: 22410},
 			expr: &choiceExpr{
-				pos: position{line: 766, col: 5, offset: 22251},
+				pos: position{line: 767, col: 5, offset: 22429},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 766, col: 5, offset: 22251},
+						pos: position{line: 767, col: 5, offset: 22429},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 766, col: 5, offset: 22251},
+							pos:        position{line: 767, col: 5, offset: 22429},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 767, col: 5, offset: 22361},
+						pos: position{line: 768, col: 5, offset: 22539},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 767, col: 5, offset: 22361},
+							pos:        position{line: 768, col: 5, offset: 22539},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -5335,12 +5362,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 769, col: 1, offset: 22469},
+			pos:  position{line: 770, col: 1, offset: 22647},
 			expr: &actionExpr{
-				pos: position{line: 770, col: 5, offset: 22485},
+				pos: position{line: 771, col: 5, offset: 22663},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 770, col: 5, offset: 22485},
+					pos:        position{line: 771, col: 5, offset: 22663},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -5348,15 +5375,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 772, col: 1, offset: 22588},
+			pos:  position{line: 773, col: 1, offset: 22766},
 			expr: &actionExpr{
-				pos: position{line: 773, col: 5, offset: 22604},
+				pos: position{line: 774, col: 5, offset: 22782},
 				run: (*parser).callonTypeLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 773, col: 5, offset: 22604},
+					pos:   position{line: 774, col: 5, offset: 22782},
 					label: "typ",
 					expr: &ruleRefExpr{
-						pos:  position{line: 773, col: 9, offset: 22608},
+						pos:  position{line: 774, col: 9, offset: 22786},
 						name: "TypeExternal",
 					},
 				},
@@ -5364,16 +5391,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 777, col: 1, offset: 22702},
+			pos:  position{line: 778, col: 1, offset: 22880},
 			expr: &choiceExpr{
-				pos: position{line: 778, col: 5, offset: 22715},
+				pos: position{line: 779, col: 5, offset: 22893},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 778, col: 5, offset: 22715},
+						pos:  position{line: 779, col: 5, offset: 22893},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 779, col: 5, offset: 22732},
+						pos:  position{line: 780, col: 5, offset: 22910},
 						name: "PrimitiveType",
 					},
 				},
@@ -5381,48 +5408,48 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 781, col: 1, offset: 22747},
+			pos:  position{line: 782, col: 1, offset: 22925},
 			expr: &choiceExpr{
-				pos: position{line: 782, col: 5, offset: 22764},
+				pos: position{line: 783, col: 5, offset: 22942},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 782, col: 5, offset: 22764},
+						pos: position{line: 783, col: 5, offset: 22942},
 						run: (*parser).callonTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 782, col: 5, offset: 22764},
+							pos: position{line: 783, col: 5, offset: 22942},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 782, col: 5, offset: 22764},
+									pos:        position{line: 783, col: 5, offset: 22942},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 12, offset: 22771},
+									pos:  position{line: 783, col: 12, offset: 22949},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 782, col: 15, offset: 22774},
+									pos:        position{line: 783, col: 15, offset: 22952},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 19, offset: 22778},
+									pos:  position{line: 783, col: 19, offset: 22956},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 782, col: 22, offset: 22781},
+									pos:   position{line: 783, col: 22, offset: 22959},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 26, offset: 22785},
+										pos:  position{line: 783, col: 26, offset: 22963},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 31, offset: 22790},
+									pos:  position{line: 783, col: 31, offset: 22968},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 782, col: 34, offset: 22793},
+									pos:        position{line: 783, col: 34, offset: 22971},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5430,43 +5457,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 783, col: 5, offset: 22820},
+						pos: position{line: 784, col: 5, offset: 22998},
 						run: (*parser).callonTypeExternal12,
 						expr: &seqExpr{
-							pos: position{line: 783, col: 5, offset: 22820},
+							pos: position{line: 784, col: 5, offset: 22998},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 783, col: 5, offset: 22820},
+									pos:        position{line: 784, col: 5, offset: 22998},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 12, offset: 22827},
+									pos:  position{line: 784, col: 12, offset: 23005},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 783, col: 15, offset: 22830},
+									pos:        position{line: 784, col: 15, offset: 23008},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 19, offset: 22834},
+									pos:  position{line: 784, col: 19, offset: 23012},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 783, col: 22, offset: 22837},
+									pos:   position{line: 784, col: 22, offset: 23015},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 783, col: 26, offset: 22841},
+										pos:  position{line: 784, col: 26, offset: 23019},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 36, offset: 22851},
+									pos:  position{line: 784, col: 36, offset: 23029},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 783, col: 39, offset: 22854},
+									pos:        position{line: 784, col: 39, offset: 23032},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5474,27 +5501,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 784, col: 5, offset: 22882},
+						pos:  position{line: 785, col: 5, offset: 23060},
 						name: "ComplexType",
 					},
 					&actionExpr{
-						pos: position{line: 785, col: 5, offset: 22898},
+						pos: position{line: 786, col: 5, offset: 23076},
 						run: (*parser).callonTypeExternal23,
 						expr: &seqExpr{
-							pos: position{line: 785, col: 5, offset: 22898},
+							pos: position{line: 786, col: 5, offset: 23076},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 785, col: 5, offset: 22898},
+									pos:   position{line: 786, col: 5, offset: 23076},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 9, offset: 22902},
+										pos:  position{line: 786, col: 9, offset: 23080},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 785, col: 31, offset: 22924},
+									pos: position{line: 786, col: 31, offset: 23102},
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 32, offset: 22925},
+										pos:  position{line: 786, col: 32, offset: 23103},
 										name: "IdentifierRest",
 									},
 								},
@@ -5506,16 +5533,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 787, col: 1, offset: 22961},
+			pos:  position{line: 788, col: 1, offset: 23139},
 			expr: &choiceExpr{
-				pos: position{line: 788, col: 5, offset: 22970},
+				pos: position{line: 789, col: 5, offset: 23148},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 788, col: 5, offset: 22970},
+						pos:  position{line: 789, col: 5, offset: 23148},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 789, col: 5, offset: 22988},
+						pos:  position{line: 790, col: 5, offset: 23166},
 						name: "ComplexType",
 					},
 				},
@@ -5523,77 +5550,77 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 791, col: 1, offset: 23001},
+			pos:  position{line: 792, col: 1, offset: 23179},
 			expr: &choiceExpr{
-				pos: position{line: 792, col: 5, offset: 23019},
+				pos: position{line: 793, col: 5, offset: 23197},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 792, col: 5, offset: 23019},
+						pos: position{line: 793, col: 5, offset: 23197},
 						run: (*parser).callonAmbiguousType2,
 						expr: &litMatcher{
-							pos:        position{line: 792, col: 5, offset: 23019},
+							pos:        position{line: 793, col: 5, offset: 23197},
 							val:        "null",
 							ignoreCase: false,
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 795, col: 5, offset: 23097},
+						pos:   position{line: 796, col: 5, offset: 23275},
 						label: "name",
 						expr: &ruleRefExpr{
-							pos:  position{line: 795, col: 10, offset: 23102},
+							pos:  position{line: 796, col: 10, offset: 23280},
 							name: "PrimitiveType",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 796, col: 5, offset: 23120},
+						pos: position{line: 797, col: 5, offset: 23298},
 						run: (*parser).callonAmbiguousType6,
 						expr: &seqExpr{
-							pos: position{line: 796, col: 5, offset: 23120},
+							pos: position{line: 797, col: 5, offset: 23298},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 796, col: 5, offset: 23120},
+									pos:   position{line: 797, col: 5, offset: 23298},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 796, col: 10, offset: 23125},
+										pos:  position{line: 797, col: 10, offset: 23303},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 796, col: 25, offset: 23140},
+									pos:  position{line: 797, col: 25, offset: 23318},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 796, col: 28, offset: 23143},
+									pos:        position{line: 797, col: 28, offset: 23321},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 796, col: 32, offset: 23147},
+									pos:  position{line: 797, col: 32, offset: 23325},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 796, col: 35, offset: 23150},
+									pos:        position{line: 797, col: 35, offset: 23328},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 796, col: 39, offset: 23154},
+									pos:  position{line: 797, col: 39, offset: 23332},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 796, col: 42, offset: 23157},
+									pos:   position{line: 797, col: 42, offset: 23335},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 796, col: 46, offset: 23161},
+										pos:  position{line: 797, col: 46, offset: 23339},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 796, col: 51, offset: 23166},
+									pos:  position{line: 797, col: 51, offset: 23344},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 796, col: 54, offset: 23169},
+									pos:        position{line: 797, col: 54, offset: 23347},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5601,42 +5628,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 799, col: 5, offset: 23268},
+						pos: position{line: 800, col: 5, offset: 23446},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 799, col: 5, offset: 23268},
+							pos:   position{line: 800, col: 5, offset: 23446},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 799, col: 10, offset: 23273},
+								pos:  position{line: 800, col: 10, offset: 23451},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 802, col: 5, offset: 23373},
+						pos: position{line: 803, col: 5, offset: 23551},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 802, col: 5, offset: 23373},
+							pos: position{line: 803, col: 5, offset: 23551},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 802, col: 5, offset: 23373},
+									pos:        position{line: 803, col: 5, offset: 23551},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 802, col: 9, offset: 23377},
+									pos:  position{line: 803, col: 9, offset: 23555},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 802, col: 12, offset: 23380},
+									pos:   position{line: 803, col: 12, offset: 23558},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 802, col: 14, offset: 23382},
+										pos:  position{line: 803, col: 14, offset: 23560},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 802, col: 25, offset: 23393},
+									pos:        position{line: 803, col: 25, offset: 23571},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5648,15 +5675,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 804, col: 1, offset: 23416},
+			pos:  position{line: 805, col: 1, offset: 23594},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 5, offset: 23430},
+				pos: position{line: 806, col: 5, offset: 23608},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 805, col: 5, offset: 23430},
+					pos:   position{line: 806, col: 5, offset: 23608},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 805, col: 11, offset: 23436},
+						pos:  position{line: 806, col: 11, offset: 23614},
 						name: "TypeList",
 					},
 				},
@@ -5664,28 +5691,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 809, col: 1, offset: 23530},
+			pos:  position{line: 810, col: 1, offset: 23708},
 			expr: &actionExpr{
-				pos: position{line: 810, col: 5, offset: 23543},
+				pos: position{line: 811, col: 5, offset: 23721},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 810, col: 5, offset: 23543},
+					pos: position{line: 811, col: 5, offset: 23721},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 810, col: 5, offset: 23543},
+							pos:   position{line: 811, col: 5, offset: 23721},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 810, col: 11, offset: 23549},
+								pos:  position{line: 811, col: 11, offset: 23727},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 810, col: 16, offset: 23554},
+							pos:   position{line: 811, col: 16, offset: 23732},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 810, col: 21, offset: 23559},
+								pos: position{line: 811, col: 21, offset: 23737},
 								expr: &ruleRefExpr{
-									pos:  position{line: 810, col: 21, offset: 23559},
+									pos:  position{line: 811, col: 21, offset: 23737},
 									name: "TypeListTail",
 								},
 							},
@@ -5696,31 +5723,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 814, col: 1, offset: 23653},
+			pos:  position{line: 815, col: 1, offset: 23831},
 			expr: &actionExpr{
-				pos: position{line: 814, col: 16, offset: 23668},
+				pos: position{line: 815, col: 16, offset: 23846},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 814, col: 16, offset: 23668},
+					pos: position{line: 815, col: 16, offset: 23846},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 814, col: 16, offset: 23668},
+							pos:  position{line: 815, col: 16, offset: 23846},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 814, col: 19, offset: 23671},
+							pos:        position{line: 815, col: 19, offset: 23849},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 814, col: 23, offset: 23675},
+							pos:  position{line: 815, col: 23, offset: 23853},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 814, col: 26, offset: 23678},
+							pos:   position{line: 815, col: 26, offset: 23856},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 814, col: 30, offset: 23682},
+								pos:  position{line: 815, col: 30, offset: 23860},
 								name: "Type",
 							},
 						},
@@ -5730,39 +5757,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 816, col: 1, offset: 23708},
+			pos:  position{line: 817, col: 1, offset: 23886},
 			expr: &choiceExpr{
-				pos: position{line: 817, col: 5, offset: 23724},
+				pos: position{line: 818, col: 5, offset: 23902},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 817, col: 5, offset: 23724},
+						pos: position{line: 818, col: 5, offset: 23902},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 817, col: 5, offset: 23724},
+							pos: position{line: 818, col: 5, offset: 23902},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 817, col: 5, offset: 23724},
+									pos:        position{line: 818, col: 5, offset: 23902},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 817, col: 9, offset: 23728},
+									pos:  position{line: 818, col: 9, offset: 23906},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 817, col: 12, offset: 23731},
+									pos:   position{line: 818, col: 12, offset: 23909},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 817, col: 19, offset: 23738},
+										pos:  position{line: 818, col: 19, offset: 23916},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 817, col: 33, offset: 23752},
+									pos:  position{line: 818, col: 33, offset: 23930},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 817, col: 36, offset: 23755},
+									pos:        position{line: 818, col: 36, offset: 23933},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5770,34 +5797,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 820, col: 5, offset: 23848},
+						pos: position{line: 821, col: 5, offset: 24026},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 820, col: 5, offset: 23848},
+							pos: position{line: 821, col: 5, offset: 24026},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 820, col: 5, offset: 23848},
+									pos:        position{line: 821, col: 5, offset: 24026},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 9, offset: 23852},
+									pos:  position{line: 821, col: 9, offset: 24030},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 820, col: 12, offset: 23855},
+									pos:   position{line: 821, col: 12, offset: 24033},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 820, col: 16, offset: 23859},
+										pos:  position{line: 821, col: 16, offset: 24037},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 21, offset: 23864},
+									pos:  position{line: 821, col: 21, offset: 24042},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 820, col: 24, offset: 23867},
+									pos:        position{line: 821, col: 24, offset: 24045},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5805,34 +5832,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 823, col: 5, offset: 23954},
+						pos: position{line: 824, col: 5, offset: 24132},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 823, col: 5, offset: 23954},
+							pos: position{line: 824, col: 5, offset: 24132},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 823, col: 5, offset: 23954},
+									pos:        position{line: 824, col: 5, offset: 24132},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 823, col: 10, offset: 23959},
+									pos:  position{line: 824, col: 10, offset: 24137},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 823, col: 13, offset: 23962},
+									pos:   position{line: 824, col: 13, offset: 24140},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 823, col: 17, offset: 23966},
+										pos:  position{line: 824, col: 17, offset: 24144},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 823, col: 22, offset: 23971},
+									pos:  position{line: 824, col: 22, offset: 24149},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 823, col: 25, offset: 23974},
+									pos:        position{line: 824, col: 25, offset: 24152},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -5840,55 +5867,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 826, col: 5, offset: 24060},
+						pos: position{line: 827, col: 5, offset: 24238},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 826, col: 5, offset: 24060},
+							pos: position{line: 827, col: 5, offset: 24238},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 826, col: 5, offset: 24060},
+									pos:        position{line: 827, col: 5, offset: 24238},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 826, col: 10, offset: 24065},
+									pos:  position{line: 827, col: 10, offset: 24243},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 826, col: 13, offset: 24068},
+									pos:   position{line: 827, col: 13, offset: 24246},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 826, col: 21, offset: 24076},
+										pos:  position{line: 827, col: 21, offset: 24254},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 826, col: 26, offset: 24081},
+									pos:  position{line: 827, col: 26, offset: 24259},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 826, col: 29, offset: 24084},
+									pos:        position{line: 827, col: 29, offset: 24262},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 826, col: 33, offset: 24088},
+									pos:  position{line: 827, col: 33, offset: 24266},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 826, col: 36, offset: 24091},
+									pos:   position{line: 827, col: 36, offset: 24269},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 826, col: 44, offset: 24099},
+										pos:  position{line: 827, col: 44, offset: 24277},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 826, col: 49, offset: 24104},
+									pos:  position{line: 827, col: 49, offset: 24282},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 826, col: 52, offset: 24107},
+									pos:        position{line: 827, col: 52, offset: 24285},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -5900,16 +5927,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 830, col: 1, offset: 24219},
+			pos:  position{line: 831, col: 1, offset: 24397},
 			expr: &choiceExpr{
-				pos: position{line: 831, col: 5, offset: 24237},
+				pos: position{line: 832, col: 5, offset: 24415},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 831, col: 5, offset: 24237},
+						pos:  position{line: 832, col: 5, offset: 24415},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 832, col: 5, offset: 24263},
+						pos:  position{line: 833, col: 5, offset: 24441},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -5917,65 +5944,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 838, col: 1, offset: 24522},
+			pos:  position{line: 839, col: 1, offset: 24700},
 			expr: &actionExpr{
-				pos: position{line: 839, col: 5, offset: 24548},
+				pos: position{line: 840, col: 5, offset: 24726},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 839, col: 9, offset: 24552},
+					pos: position{line: 840, col: 9, offset: 24730},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 839, col: 9, offset: 24552},
+							pos:        position{line: 840, col: 9, offset: 24730},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 839, col: 19, offset: 24562},
+							pos:        position{line: 840, col: 19, offset: 24740},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 839, col: 30, offset: 24573},
+							pos:        position{line: 840, col: 30, offset: 24751},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 839, col: 41, offset: 24584},
+							pos:        position{line: 840, col: 41, offset: 24762},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 9, offset: 24601},
+							pos:        position{line: 841, col: 9, offset: 24779},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 18, offset: 24610},
+							pos:        position{line: 841, col: 18, offset: 24788},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 28, offset: 24620},
+							pos:        position{line: 841, col: 28, offset: 24798},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 38, offset: 24630},
+							pos:        position{line: 841, col: 38, offset: 24808},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 9, offset: 24646},
+							pos:        position{line: 842, col: 9, offset: 24824},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 9, offset: 24664},
+							pos:        position{line: 843, col: 9, offset: 24842},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 18, offset: 24673},
+							pos:        position{line: 843, col: 18, offset: 24851},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -5985,50 +6012,50 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 851, col: 1, offset: 25155},
+			pos:  position{line: 852, col: 1, offset: 25333},
 			expr: &actionExpr{
-				pos: position{line: 852, col: 5, offset: 25181},
+				pos: position{line: 853, col: 5, offset: 25359},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 852, col: 9, offset: 25185},
+					pos: position{line: 853, col: 9, offset: 25363},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 852, col: 9, offset: 25185},
+							pos:        position{line: 853, col: 9, offset: 25363},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 852, col: 22, offset: 25198},
+							pos:        position{line: 853, col: 22, offset: 25376},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 853, col: 9, offset: 25213},
+							pos:        position{line: 854, col: 9, offset: 25391},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 854, col: 9, offset: 25229},
+							pos:        position{line: 855, col: 9, offset: 25407},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 855, col: 9, offset: 25247},
+							pos:        position{line: 856, col: 9, offset: 25425},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 855, col: 16, offset: 25254},
+							pos:        position{line: 856, col: 16, offset: 25432},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 9, offset: 25268},
+							pos:        position{line: 857, col: 9, offset: 25446},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 18, offset: 25277},
+							pos:        position{line: 857, col: 18, offset: 25455},
 							val:        "error",
 							ignoreCase: false,
 						},
@@ -6038,28 +6065,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 860, col: 1, offset: 25392},
+			pos:  position{line: 861, col: 1, offset: 25570},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 5, offset: 25410},
+				pos: position{line: 862, col: 5, offset: 25588},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 5, offset: 25410},
+					pos: position{line: 862, col: 5, offset: 25588},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 861, col: 5, offset: 25410},
+							pos:   position{line: 862, col: 5, offset: 25588},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 11, offset: 25416},
+								pos:  position{line: 862, col: 11, offset: 25594},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 21, offset: 25426},
+							pos:   position{line: 862, col: 21, offset: 25604},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 861, col: 26, offset: 25431},
+								pos: position{line: 862, col: 26, offset: 25609},
 								expr: &ruleRefExpr{
-									pos:  position{line: 861, col: 26, offset: 25431},
+									pos:  position{line: 862, col: 26, offset: 25609},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -6070,31 +6097,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 865, col: 1, offset: 25530},
+			pos:  position{line: 866, col: 1, offset: 25708},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 21, offset: 25550},
+				pos: position{line: 866, col: 21, offset: 25728},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 865, col: 21, offset: 25550},
+					pos: position{line: 866, col: 21, offset: 25728},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 21, offset: 25550},
+							pos:  position{line: 866, col: 21, offset: 25728},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 865, col: 24, offset: 25553},
+							pos:        position{line: 866, col: 24, offset: 25731},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 28, offset: 25557},
+							pos:  position{line: 866, col: 28, offset: 25735},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 31, offset: 25560},
+							pos:   position{line: 866, col: 31, offset: 25738},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 35, offset: 25564},
+								pos:  position{line: 866, col: 35, offset: 25742},
 								name: "TypeField",
 							},
 						},
@@ -6104,39 +6131,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 867, col: 1, offset: 25595},
+			pos:  position{line: 868, col: 1, offset: 25773},
 			expr: &actionExpr{
-				pos: position{line: 868, col: 5, offset: 25609},
+				pos: position{line: 869, col: 5, offset: 25787},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 868, col: 5, offset: 25609},
+					pos: position{line: 869, col: 5, offset: 25787},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 868, col: 5, offset: 25609},
+							pos:   position{line: 869, col: 5, offset: 25787},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 868, col: 10, offset: 25614},
+								pos:  position{line: 869, col: 10, offset: 25792},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 868, col: 25, offset: 25629},
+							pos:  position{line: 869, col: 25, offset: 25807},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 868, col: 28, offset: 25632},
+							pos:        position{line: 869, col: 28, offset: 25810},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 868, col: 32, offset: 25636},
+							pos:  position{line: 869, col: 32, offset: 25814},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 868, col: 35, offset: 25639},
+							pos:   position{line: 869, col: 35, offset: 25817},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 868, col: 39, offset: 25643},
+								pos:  position{line: 869, col: 39, offset: 25821},
 								name: "Type",
 							},
 						},
@@ -6146,16 +6173,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 872, col: 1, offset: 25725},
+			pos:  position{line: 873, col: 1, offset: 25903},
 			expr: &choiceExpr{
-				pos: position{line: 873, col: 5, offset: 25743},
+				pos: position{line: 874, col: 5, offset: 25921},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 873, col: 5, offset: 25743},
+						pos:  position{line: 874, col: 5, offset: 25921},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 873, col: 24, offset: 25762},
+						pos:  position{line: 874, col: 24, offset: 25940},
 						name: "RelativeOperator",
 					},
 				},
@@ -6163,12 +6190,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 875, col: 1, offset: 25780},
+			pos:  position{line: 876, col: 1, offset: 25958},
 			expr: &actionExpr{
-				pos: position{line: 875, col: 12, offset: 25791},
+				pos: position{line: 876, col: 12, offset: 25969},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 875, col: 12, offset: 25791},
+					pos:        position{line: 876, col: 12, offset: 25969},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -6176,12 +6203,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 877, col: 1, offset: 25821},
+			pos:  position{line: 878, col: 1, offset: 25999},
 			expr: &actionExpr{
-				pos: position{line: 877, col: 11, offset: 25831},
+				pos: position{line: 878, col: 11, offset: 26009},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 877, col: 11, offset: 25831},
+					pos:        position{line: 878, col: 11, offset: 26009},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -6189,12 +6216,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 879, col: 1, offset: 25859},
+			pos:  position{line: 880, col: 1, offset: 26037},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 11, offset: 25869},
+				pos: position{line: 880, col: 11, offset: 26047},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 879, col: 11, offset: 25869},
+					pos:        position{line: 880, col: 11, offset: 26047},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -6202,12 +6229,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 881, col: 1, offset: 25897},
+			pos:  position{line: 882, col: 1, offset: 26075},
 			expr: &actionExpr{
-				pos: position{line: 881, col: 12, offset: 25908},
+				pos: position{line: 882, col: 12, offset: 26086},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 881, col: 12, offset: 25908},
+					pos:        position{line: 882, col: 12, offset: 26086},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -6215,12 +6242,12 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 883, col: 1, offset: 25938},
+			pos:  position{line: 884, col: 1, offset: 26116},
 			expr: &actionExpr{
-				pos: position{line: 883, col: 11, offset: 25948},
+				pos: position{line: 884, col: 11, offset: 26126},
 				run: (*parser).callonByToken1,
 				expr: &litMatcher{
-					pos:        position{line: 883, col: 11, offset: 25948},
+					pos:        position{line: 884, col: 11, offset: 26126},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -6228,9 +6255,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 885, col: 1, offset: 25976},
+			pos:  position{line: 886, col: 1, offset: 26154},
 			expr: &charClassMatcher{
-				pos:        position{line: 885, col: 19, offset: 25994},
+				pos:        position{line: 886, col: 19, offset: 26172},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -6240,16 +6267,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 887, col: 1, offset: 26006},
+			pos:  position{line: 888, col: 1, offset: 26184},
 			expr: &choiceExpr{
-				pos: position{line: 887, col: 18, offset: 26023},
+				pos: position{line: 888, col: 18, offset: 26201},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 887, col: 18, offset: 26023},
+						pos:  position{line: 888, col: 18, offset: 26201},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 887, col: 36, offset: 26041},
+						pos:        position{line: 888, col: 36, offset: 26219},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -6260,15 +6287,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 889, col: 1, offset: 26048},
+			pos:  position{line: 890, col: 1, offset: 26226},
 			expr: &actionExpr{
-				pos: position{line: 890, col: 5, offset: 26063},
+				pos: position{line: 891, col: 5, offset: 26241},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 890, col: 5, offset: 26063},
+					pos:   position{line: 891, col: 5, offset: 26241},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 890, col: 8, offset: 26066},
+						pos:  position{line: 891, col: 8, offset: 26244},
 						name: "IdentifierName",
 					},
 				},
@@ -6276,29 +6303,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 892, col: 1, offset: 26153},
+			pos:  position{line: 893, col: 1, offset: 26331},
 			expr: &choiceExpr{
-				pos: position{line: 893, col: 5, offset: 26172},
+				pos: position{line: 894, col: 5, offset: 26350},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 893, col: 5, offset: 26172},
+						pos: position{line: 894, col: 5, offset: 26350},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 893, col: 5, offset: 26172},
+							pos: position{line: 894, col: 5, offset: 26350},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 893, col: 5, offset: 26172},
+									pos: position{line: 894, col: 5, offset: 26350},
 									expr: &seqExpr{
-										pos: position{line: 893, col: 7, offset: 26174},
+										pos: position{line: 894, col: 7, offset: 26352},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 7, offset: 26174},
+												pos:  position{line: 894, col: 7, offset: 26352},
 												name: "IdGuard",
 											},
 											&notExpr{
-												pos: position{line: 893, col: 15, offset: 26182},
+												pos: position{line: 894, col: 15, offset: 26360},
 												expr: &ruleRefExpr{
-													pos:  position{line: 893, col: 16, offset: 26183},
+													pos:  position{line: 894, col: 16, offset: 26361},
 													name: "IdentifierRest",
 												},
 											},
@@ -6306,13 +6333,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 893, col: 32, offset: 26199},
+									pos:  position{line: 894, col: 32, offset: 26377},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 893, col: 48, offset: 26215},
+									pos: position{line: 894, col: 48, offset: 26393},
 									expr: &ruleRefExpr{
-										pos:  position{line: 893, col: 48, offset: 26215},
+										pos:  position{line: 894, col: 48, offset: 26393},
 										name: "IdentifierRest",
 									},
 								},
@@ -6320,30 +6347,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 894, col: 5, offset: 26267},
+						pos: position{line: 895, col: 5, offset: 26445},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 894, col: 5, offset: 26267},
+							pos:        position{line: 895, col: 5, offset: 26445},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 895, col: 5, offset: 26306},
+						pos: position{line: 896, col: 5, offset: 26484},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 895, col: 5, offset: 26306},
+							pos: position{line: 896, col: 5, offset: 26484},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 895, col: 5, offset: 26306},
+									pos:        position{line: 896, col: 5, offset: 26484},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 895, col: 10, offset: 26311},
+									pos:   position{line: 896, col: 10, offset: 26489},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 895, col: 13, offset: 26314},
+										pos:  position{line: 896, col: 13, offset: 26492},
 										name: "IdGuard",
 									},
 								},
@@ -6351,10 +6378,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 897, col: 5, offset: 26405},
+						pos: position{line: 898, col: 5, offset: 26583},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 897, col: 5, offset: 26405},
+							pos:        position{line: 898, col: 5, offset: 26583},
 							val:        "type",
 							ignoreCase: false,
 						},
@@ -6364,24 +6391,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdGuard",
-			pos:  position{line: 900, col: 1, offset: 26445},
+			pos:  position{line: 901, col: 1, offset: 26623},
 			expr: &choiceExpr{
-				pos: position{line: 901, col: 5, offset: 26457},
+				pos: position{line: 902, col: 5, offset: 26635},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 901, col: 5, offset: 26457},
+						pos:  position{line: 902, col: 5, offset: 26635},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 902, col: 5, offset: 26476},
+						pos:  position{line: 903, col: 5, offset: 26654},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 903, col: 5, offset: 26492},
+						pos:  position{line: 904, col: 5, offset: 26670},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 904, col: 5, offset: 26509},
+						pos:  position{line: 905, col: 5, offset: 26687},
 						name: "SearchGuard",
 					},
 				},
@@ -6389,54 +6416,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 906, col: 1, offset: 26522},
+			pos:  position{line: 907, col: 1, offset: 26700},
 			expr: &choiceExpr{
-				pos: position{line: 907, col: 5, offset: 26535},
+				pos: position{line: 908, col: 5, offset: 26713},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 907, col: 5, offset: 26535},
+						pos:  position{line: 908, col: 5, offset: 26713},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 908, col: 5, offset: 26547},
+						pos:  position{line: 909, col: 5, offset: 26725},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 909, col: 5, offset: 26559},
+						pos:  position{line: 910, col: 5, offset: 26737},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 910, col: 5, offset: 26569},
+						pos: position{line: 911, col: 5, offset: 26747},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 910, col: 5, offset: 26569},
+								pos:  position{line: 911, col: 5, offset: 26747},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 910, col: 11, offset: 26575},
+								pos:  position{line: 911, col: 11, offset: 26753},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 910, col: 13, offset: 26577},
+								pos:        position{line: 911, col: 13, offset: 26755},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 910, col: 19, offset: 26583},
+								pos:  position{line: 911, col: 19, offset: 26761},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 910, col: 21, offset: 26585},
+								pos:  position{line: 911, col: 21, offset: 26763},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 911, col: 5, offset: 26597},
+						pos:  position{line: 912, col: 5, offset: 26775},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 912, col: 5, offset: 26606},
+						pos:  position{line: 913, col: 5, offset: 26784},
 						name: "Weeks",
 					},
 				},
@@ -6444,32 +6471,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 914, col: 1, offset: 26613},
+			pos:  position{line: 915, col: 1, offset: 26791},
 			expr: &choiceExpr{
-				pos: position{line: 915, col: 5, offset: 26630},
+				pos: position{line: 916, col: 5, offset: 26808},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 915, col: 5, offset: 26630},
+						pos:        position{line: 916, col: 5, offset: 26808},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 916, col: 5, offset: 26644},
+						pos:        position{line: 917, col: 5, offset: 26822},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 917, col: 5, offset: 26657},
+						pos:        position{line: 918, col: 5, offset: 26835},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 918, col: 5, offset: 26668},
+						pos:        position{line: 919, col: 5, offset: 26846},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 919, col: 5, offset: 26678},
+						pos:        position{line: 920, col: 5, offset: 26856},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -6478,32 +6505,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 921, col: 1, offset: 26683},
+			pos:  position{line: 922, col: 1, offset: 26861},
 			expr: &choiceExpr{
-				pos: position{line: 922, col: 5, offset: 26700},
+				pos: position{line: 923, col: 5, offset: 26878},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 922, col: 5, offset: 26700},
+						pos:        position{line: 923, col: 5, offset: 26878},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 923, col: 5, offset: 26714},
+						pos:        position{line: 924, col: 5, offset: 26892},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 924, col: 5, offset: 26727},
+						pos:        position{line: 925, col: 5, offset: 26905},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 925, col: 5, offset: 26738},
+						pos:        position{line: 926, col: 5, offset: 26916},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 926, col: 5, offset: 26748},
+						pos:        position{line: 927, col: 5, offset: 26926},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -6512,32 +6539,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 928, col: 1, offset: 26753},
+			pos:  position{line: 929, col: 1, offset: 26931},
 			expr: &choiceExpr{
-				pos: position{line: 929, col: 5, offset: 26768},
+				pos: position{line: 930, col: 5, offset: 26946},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 929, col: 5, offset: 26768},
+						pos:        position{line: 930, col: 5, offset: 26946},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 930, col: 5, offset: 26780},
+						pos:        position{line: 931, col: 5, offset: 26958},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 931, col: 5, offset: 26790},
+						pos:        position{line: 932, col: 5, offset: 26968},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 932, col: 5, offset: 26799},
+						pos:        position{line: 933, col: 5, offset: 26977},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 933, col: 5, offset: 26807},
+						pos:        position{line: 934, col: 5, offset: 26985},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -6546,22 +6573,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 935, col: 1, offset: 26815},
+			pos:  position{line: 936, col: 1, offset: 26993},
 			expr: &choiceExpr{
-				pos: position{line: 935, col: 13, offset: 26827},
+				pos: position{line: 936, col: 13, offset: 27005},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 935, col: 13, offset: 26827},
+						pos:        position{line: 936, col: 13, offset: 27005},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 935, col: 20, offset: 26834},
+						pos:        position{line: 936, col: 20, offset: 27012},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 935, col: 26, offset: 26840},
+						pos:        position{line: 936, col: 26, offset: 27018},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -6570,32 +6597,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 937, col: 1, offset: 26845},
+			pos:  position{line: 938, col: 1, offset: 27023},
 			expr: &choiceExpr{
-				pos: position{line: 937, col: 14, offset: 26858},
+				pos: position{line: 938, col: 14, offset: 27036},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 937, col: 14, offset: 26858},
+						pos:        position{line: 938, col: 14, offset: 27036},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 937, col: 22, offset: 26866},
+						pos:        position{line: 938, col: 22, offset: 27044},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 937, col: 29, offset: 26873},
+						pos:        position{line: 938, col: 29, offset: 27051},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 937, col: 35, offset: 26879},
+						pos:        position{line: 938, col: 35, offset: 27057},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 937, col: 40, offset: 26884},
+						pos:        position{line: 938, col: 40, offset: 27062},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -6604,39 +6631,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 939, col: 1, offset: 26889},
+			pos:  position{line: 940, col: 1, offset: 27067},
 			expr: &choiceExpr{
-				pos: position{line: 940, col: 5, offset: 26901},
+				pos: position{line: 941, col: 5, offset: 27079},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 940, col: 5, offset: 26901},
+						pos: position{line: 941, col: 5, offset: 27079},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 940, col: 5, offset: 26901},
+							pos:        position{line: 941, col: 5, offset: 27079},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 941, col: 5, offset: 26987},
+						pos: position{line: 942, col: 5, offset: 27165},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 941, col: 5, offset: 26987},
+							pos: position{line: 942, col: 5, offset: 27165},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 941, col: 5, offset: 26987},
+									pos:   position{line: 942, col: 5, offset: 27165},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 941, col: 9, offset: 26991},
+										pos:  position{line: 942, col: 9, offset: 27169},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 941, col: 14, offset: 26996},
+									pos:  position{line: 942, col: 14, offset: 27174},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 941, col: 17, offset: 26999},
+									pos:  position{line: 942, col: 17, offset: 27177},
 									name: "SecondsToken",
 								},
 							},
@@ -6647,39 +6674,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 943, col: 1, offset: 27088},
+			pos:  position{line: 944, col: 1, offset: 27266},
 			expr: &choiceExpr{
-				pos: position{line: 944, col: 5, offset: 27100},
+				pos: position{line: 945, col: 5, offset: 27278},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 944, col: 5, offset: 27100},
+						pos: position{line: 945, col: 5, offset: 27278},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 944, col: 5, offset: 27100},
+							pos:        position{line: 945, col: 5, offset: 27278},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 945, col: 5, offset: 27187},
+						pos: position{line: 946, col: 5, offset: 27365},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 945, col: 5, offset: 27187},
+							pos: position{line: 946, col: 5, offset: 27365},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 945, col: 5, offset: 27187},
+									pos:   position{line: 946, col: 5, offset: 27365},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 9, offset: 27191},
+										pos:  position{line: 946, col: 9, offset: 27369},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 14, offset: 27196},
+									pos:  position{line: 946, col: 14, offset: 27374},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 17, offset: 27199},
+									pos:  position{line: 946, col: 17, offset: 27377},
 									name: "MinutesToken",
 								},
 							},
@@ -6690,39 +6717,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 947, col: 1, offset: 27297},
+			pos:  position{line: 948, col: 1, offset: 27475},
 			expr: &choiceExpr{
-				pos: position{line: 948, col: 5, offset: 27307},
+				pos: position{line: 949, col: 5, offset: 27485},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 948, col: 5, offset: 27307},
+						pos: position{line: 949, col: 5, offset: 27485},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 948, col: 5, offset: 27307},
+							pos:        position{line: 949, col: 5, offset: 27485},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 949, col: 5, offset: 27394},
+						pos: position{line: 950, col: 5, offset: 27572},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 949, col: 5, offset: 27394},
+							pos: position{line: 950, col: 5, offset: 27572},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 949, col: 5, offset: 27394},
+									pos:   position{line: 950, col: 5, offset: 27572},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 949, col: 9, offset: 27398},
+										pos:  position{line: 950, col: 9, offset: 27576},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 949, col: 14, offset: 27403},
+									pos:  position{line: 950, col: 14, offset: 27581},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 949, col: 17, offset: 27406},
+									pos:  position{line: 950, col: 17, offset: 27584},
 									name: "HoursToken",
 								},
 							},
@@ -6733,39 +6760,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 951, col: 1, offset: 27504},
+			pos:  position{line: 952, col: 1, offset: 27682},
 			expr: &choiceExpr{
-				pos: position{line: 952, col: 5, offset: 27513},
+				pos: position{line: 953, col: 5, offset: 27691},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 952, col: 5, offset: 27513},
+						pos: position{line: 953, col: 5, offset: 27691},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 952, col: 5, offset: 27513},
+							pos:        position{line: 953, col: 5, offset: 27691},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 953, col: 5, offset: 27602},
+						pos: position{line: 954, col: 5, offset: 27780},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 953, col: 5, offset: 27602},
+							pos: position{line: 954, col: 5, offset: 27780},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 953, col: 5, offset: 27602},
+									pos:   position{line: 954, col: 5, offset: 27780},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 953, col: 9, offset: 27606},
+										pos:  position{line: 954, col: 9, offset: 27784},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 14, offset: 27611},
+									pos:  position{line: 954, col: 14, offset: 27789},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 17, offset: 27614},
+									pos:  position{line: 954, col: 17, offset: 27792},
 									name: "DaysToken",
 								},
 							},
@@ -6776,39 +6803,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 955, col: 1, offset: 27716},
+			pos:  position{line: 956, col: 1, offset: 27894},
 			expr: &choiceExpr{
-				pos: position{line: 956, col: 5, offset: 27726},
+				pos: position{line: 957, col: 5, offset: 27904},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 956, col: 5, offset: 27726},
+						pos: position{line: 957, col: 5, offset: 27904},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 956, col: 5, offset: 27726},
+							pos:        position{line: 957, col: 5, offset: 27904},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 957, col: 5, offset: 27818},
+						pos: position{line: 958, col: 5, offset: 27996},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 957, col: 5, offset: 27818},
+							pos: position{line: 958, col: 5, offset: 27996},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 957, col: 5, offset: 27818},
+									pos:   position{line: 958, col: 5, offset: 27996},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 957, col: 9, offset: 27822},
+										pos:  position{line: 958, col: 9, offset: 28000},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 957, col: 14, offset: 27827},
+									pos:  position{line: 958, col: 14, offset: 28005},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 957, col: 17, offset: 27830},
+									pos:  position{line: 958, col: 17, offset: 28008},
 									name: "WeeksToken",
 								},
 							},
@@ -6819,42 +6846,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 960, col: 1, offset: 27961},
+			pos:  position{line: 961, col: 1, offset: 28139},
 			expr: &actionExpr{
-				pos: position{line: 961, col: 5, offset: 27968},
+				pos: position{line: 962, col: 5, offset: 28146},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 961, col: 5, offset: 27968},
+					pos: position{line: 962, col: 5, offset: 28146},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 961, col: 5, offset: 27968},
+							pos:  position{line: 962, col: 5, offset: 28146},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 961, col: 10, offset: 27973},
+							pos:        position{line: 962, col: 10, offset: 28151},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 961, col: 14, offset: 27977},
+							pos:  position{line: 962, col: 14, offset: 28155},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 961, col: 19, offset: 27982},
+							pos:        position{line: 962, col: 19, offset: 28160},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 961, col: 23, offset: 27986},
+							pos:  position{line: 962, col: 23, offset: 28164},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 961, col: 28, offset: 27991},
+							pos:        position{line: 962, col: 28, offset: 28169},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 961, col: 32, offset: 27995},
+							pos:  position{line: 962, col: 32, offset: 28173},
 							name: "UInt",
 						},
 					},
@@ -6863,42 +6890,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 963, col: 1, offset: 28032},
+			pos:  position{line: 964, col: 1, offset: 28210},
 			expr: &actionExpr{
-				pos: position{line: 964, col: 5, offset: 28040},
+				pos: position{line: 965, col: 5, offset: 28218},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 964, col: 5, offset: 28040},
+					pos: position{line: 965, col: 5, offset: 28218},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 964, col: 5, offset: 28040},
+							pos: position{line: 965, col: 5, offset: 28218},
 							expr: &seqExpr{
-								pos: position{line: 964, col: 8, offset: 28043},
+								pos: position{line: 965, col: 8, offset: 28221},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 964, col: 8, offset: 28043},
+										pos:  position{line: 965, col: 8, offset: 28221},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 964, col: 12, offset: 28047},
+										pos:        position{line: 965, col: 12, offset: 28225},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 964, col: 16, offset: 28051},
+										pos:  position{line: 965, col: 16, offset: 28229},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 964, col: 20, offset: 28055},
+										pos: position{line: 965, col: 20, offset: 28233},
 										expr: &choiceExpr{
-											pos: position{line: 964, col: 22, offset: 28057},
+											pos: position{line: 965, col: 22, offset: 28235},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 964, col: 22, offset: 28057},
+													pos:  position{line: 965, col: 22, offset: 28235},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 964, col: 33, offset: 28068},
+													pos:        position{line: 965, col: 33, offset: 28246},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -6909,10 +6936,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 964, col: 39, offset: 28074},
+							pos:   position{line: 965, col: 39, offset: 28252},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 964, col: 41, offset: 28076},
+								pos:  position{line: 965, col: 41, offset: 28254},
 								name: "IP6Variations",
 							},
 						},
@@ -6922,32 +6949,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 968, col: 1, offset: 28240},
+			pos:  position{line: 969, col: 1, offset: 28418},
 			expr: &choiceExpr{
-				pos: position{line: 969, col: 5, offset: 28258},
+				pos: position{line: 970, col: 5, offset: 28436},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 969, col: 5, offset: 28258},
+						pos: position{line: 970, col: 5, offset: 28436},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 969, col: 5, offset: 28258},
+							pos: position{line: 970, col: 5, offset: 28436},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 969, col: 5, offset: 28258},
+									pos:   position{line: 970, col: 5, offset: 28436},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 969, col: 7, offset: 28260},
+										pos: position{line: 970, col: 7, offset: 28438},
 										expr: &ruleRefExpr{
-											pos:  position{line: 969, col: 7, offset: 28260},
+											pos:  position{line: 970, col: 7, offset: 28438},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 969, col: 17, offset: 28270},
+									pos:   position{line: 970, col: 17, offset: 28448},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 969, col: 19, offset: 28272},
+										pos:  position{line: 970, col: 19, offset: 28450},
 										name: "IP6Tail",
 									},
 								},
@@ -6955,51 +6982,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 972, col: 5, offset: 28336},
+						pos: position{line: 973, col: 5, offset: 28514},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 972, col: 5, offset: 28336},
+							pos: position{line: 973, col: 5, offset: 28514},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 972, col: 5, offset: 28336},
+									pos:   position{line: 973, col: 5, offset: 28514},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 972, col: 7, offset: 28338},
+										pos:  position{line: 973, col: 7, offset: 28516},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 972, col: 11, offset: 28342},
+									pos:   position{line: 973, col: 11, offset: 28520},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 972, col: 13, offset: 28344},
+										pos: position{line: 973, col: 13, offset: 28522},
 										expr: &ruleRefExpr{
-											pos:  position{line: 972, col: 13, offset: 28344},
+											pos:  position{line: 973, col: 13, offset: 28522},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 972, col: 23, offset: 28354},
+									pos:        position{line: 973, col: 23, offset: 28532},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 972, col: 28, offset: 28359},
+									pos:   position{line: 973, col: 28, offset: 28537},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 972, col: 30, offset: 28361},
+										pos: position{line: 973, col: 30, offset: 28539},
 										expr: &ruleRefExpr{
-											pos:  position{line: 972, col: 30, offset: 28361},
+											pos:  position{line: 973, col: 30, offset: 28539},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 972, col: 40, offset: 28371},
+									pos:   position{line: 973, col: 40, offset: 28549},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 972, col: 42, offset: 28373},
+										pos:  position{line: 973, col: 42, offset: 28551},
 										name: "IP6Tail",
 									},
 								},
@@ -7007,32 +7034,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 975, col: 5, offset: 28472},
+						pos: position{line: 976, col: 5, offset: 28650},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 975, col: 5, offset: 28472},
+							pos: position{line: 976, col: 5, offset: 28650},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 975, col: 5, offset: 28472},
+									pos:        position{line: 976, col: 5, offset: 28650},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 975, col: 10, offset: 28477},
+									pos:   position{line: 976, col: 10, offset: 28655},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 975, col: 12, offset: 28479},
+										pos: position{line: 976, col: 12, offset: 28657},
 										expr: &ruleRefExpr{
-											pos:  position{line: 975, col: 12, offset: 28479},
+											pos:  position{line: 976, col: 12, offset: 28657},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 975, col: 22, offset: 28489},
+									pos:   position{line: 976, col: 22, offset: 28667},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 975, col: 24, offset: 28491},
+										pos:  position{line: 976, col: 24, offset: 28669},
 										name: "IP6Tail",
 									},
 								},
@@ -7040,32 +7067,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 28562},
+						pos: position{line: 979, col: 5, offset: 28740},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 978, col: 5, offset: 28562},
+							pos: position{line: 979, col: 5, offset: 28740},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 978, col: 5, offset: 28562},
+									pos:   position{line: 979, col: 5, offset: 28740},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 7, offset: 28564},
+										pos:  position{line: 979, col: 7, offset: 28742},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 11, offset: 28568},
+									pos:   position{line: 979, col: 11, offset: 28746},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 978, col: 13, offset: 28570},
+										pos: position{line: 979, col: 13, offset: 28748},
 										expr: &ruleRefExpr{
-											pos:  position{line: 978, col: 13, offset: 28570},
+											pos:  position{line: 979, col: 13, offset: 28748},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 978, col: 23, offset: 28580},
+									pos:        position{line: 979, col: 23, offset: 28758},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -7073,10 +7100,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 981, col: 5, offset: 28648},
+						pos: position{line: 982, col: 5, offset: 28826},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 981, col: 5, offset: 28648},
+							pos:        position{line: 982, col: 5, offset: 28826},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -7086,16 +7113,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 985, col: 1, offset: 28685},
+			pos:  position{line: 986, col: 1, offset: 28863},
 			expr: &choiceExpr{
-				pos: position{line: 986, col: 5, offset: 28697},
+				pos: position{line: 987, col: 5, offset: 28875},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 986, col: 5, offset: 28697},
+						pos:  position{line: 987, col: 5, offset: 28875},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 987, col: 5, offset: 28704},
+						pos:  position{line: 988, col: 5, offset: 28882},
 						name: "Hex",
 					},
 				},
@@ -7103,23 +7130,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 989, col: 1, offset: 28709},
+			pos:  position{line: 990, col: 1, offset: 28887},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 12, offset: 28720},
+				pos: position{line: 990, col: 12, offset: 28898},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 989, col: 12, offset: 28720},
+					pos: position{line: 990, col: 12, offset: 28898},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 989, col: 12, offset: 28720},
+							pos:        position{line: 990, col: 12, offset: 28898},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 989, col: 16, offset: 28724},
+							pos:   position{line: 990, col: 16, offset: 28902},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 989, col: 18, offset: 28726},
+								pos:  position{line: 990, col: 18, offset: 28904},
 								name: "Hex",
 							},
 						},
@@ -7129,23 +7156,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 991, col: 1, offset: 28764},
+			pos:  position{line: 992, col: 1, offset: 28942},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 12, offset: 28775},
+				pos: position{line: 992, col: 12, offset: 28953},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 991, col: 12, offset: 28775},
+					pos: position{line: 992, col: 12, offset: 28953},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 991, col: 12, offset: 28775},
+							pos:   position{line: 992, col: 12, offset: 28953},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 991, col: 14, offset: 28777},
+								pos:  position{line: 992, col: 14, offset: 28955},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 991, col: 18, offset: 28781},
+							pos:        position{line: 992, col: 18, offset: 28959},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -7155,31 +7182,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 993, col: 1, offset: 28819},
+			pos:  position{line: 994, col: 1, offset: 28997},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 5, offset: 28830},
+				pos: position{line: 995, col: 5, offset: 29008},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 994, col: 5, offset: 28830},
+					pos: position{line: 995, col: 5, offset: 29008},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 994, col: 5, offset: 28830},
+							pos:   position{line: 995, col: 5, offset: 29008},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 7, offset: 28832},
+								pos:  position{line: 995, col: 7, offset: 29010},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 994, col: 10, offset: 28835},
+							pos:        position{line: 995, col: 10, offset: 29013},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 994, col: 14, offset: 28839},
+							pos:   position{line: 995, col: 14, offset: 29017},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 16, offset: 28841},
+								pos:  position{line: 995, col: 16, offset: 29019},
 								name: "UInt",
 							},
 						},
@@ -7189,31 +7216,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 998, col: 1, offset: 28914},
+			pos:  position{line: 999, col: 1, offset: 29092},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 5, offset: 28925},
+				pos: position{line: 1000, col: 5, offset: 29103},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 999, col: 5, offset: 28925},
+					pos: position{line: 1000, col: 5, offset: 29103},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 999, col: 5, offset: 28925},
+							pos:   position{line: 1000, col: 5, offset: 29103},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 7, offset: 28927},
+								pos:  position{line: 1000, col: 7, offset: 29105},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 999, col: 11, offset: 28931},
+							pos:        position{line: 1000, col: 11, offset: 29109},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 999, col: 15, offset: 28935},
+							pos:   position{line: 1000, col: 15, offset: 29113},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 17, offset: 28937},
+								pos:  position{line: 1000, col: 17, offset: 29115},
 								name: "UInt",
 							},
 						},
@@ -7223,15 +7250,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1003, col: 1, offset: 29000},
+			pos:  position{line: 1004, col: 1, offset: 29178},
 			expr: &actionExpr{
-				pos: position{line: 1004, col: 4, offset: 29008},
+				pos: position{line: 1005, col: 4, offset: 29186},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1004, col: 4, offset: 29008},
+					pos:   position{line: 1005, col: 4, offset: 29186},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1004, col: 6, offset: 29010},
+						pos:  position{line: 1005, col: 6, offset: 29188},
 						name: "UIntString",
 					},
 				},
@@ -7239,16 +7266,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1006, col: 1, offset: 29050},
+			pos:  position{line: 1007, col: 1, offset: 29228},
 			expr: &choiceExpr{
-				pos: position{line: 1007, col: 5, offset: 29064},
+				pos: position{line: 1008, col: 5, offset: 29242},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 29064},
+						pos:  position{line: 1008, col: 5, offset: 29242},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 29079},
+						pos:  position{line: 1009, col: 5, offset: 29257},
 						name: "MinusIntString",
 					},
 				},
@@ -7256,14 +7283,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1010, col: 1, offset: 29095},
+			pos:  position{line: 1011, col: 1, offset: 29273},
 			expr: &actionExpr{
-				pos: position{line: 1010, col: 14, offset: 29108},
+				pos: position{line: 1011, col: 14, offset: 29286},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1010, col: 14, offset: 29108},
+					pos: position{line: 1011, col: 14, offset: 29286},
 					expr: &charClassMatcher{
-						pos:        position{line: 1010, col: 14, offset: 29108},
+						pos:        position{line: 1011, col: 14, offset: 29286},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7274,20 +7301,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1012, col: 1, offset: 29147},
+			pos:  position{line: 1013, col: 1, offset: 29325},
 			expr: &actionExpr{
-				pos: position{line: 1013, col: 5, offset: 29166},
+				pos: position{line: 1014, col: 5, offset: 29344},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1013, col: 5, offset: 29166},
+					pos: position{line: 1014, col: 5, offset: 29344},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1013, col: 5, offset: 29166},
+							pos:        position{line: 1014, col: 5, offset: 29344},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1013, col: 9, offset: 29170},
+							pos:  position{line: 1014, col: 9, offset: 29348},
 							name: "UIntString",
 						},
 					},
@@ -7296,28 +7323,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1015, col: 1, offset: 29213},
+			pos:  position{line: 1016, col: 1, offset: 29391},
 			expr: &choiceExpr{
-				pos: position{line: 1016, col: 5, offset: 29229},
+				pos: position{line: 1017, col: 5, offset: 29407},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 29229},
+						pos: position{line: 1017, col: 5, offset: 29407},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1016, col: 5, offset: 29229},
+							pos: position{line: 1017, col: 5, offset: 29407},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1016, col: 5, offset: 29229},
+									pos: position{line: 1017, col: 5, offset: 29407},
 									expr: &litMatcher{
-										pos:        position{line: 1016, col: 5, offset: 29229},
+										pos:        position{line: 1017, col: 5, offset: 29407},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1016, col: 10, offset: 29234},
+									pos: position{line: 1017, col: 10, offset: 29412},
 									expr: &charClassMatcher{
-										pos:        position{line: 1016, col: 10, offset: 29234},
+										pos:        position{line: 1017, col: 10, offset: 29412},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7325,14 +7352,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1016, col: 17, offset: 29241},
+									pos:        position{line: 1017, col: 17, offset: 29419},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1016, col: 21, offset: 29245},
+									pos: position{line: 1017, col: 21, offset: 29423},
 									expr: &charClassMatcher{
-										pos:        position{line: 1016, col: 21, offset: 29245},
+										pos:        position{line: 1017, col: 21, offset: 29423},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7340,9 +7367,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1016, col: 28, offset: 29252},
+									pos: position{line: 1017, col: 28, offset: 29430},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1016, col: 28, offset: 29252},
+										pos:  position{line: 1017, col: 28, offset: 29430},
 										name: "ExponentPart",
 									},
 								},
@@ -7350,28 +7377,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 29311},
+						pos: position{line: 1020, col: 5, offset: 29489},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 29311},
+							pos: position{line: 1020, col: 5, offset: 29489},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1019, col: 5, offset: 29311},
+									pos: position{line: 1020, col: 5, offset: 29489},
 									expr: &litMatcher{
-										pos:        position{line: 1019, col: 5, offset: 29311},
+										pos:        position{line: 1020, col: 5, offset: 29489},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 10, offset: 29316},
+									pos:        position{line: 1020, col: 10, offset: 29494},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1019, col: 14, offset: 29320},
+									pos: position{line: 1020, col: 14, offset: 29498},
 									expr: &charClassMatcher{
-										pos:        position{line: 1019, col: 14, offset: 29320},
+										pos:        position{line: 1020, col: 14, offset: 29498},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7379,9 +7406,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1019, col: 21, offset: 29327},
+									pos: position{line: 1020, col: 21, offset: 29505},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 21, offset: 29327},
+										pos:  position{line: 1020, col: 21, offset: 29505},
 										name: "ExponentPart",
 									},
 								},
@@ -7393,19 +7420,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1023, col: 1, offset: 29383},
+			pos:  position{line: 1024, col: 1, offset: 29561},
 			expr: &seqExpr{
-				pos: position{line: 1023, col: 16, offset: 29398},
+				pos: position{line: 1024, col: 16, offset: 29576},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1023, col: 16, offset: 29398},
+						pos:        position{line: 1024, col: 16, offset: 29576},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1023, col: 21, offset: 29403},
+						pos: position{line: 1024, col: 21, offset: 29581},
 						expr: &charClassMatcher{
-							pos:        position{line: 1023, col: 21, offset: 29403},
+							pos:        position{line: 1024, col: 21, offset: 29581},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -7413,7 +7440,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1023, col: 27, offset: 29409},
+						pos:  position{line: 1024, col: 27, offset: 29587},
 						name: "UIntString",
 					},
 				},
@@ -7421,14 +7448,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1025, col: 1, offset: 29421},
+			pos:  position{line: 1026, col: 1, offset: 29599},
 			expr: &actionExpr{
-				pos: position{line: 1025, col: 7, offset: 29427},
+				pos: position{line: 1026, col: 7, offset: 29605},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1025, col: 7, offset: 29427},
+					pos: position{line: 1026, col: 7, offset: 29605},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1025, col: 7, offset: 29427},
+						pos:  position{line: 1026, col: 7, offset: 29605},
 						name: "HexDigit",
 					},
 				},
@@ -7436,9 +7463,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1027, col: 1, offset: 29469},
+			pos:  position{line: 1028, col: 1, offset: 29647},
 			expr: &charClassMatcher{
-				pos:        position{line: 1027, col: 12, offset: 29480},
+				pos:        position{line: 1028, col: 12, offset: 29658},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -7447,34 +7474,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1030, col: 1, offset: 29494},
+			pos:  position{line: 1031, col: 1, offset: 29672},
 			expr: &choiceExpr{
-				pos: position{line: 1031, col: 5, offset: 29511},
+				pos: position{line: 1032, col: 5, offset: 29689},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 29511},
+						pos: position{line: 1032, col: 5, offset: 29689},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1031, col: 5, offset: 29511},
+							pos: position{line: 1032, col: 5, offset: 29689},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1031, col: 5, offset: 29511},
+									pos:        position{line: 1032, col: 5, offset: 29689},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1031, col: 9, offset: 29515},
+									pos:   position{line: 1032, col: 9, offset: 29693},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1031, col: 11, offset: 29517},
+										pos: position{line: 1032, col: 11, offset: 29695},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1031, col: 11, offset: 29517},
+											pos:  position{line: 1032, col: 11, offset: 29695},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1031, col: 29, offset: 29535},
+									pos:        position{line: 1032, col: 29, offset: 29713},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -7482,29 +7509,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 29572},
+						pos: position{line: 1033, col: 5, offset: 29750},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1032, col: 5, offset: 29572},
+							pos: position{line: 1033, col: 5, offset: 29750},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1032, col: 5, offset: 29572},
+									pos:        position{line: 1033, col: 5, offset: 29750},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1032, col: 9, offset: 29576},
+									pos:   position{line: 1033, col: 9, offset: 29754},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1032, col: 11, offset: 29578},
+										pos: position{line: 1033, col: 11, offset: 29756},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1032, col: 11, offset: 29578},
+											pos:  position{line: 1033, col: 11, offset: 29756},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 29, offset: 29596},
+									pos:        position{line: 1033, col: 29, offset: 29774},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -7516,55 +7543,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1034, col: 1, offset: 29630},
+			pos:  position{line: 1035, col: 1, offset: 29808},
 			expr: &choiceExpr{
-				pos: position{line: 1035, col: 5, offset: 29651},
+				pos: position{line: 1036, col: 5, offset: 29829},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 29651},
+						pos: position{line: 1036, col: 5, offset: 29829},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1035, col: 5, offset: 29651},
+							pos: position{line: 1036, col: 5, offset: 29829},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1035, col: 5, offset: 29651},
+									pos: position{line: 1036, col: 5, offset: 29829},
 									expr: &choiceExpr{
-										pos: position{line: 1035, col: 7, offset: 29653},
+										pos: position{line: 1036, col: 7, offset: 29831},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1035, col: 7, offset: 29653},
+												pos:        position{line: 1036, col: 7, offset: 29831},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1035, col: 13, offset: 29659},
+												pos:  position{line: 1036, col: 13, offset: 29837},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1035, col: 26, offset: 29672,
+									line: 1036, col: 26, offset: 29850,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 29709},
+						pos: position{line: 1037, col: 5, offset: 29887},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1036, col: 5, offset: 29709},
+							pos: position{line: 1037, col: 5, offset: 29887},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1036, col: 5, offset: 29709},
+									pos:        position{line: 1037, col: 5, offset: 29887},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1036, col: 10, offset: 29714},
+									pos:   position{line: 1037, col: 10, offset: 29892},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1036, col: 12, offset: 29716},
+										pos:  position{line: 1037, col: 12, offset: 29894},
 										name: "EscapeSequence",
 									},
 								},
@@ -7576,28 +7603,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1038, col: 1, offset: 29750},
+			pos:  position{line: 1039, col: 1, offset: 29928},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 5, offset: 29762},
+				pos: position{line: 1040, col: 5, offset: 29940},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1039, col: 5, offset: 29762},
+					pos: position{line: 1040, col: 5, offset: 29940},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1039, col: 5, offset: 29762},
+							pos:   position{line: 1040, col: 5, offset: 29940},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1039, col: 10, offset: 29767},
+								pos:  position{line: 1040, col: 10, offset: 29945},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1039, col: 23, offset: 29780},
+							pos:   position{line: 1040, col: 23, offset: 29958},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1039, col: 28, offset: 29785},
+								pos: position{line: 1040, col: 28, offset: 29963},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1039, col: 28, offset: 29785},
+									pos:  position{line: 1040, col: 28, offset: 29963},
 									name: "KeyWordRest",
 								},
 							},
@@ -7608,15 +7635,15 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1041, col: 1, offset: 29847},
+			pos:  position{line: 1042, col: 1, offset: 30025},
 			expr: &choiceExpr{
-				pos: position{line: 1042, col: 5, offset: 29864},
+				pos: position{line: 1043, col: 5, offset: 30042},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1042, col: 5, offset: 29864},
+						pos: position{line: 1043, col: 5, offset: 30042},
 						run: (*parser).callonKeyWordStart2,
 						expr: &charClassMatcher{
-							pos:        position{line: 1042, col: 5, offset: 29864},
+							pos:        position{line: 1043, col: 5, offset: 30042},
 							val:        "[a-zA-Z_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -7625,7 +7652,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 5, offset: 29916},
+						pos:  position{line: 1044, col: 5, offset: 30094},
 						name: "KeyWordEsc",
 					},
 				},
@@ -7633,16 +7660,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1045, col: 1, offset: 29928},
+			pos:  position{line: 1046, col: 1, offset: 30106},
 			expr: &choiceExpr{
-				pos: position{line: 1046, col: 5, offset: 29944},
+				pos: position{line: 1047, col: 5, offset: 30122},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1046, col: 5, offset: 29944},
+						pos:  position{line: 1047, col: 5, offset: 30122},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1047, col: 5, offset: 29961},
+						pos:        position{line: 1048, col: 5, offset: 30139},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7653,30 +7680,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1049, col: 1, offset: 29968},
+			pos:  position{line: 1050, col: 1, offset: 30146},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 14, offset: 29981},
+				pos: position{line: 1050, col: 14, offset: 30159},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1049, col: 14, offset: 29981},
+					pos: position{line: 1050, col: 14, offset: 30159},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1049, col: 14, offset: 29981},
+							pos:        position{line: 1050, col: 14, offset: 30159},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 19, offset: 29986},
+							pos:   position{line: 1050, col: 19, offset: 30164},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1049, col: 22, offset: 29989},
+								pos: position{line: 1050, col: 22, offset: 30167},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1049, col: 22, offset: 29989},
+										pos:  position{line: 1050, col: 22, offset: 30167},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1049, col: 38, offset: 30005},
+										pos:  position{line: 1050, col: 38, offset: 30183},
 										name: "EscapeSequence",
 									},
 								},
@@ -7688,55 +7715,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1051, col: 1, offset: 30041},
+			pos:  position{line: 1052, col: 1, offset: 30219},
 			expr: &choiceExpr{
-				pos: position{line: 1052, col: 5, offset: 30062},
+				pos: position{line: 1053, col: 5, offset: 30240},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1052, col: 5, offset: 30062},
+						pos: position{line: 1053, col: 5, offset: 30240},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1052, col: 5, offset: 30062},
+							pos: position{line: 1053, col: 5, offset: 30240},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1052, col: 5, offset: 30062},
+									pos: position{line: 1053, col: 5, offset: 30240},
 									expr: &choiceExpr{
-										pos: position{line: 1052, col: 7, offset: 30064},
+										pos: position{line: 1053, col: 7, offset: 30242},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1052, col: 7, offset: 30064},
+												pos:        position{line: 1053, col: 7, offset: 30242},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1052, col: 13, offset: 30070},
+												pos:  position{line: 1053, col: 13, offset: 30248},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1052, col: 26, offset: 30083,
+									line: 1053, col: 26, offset: 30261,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1053, col: 5, offset: 30120},
+						pos: position{line: 1054, col: 5, offset: 30298},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1053, col: 5, offset: 30120},
+							pos: position{line: 1054, col: 5, offset: 30298},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1053, col: 5, offset: 30120},
+									pos:        position{line: 1054, col: 5, offset: 30298},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1053, col: 10, offset: 30125},
+									pos:   position{line: 1054, col: 10, offset: 30303},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1053, col: 12, offset: 30127},
+										pos:  position{line: 1054, col: 12, offset: 30305},
 										name: "EscapeSequence",
 									},
 								},
@@ -7748,38 +7775,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1055, col: 1, offset: 30161},
+			pos:  position{line: 1056, col: 1, offset: 30339},
 			expr: &choiceExpr{
-				pos: position{line: 1056, col: 5, offset: 30180},
+				pos: position{line: 1057, col: 5, offset: 30358},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 30180},
+						pos: position{line: 1057, col: 5, offset: 30358},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 30180},
+							pos: position{line: 1057, col: 5, offset: 30358},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1056, col: 5, offset: 30180},
+									pos:        position{line: 1057, col: 5, offset: 30358},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1056, col: 9, offset: 30184},
+									pos:  position{line: 1057, col: 9, offset: 30362},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1056, col: 18, offset: 30193},
+									pos:  position{line: 1057, col: 18, offset: 30371},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1057, col: 5, offset: 30244},
+						pos:  position{line: 1058, col: 5, offset: 30422},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1058, col: 5, offset: 30265},
+						pos:  position{line: 1059, col: 5, offset: 30443},
 						name: "UnicodeEscape",
 					},
 				},
@@ -7787,75 +7814,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1060, col: 1, offset: 30280},
+			pos:  position{line: 1061, col: 1, offset: 30458},
 			expr: &choiceExpr{
-				pos: position{line: 1061, col: 5, offset: 30301},
+				pos: position{line: 1062, col: 5, offset: 30479},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1061, col: 5, offset: 30301},
+						pos:        position{line: 1062, col: 5, offset: 30479},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1062, col: 5, offset: 30309},
+						pos:        position{line: 1063, col: 5, offset: 30487},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1063, col: 5, offset: 30318},
+						pos:        position{line: 1064, col: 5, offset: 30496},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1064, col: 5, offset: 30327},
+						pos: position{line: 1065, col: 5, offset: 30505},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 1064, col: 5, offset: 30327},
+							pos:        position{line: 1065, col: 5, offset: 30505},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 30356},
+						pos: position{line: 1066, col: 5, offset: 30534},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 1065, col: 5, offset: 30356},
+							pos:        position{line: 1066, col: 5, offset: 30534},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 30385},
+						pos: position{line: 1067, col: 5, offset: 30563},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 1066, col: 5, offset: 30385},
+							pos:        position{line: 1067, col: 5, offset: 30563},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30414},
+						pos: position{line: 1068, col: 5, offset: 30592},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 1067, col: 5, offset: 30414},
+							pos:        position{line: 1068, col: 5, offset: 30592},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 30443},
+						pos: position{line: 1069, col: 5, offset: 30621},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 1068, col: 5, offset: 30443},
+							pos:        position{line: 1069, col: 5, offset: 30621},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 30472},
+						pos: position{line: 1070, col: 5, offset: 30650},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 1069, col: 5, offset: 30472},
+							pos:        position{line: 1070, col: 5, offset: 30650},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -7865,30 +7892,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1071, col: 1, offset: 30498},
+			pos:  position{line: 1072, col: 1, offset: 30676},
 			expr: &choiceExpr{
-				pos: position{line: 1072, col: 5, offset: 30516},
+				pos: position{line: 1073, col: 5, offset: 30694},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1072, col: 5, offset: 30516},
+						pos: position{line: 1073, col: 5, offset: 30694},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1072, col: 5, offset: 30516},
+							pos:        position{line: 1073, col: 5, offset: 30694},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 30544},
+						pos: position{line: 1074, col: 5, offset: 30722},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1073, col: 5, offset: 30544},
+							pos:        position{line: 1074, col: 5, offset: 30722},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1074, col: 5, offset: 30574},
+						pos:        position{line: 1075, col: 5, offset: 30752},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -7899,41 +7926,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1076, col: 1, offset: 30580},
+			pos:  position{line: 1077, col: 1, offset: 30758},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 5, offset: 30598},
+				pos: position{line: 1078, col: 5, offset: 30776},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30598},
+						pos: position{line: 1078, col: 5, offset: 30776},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30598},
+							pos: position{line: 1078, col: 5, offset: 30776},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1077, col: 5, offset: 30598},
+									pos:        position{line: 1078, col: 5, offset: 30776},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 9, offset: 30602},
+									pos:   position{line: 1078, col: 9, offset: 30780},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1077, col: 16, offset: 30609},
+										pos: position{line: 1078, col: 16, offset: 30787},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1077, col: 16, offset: 30609},
+												pos:  position{line: 1078, col: 16, offset: 30787},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1077, col: 25, offset: 30618},
+												pos:  position{line: 1078, col: 25, offset: 30796},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1077, col: 34, offset: 30627},
+												pos:  position{line: 1078, col: 34, offset: 30805},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1077, col: 43, offset: 30636},
+												pos:  position{line: 1078, col: 43, offset: 30814},
 												name: "HexDigit",
 											},
 										},
@@ -7943,63 +7970,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 30699},
+						pos: position{line: 1081, col: 5, offset: 30877},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 30699},
+							pos: position{line: 1081, col: 5, offset: 30877},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1080, col: 5, offset: 30699},
+									pos:        position{line: 1081, col: 5, offset: 30877},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1080, col: 9, offset: 30703},
+									pos:        position{line: 1081, col: 9, offset: 30881},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 13, offset: 30707},
+									pos:   position{line: 1081, col: 13, offset: 30885},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1080, col: 20, offset: 30714},
+										pos: position{line: 1081, col: 20, offset: 30892},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1080, col: 20, offset: 30714},
+												pos:  position{line: 1081, col: 20, offset: 30892},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1080, col: 29, offset: 30723},
+												pos: position{line: 1081, col: 29, offset: 30901},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1080, col: 29, offset: 30723},
+													pos:  position{line: 1081, col: 29, offset: 30901},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1080, col: 39, offset: 30733},
+												pos: position{line: 1081, col: 39, offset: 30911},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1080, col: 39, offset: 30733},
+													pos:  position{line: 1081, col: 39, offset: 30911},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1080, col: 49, offset: 30743},
+												pos: position{line: 1081, col: 49, offset: 30921},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1080, col: 49, offset: 30743},
+													pos:  position{line: 1081, col: 49, offset: 30921},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1080, col: 59, offset: 30753},
+												pos: position{line: 1081, col: 59, offset: 30931},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1080, col: 59, offset: 30753},
+													pos:  position{line: 1081, col: 59, offset: 30931},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1080, col: 69, offset: 30763},
+												pos: position{line: 1081, col: 69, offset: 30941},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1080, col: 69, offset: 30763},
+													pos:  position{line: 1081, col: 69, offset: 30941},
 													name: "HexDigit",
 												},
 											},
@@ -8007,7 +8034,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1080, col: 80, offset: 30774},
+									pos:        position{line: 1081, col: 80, offset: 30952},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8019,28 +8046,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1084, col: 1, offset: 30828},
+			pos:  position{line: 1085, col: 1, offset: 31006},
 			expr: &actionExpr{
-				pos: position{line: 1085, col: 5, offset: 30839},
+				pos: position{line: 1086, col: 5, offset: 31017},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1085, col: 5, offset: 30839},
+					pos: position{line: 1086, col: 5, offset: 31017},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1085, col: 5, offset: 30839},
+							pos:        position{line: 1086, col: 5, offset: 31017},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1085, col: 9, offset: 30843},
+							pos:   position{line: 1086, col: 9, offset: 31021},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1085, col: 14, offset: 30848},
+								pos:  position{line: 1086, col: 14, offset: 31026},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1085, col: 25, offset: 30859},
+							pos:        position{line: 1086, col: 25, offset: 31037},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -8050,24 +8077,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1087, col: 1, offset: 30885},
+			pos:  position{line: 1088, col: 1, offset: 31063},
 			expr: &actionExpr{
-				pos: position{line: 1088, col: 5, offset: 30900},
+				pos: position{line: 1089, col: 5, offset: 31078},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1088, col: 5, offset: 30900},
+					pos: position{line: 1089, col: 5, offset: 31078},
 					expr: &choiceExpr{
-						pos: position{line: 1088, col: 6, offset: 30901},
+						pos: position{line: 1089, col: 6, offset: 31079},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1088, col: 6, offset: 30901},
+								pos:        position{line: 1089, col: 6, offset: 31079},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1088, col: 13, offset: 30908},
+								pos:        position{line: 1089, col: 13, offset: 31086},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -8078,9 +8105,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1090, col: 1, offset: 30948},
+			pos:  position{line: 1091, col: 1, offset: 31126},
 			expr: &charClassMatcher{
-				pos:        position{line: 1091, col: 5, offset: 30964},
+				pos:        position{line: 1092, col: 5, offset: 31142},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -8090,42 +8117,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1093, col: 1, offset: 30979},
+			pos:  position{line: 1094, col: 1, offset: 31157},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1093, col: 6, offset: 30984},
+				pos: position{line: 1094, col: 6, offset: 31162},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1093, col: 6, offset: 30984},
+					pos:  position{line: 1094, col: 6, offset: 31162},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1095, col: 1, offset: 30995},
+			pos:  position{line: 1096, col: 1, offset: 31173},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1095, col: 6, offset: 31000},
+				pos: position{line: 1096, col: 6, offset: 31178},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1095, col: 6, offset: 31000},
+					pos:  position{line: 1096, col: 6, offset: 31178},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1097, col: 1, offset: 31011},
+			pos:  position{line: 1098, col: 1, offset: 31189},
 			expr: &choiceExpr{
-				pos: position{line: 1098, col: 5, offset: 31024},
+				pos: position{line: 1099, col: 5, offset: 31202},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1098, col: 5, offset: 31024},
+						pos:  position{line: 1099, col: 5, offset: 31202},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 31039},
+						pos:  position{line: 1100, col: 5, offset: 31217},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 31058},
+						pos:  position{line: 1101, col: 5, offset: 31236},
 						name: "Comment",
 					},
 				},
@@ -8133,45 +8160,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1102, col: 1, offset: 31067},
+			pos:  position{line: 1103, col: 1, offset: 31245},
 			expr: &anyMatcher{
-				line: 1103, col: 5, offset: 31087,
+				line: 1104, col: 5, offset: 31265,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1105, col: 1, offset: 31090},
+			pos:         position{line: 1106, col: 1, offset: 31268},
 			expr: &choiceExpr{
-				pos: position{line: 1106, col: 5, offset: 31118},
+				pos: position{line: 1107, col: 5, offset: 31296},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1106, col: 5, offset: 31118},
+						pos:        position{line: 1107, col: 5, offset: 31296},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1107, col: 5, offset: 31127},
+						pos:        position{line: 1108, col: 5, offset: 31305},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1108, col: 5, offset: 31136},
+						pos:        position{line: 1109, col: 5, offset: 31314},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1109, col: 5, offset: 31145},
+						pos:        position{line: 1110, col: 5, offset: 31323},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1110, col: 5, offset: 31153},
+						pos:        position{line: 1111, col: 5, offset: 31331},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1111, col: 5, offset: 31166},
+						pos:        position{line: 1112, col: 5, offset: 31344},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -8180,9 +8207,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1113, col: 1, offset: 31176},
+			pos:  position{line: 1114, col: 1, offset: 31354},
 			expr: &charClassMatcher{
-				pos:        position{line: 1114, col: 5, offset: 31195},
+				pos:        position{line: 1115, col: 5, offset: 31373},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -8192,45 +8219,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1120, col: 1, offset: 31525},
+			pos:         position{line: 1121, col: 1, offset: 31703},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1123, col: 5, offset: 31596},
+				pos:  position{line: 1124, col: 5, offset: 31774},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1125, col: 1, offset: 31615},
+			pos:  position{line: 1126, col: 1, offset: 31793},
 			expr: &seqExpr{
-				pos: position{line: 1126, col: 5, offset: 31636},
+				pos: position{line: 1127, col: 5, offset: 31814},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1126, col: 5, offset: 31636},
+						pos:        position{line: 1127, col: 5, offset: 31814},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1126, col: 10, offset: 31641},
+						pos: position{line: 1127, col: 10, offset: 31819},
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 11, offset: 31642},
+							pos: position{line: 1127, col: 11, offset: 31820},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1126, col: 11, offset: 31642},
+									pos: position{line: 1127, col: 11, offset: 31820},
 									expr: &litMatcher{
-										pos:        position{line: 1126, col: 12, offset: 31643},
+										pos:        position{line: 1127, col: 12, offset: 31821},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 17, offset: 31648},
+									pos:  position{line: 1127, col: 17, offset: 31826},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1126, col: 35, offset: 31666},
+						pos:        position{line: 1127, col: 35, offset: 31844},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -8239,29 +8266,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1128, col: 1, offset: 31672},
+			pos:  position{line: 1129, col: 1, offset: 31850},
 			expr: &seqExpr{
-				pos: position{line: 1129, col: 5, offset: 31694},
+				pos: position{line: 1130, col: 5, offset: 31872},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1129, col: 5, offset: 31694},
+						pos:        position{line: 1130, col: 5, offset: 31872},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1129, col: 10, offset: 31699},
+						pos: position{line: 1130, col: 10, offset: 31877},
 						expr: &seqExpr{
-							pos: position{line: 1129, col: 11, offset: 31700},
+							pos: position{line: 1130, col: 11, offset: 31878},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1129, col: 11, offset: 31700},
+									pos: position{line: 1130, col: 11, offset: 31878},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1129, col: 12, offset: 31701},
+										pos:  position{line: 1130, col: 12, offset: 31879},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1129, col: 27, offset: 31716},
+									pos:  position{line: 1130, col: 27, offset: 31894},
 									name: "SourceCharacter",
 								},
 							},
@@ -8272,19 +8299,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1131, col: 1, offset: 31735},
+			pos:  position{line: 1132, col: 1, offset: 31913},
 			expr: &seqExpr{
-				pos: position{line: 1131, col: 7, offset: 31741},
+				pos: position{line: 1132, col: 7, offset: 31919},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1131, col: 7, offset: 31741},
+						pos: position{line: 1132, col: 7, offset: 31919},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1131, col: 7, offset: 31741},
+							pos:  position{line: 1132, col: 7, offset: 31919},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 19, offset: 31753},
+						pos:  position{line: 1132, col: 19, offset: 31931},
 						name: "LineTerminator",
 					},
 				},
@@ -8292,16 +8319,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1133, col: 1, offset: 31769},
+			pos:  position{line: 1134, col: 1, offset: 31947},
 			expr: &choiceExpr{
-				pos: position{line: 1133, col: 7, offset: 31775},
+				pos: position{line: 1134, col: 7, offset: 31953},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 7, offset: 31775},
+						pos:  position{line: 1134, col: 7, offset: 31953},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 11, offset: 31779},
+						pos:  position{line: 1134, col: 11, offset: 31957},
 						name: "EOF",
 					},
 				},
@@ -8309,11 +8336,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1135, col: 1, offset: 31784},
+			pos:  position{line: 1136, col: 1, offset: 31962},
 			expr: &notExpr{
-				pos: position{line: 1135, col: 7, offset: 31790},
+				pos: position{line: 1136, col: 7, offset: 31968},
 				expr: &anyMatcher{
-					line: 1135, col: 8, offset: 31791,
+					line: 1136, col: 8, offset: 31969,
 				},
 			},
 		},
@@ -8442,15 +8469,26 @@ func (p *parser) callonParallelTail1() (interface{}, error) {
 	return p.cur.onParallelTail1(stack["ch"])
 }
 
-func (c *current) onSwitchBranch1(filter, proc interface{}) (interface{}, error) {
+func (c *current) onSwitchBranch2(filter, proc interface{}) (interface{}, error) {
 	return map[string]interface{}{"filter": filter, "proc": proc}, nil
 
 }
 
-func (p *parser) callonSwitchBranch1() (interface{}, error) {
+func (p *parser) callonSwitchBranch2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitchBranch1(stack["filter"], stack["proc"])
+	return p.cur.onSwitchBranch2(stack["filter"], stack["proc"])
+}
+
+func (c *current) onSwitchBranch14(proc interface{}) (interface{}, error) {
+	return map[string]interface{}{"filter": map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}, nil
+
+}
+
+func (p *parser) callonSwitchBranch14() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSwitchBranch14(stack["proc"])
 }
 
 func (c *current) onSwitch2(first, rest interface{}) (interface{}, error) {
@@ -8475,16 +8513,6 @@ func (p *parser) callonSwitch9() (interface{}, error) {
 	return p.cur.onSwitch9(stack["first"])
 }
 
-func (c *current) onSwitchTail1(ch interface{}) (interface{}, error) {
-	return ch, nil
-}
-
-func (p *parser) callonSwitchTail1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSwitchTail1(stack["ch"])
-}
-
 func (c *current) onOperation2(procArray interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "ParallelProc", "procs": procArray}, nil
 
@@ -8507,35 +8535,35 @@ func (p *parser) callonOperation14() (interface{}, error) {
 	return p.cur.onOperation14(stack["caseArray"])
 }
 
-func (c *current) onOperation27(f interface{}) (interface{}, error) {
+func (c *current) onOperation25(f interface{}) (interface{}, error) {
 	return f, nil
 }
 
-func (p *parser) callonOperation27() (interface{}, error) {
+func (p *parser) callonOperation25() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation27(stack["f"])
+	return p.cur.onOperation25(stack["f"])
 }
 
-func (c *current) onOperation33(a interface{}) (interface{}, error) {
+func (c *current) onOperation31(a interface{}) (interface{}, error) {
 	return a, nil
 }
 
-func (p *parser) callonOperation33() (interface{}, error) {
+func (p *parser) callonOperation31() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation33(stack["a"])
+	return p.cur.onOperation31(stack["a"])
 }
 
-func (c *current) onOperation39(expr interface{}) (interface{}, error) {
+func (c *current) onOperation37(expr interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
 
 }
 
-func (p *parser) callonOperation39() (interface{}, error) {
+func (p *parser) callonOperation37() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOperation39(stack["expr"])
+	return p.cur.onOperation37(stack["expr"])
 }
 
 func (c *current) onSearchBoolean1(first, rest interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -184,52 +184,57 @@ function peg$parse(input, options) {
       peg$c21 = peg$literalExpectation("=>", false),
       peg$c22 = function(ch) { return ch },
       peg$c23 = function(filter, proc) {
-          return {"filter": filter, "proc": proc}
-        },
-      peg$c24 = "case",
-      peg$c25 = peg$literalExpectation("case", false),
-      peg$c26 = "split",
-      peg$c27 = peg$literalExpectation("split", false),
-      peg$c28 = "(",
-      peg$c29 = peg$literalExpectation("(", false),
-      peg$c30 = ")",
-      peg$c31 = peg$literalExpectation(")", false),
-      peg$c32 = function(procArray) {
+            return {"filter": filter, "proc": proc}
+          },
+      peg$c24 = function(proc) {
+            return {"filter": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
+          },
+      peg$c25 = "case",
+      peg$c26 = peg$literalExpectation("case", true),
+      peg$c27 = "default",
+      peg$c28 = peg$literalExpectation("default", true),
+      peg$c29 = "split",
+      peg$c30 = peg$literalExpectation("split", false),
+      peg$c31 = "(",
+      peg$c32 = peg$literalExpectation("(", false),
+      peg$c33 = ")",
+      peg$c34 = peg$literalExpectation(")", false),
+      peg$c35 = function(procArray) {
             return {"op": "ParallelProc", "procs": procArray}
           },
-      peg$c33 = "switch",
-      peg$c34 = peg$literalExpectation("switch", false),
-      peg$c35 = function(caseArray) {
+      peg$c36 = "switch",
+      peg$c37 = peg$literalExpectation("switch", false),
+      peg$c38 = function(caseArray) {
             return {"op": "SwitchProc", "cases": caseArray}
           },
-      peg$c36 = function(f) { return f },
-      peg$c37 = function(a) { return a },
-      peg$c38 = function(expr) {
+      peg$c39 = function(f) { return f },
+      peg$c40 = function(a) { return a },
+      peg$c41 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c39 = ":",
-      peg$c40 = peg$literalExpectation(":", false),
-      peg$c41 = "-with",
-      peg$c42 = peg$literalExpectation("-with", false),
-      peg$c43 = ",",
-      peg$c44 = peg$literalExpectation(",", false),
-      peg$c45 = function(first, rest) {
+      peg$c42 = ":",
+      peg$c43 = peg$literalExpectation(":", false),
+      peg$c44 = "-with",
+      peg$c45 = peg$literalExpectation("-with", false),
+      peg$c46 = ",",
+      peg$c47 = peg$literalExpectation(",", false),
+      peg$c48 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c46 = function(t) { return ["or", t] },
-      peg$c47 = function(first, expr) { return ["and", expr] },
-      peg$c48 = function(first, rest) {
+      peg$c49 = function(t) { return ["or", t] },
+      peg$c50 = function(first, expr) { return ["and", expr] },
+      peg$c51 = function(first, rest) {
             return makeBinaryExprChain(first,rest)
           },
-      peg$c49 = "!",
-      peg$c50 = peg$literalExpectation("!", false),
-      peg$c51 = function(e) {
+      peg$c52 = "!",
+      peg$c53 = peg$literalExpectation("!", false),
+      peg$c54 = function(e) {
             return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c52 = function(expr) { return expr },
-      peg$c53 = "*",
-      peg$c54 = peg$literalExpectation("*", false),
-      peg$c55 = function(compareOp, v) {
+      peg$c55 = function(expr) { return expr },
+      peg$c56 = "*",
+      peg$c57 = peg$literalExpectation("*", false),
+      peg$c58 = function(compareOp, v) {
             return {"op": "FunctionCall", "function": "or",
               
             "args": [
@@ -256,10 +261,10 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c56 = function(f, comp, v) {
+      peg$c59 = function(f, comp, v) {
             return {"op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v}
           },
-      peg$c57 = function(v) {
+      peg$c60 = function(v) {
             return {"op": "FunctionCall", "function": "or",
               
             "args": [
@@ -286,16 +291,16 @@ function peg$parse(input, options) {
 
 
           },
-      peg$c58 = function(v) {
+      peg$c61 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c59 = function() {
+      peg$c62 = function() {
             return {"op": "Literal", "type": "bool", "value": "true"}
           },
-      peg$c60 = function(v) {
+      peg$c63 = function(v) {
             return {"op": "Literal", "type": "string", "value": v}
           },
-      peg$c61 = function(v) {
+      peg$c64 = function(v) {
             let str = v
             let literal = {"op": "Literal", "type": "string", "value": v}
             if (reglob.IsGlobby(str)) {
@@ -304,86 +309,86 @@ function peg$parse(input, options) {
             }
             return literal
           },
-      peg$c62 = function(head, tail) {
+      peg$c65 = function(head, tail) {
             return joinChars(head) + joinChars(tail)
           },
-      peg$c63 = function(s, v) { return s+v },
-      peg$c64 = function() { return text() },
-      peg$c65 = "type(",
-      peg$c66 = peg$literalExpectation("type(", false),
-      peg$c67 = "!=",
-      peg$c68 = peg$literalExpectation("!=", false),
-      peg$c69 = "in",
-      peg$c70 = peg$literalExpectation("in", false),
-      peg$c71 = "<=",
-      peg$c72 = peg$literalExpectation("<=", false),
-      peg$c73 = "<",
-      peg$c74 = peg$literalExpectation("<", false),
-      peg$c75 = ">=",
-      peg$c76 = peg$literalExpectation(">=", false),
-      peg$c77 = ">",
-      peg$c78 = peg$literalExpectation(">", false),
-      peg$c79 = function(first, op, expr) { return [op, expr] },
-      peg$c80 = function(first, rest) {
+      peg$c66 = function(s, v) { return s+v },
+      peg$c67 = function() { return text() },
+      peg$c68 = "type(",
+      peg$c69 = peg$literalExpectation("type(", false),
+      peg$c70 = "!=",
+      peg$c71 = peg$literalExpectation("!=", false),
+      peg$c72 = "in",
+      peg$c73 = peg$literalExpectation("in", false),
+      peg$c74 = "<=",
+      peg$c75 = peg$literalExpectation("<=", false),
+      peg$c76 = "<",
+      peg$c77 = peg$literalExpectation("<", false),
+      peg$c78 = ">=",
+      peg$c79 = peg$literalExpectation(">=", false),
+      peg$c80 = ">",
+      peg$c81 = peg$literalExpectation(">", false),
+      peg$c82 = function(first, op, expr) { return [op, expr] },
+      peg$c83 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c81 = function(e, typ) {
+      peg$c84 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c82 = function(every, keys, limit) {
+      peg$c85 = function(every, keys, limit) {
             return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
-      peg$c83 = function(every, reducers, keys, limit) {
+      peg$c86 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
             return p
           },
-      peg$c84 = "summarize",
-      peg$c85 = peg$literalExpectation("summarize", false),
-      peg$c86 = "",
-      peg$c87 = "every",
-      peg$c88 = peg$literalExpectation("every", true),
-      peg$c89 = function(dur) { return dur },
-      peg$c90 = function() { return null },
-      peg$c91 = function(columns) { return columns },
-      peg$c92 = "with",
-      peg$c93 = peg$literalExpectation("with", false),
-      peg$c94 = "-limit",
-      peg$c95 = peg$literalExpectation("-limit", false),
-      peg$c96 = function(limit) { return limit },
-      peg$c97 = function() { return 0 },
-      peg$c98 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c99 = function(first, expr) { return expr },
-      peg$c100 = function(lval, reducer) {
+      peg$c87 = "summarize",
+      peg$c88 = peg$literalExpectation("summarize", false),
+      peg$c89 = "",
+      peg$c90 = "every",
+      peg$c91 = peg$literalExpectation("every", true),
+      peg$c92 = function(dur) { return dur },
+      peg$c93 = function() { return null },
+      peg$c94 = function(columns) { return columns },
+      peg$c95 = "with",
+      peg$c96 = peg$literalExpectation("with", false),
+      peg$c97 = "-limit",
+      peg$c98 = peg$literalExpectation("-limit", false),
+      peg$c99 = function(limit) { return limit },
+      peg$c100 = function() { return 0 },
+      peg$c101 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c102 = function(first, expr) { return expr },
+      peg$c103 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c101 = function(reducer) {
+      peg$c104 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c102 = ".",
-      peg$c103 = peg$literalExpectation(".", false),
-      peg$c104 = function(op, expr, where) {
+      peg$c105 = ".",
+      peg$c106 = peg$literalExpectation(".", false),
+      peg$c107 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c105 = "where",
-      peg$c106 = peg$literalExpectation("where", false),
-      peg$c107 = function(first, rest) {
+      peg$c108 = "where",
+      peg$c109 = peg$literalExpectation("where", false),
+      peg$c110 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c108 = "sort",
-      peg$c109 = peg$literalExpectation("sort", true),
-      peg$c110 = function(args, l) { return l },
-      peg$c111 = function(args, list) {
+      peg$c111 = "sort",
+      peg$c112 = peg$literalExpectation("sort", true),
+      peg$c113 = function(args, l) { return l },
+      peg$c114 = function(args, list) {
             let argm = args
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
@@ -396,24 +401,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c112 = function(args) { return makeArgMap(args) },
-      peg$c113 = "-r",
-      peg$c114 = peg$literalExpectation("-r", false),
-      peg$c115 = function() { return {"name": "r", "value": null} },
-      peg$c116 = "-nulls",
-      peg$c117 = peg$literalExpectation("-nulls", false),
-      peg$c118 = "first",
-      peg$c119 = peg$literalExpectation("first", false),
-      peg$c120 = "last",
-      peg$c121 = peg$literalExpectation("last", false),
-      peg$c122 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c123 = "top",
-      peg$c124 = peg$literalExpectation("top", true),
-      peg$c125 = function(n) { return n},
-      peg$c126 = "-flush",
-      peg$c127 = peg$literalExpectation("-flush", false),
-      peg$c128 = function(limit, flush, f) { return f },
-      peg$c129 = function(limit, flush, fields) {
+      peg$c115 = function(args) { return makeArgMap(args) },
+      peg$c116 = "-r",
+      peg$c117 = peg$literalExpectation("-r", false),
+      peg$c118 = function() { return {"name": "r", "value": null} },
+      peg$c119 = "-nulls",
+      peg$c120 = peg$literalExpectation("-nulls", false),
+      peg$c121 = "first",
+      peg$c122 = peg$literalExpectation("first", false),
+      peg$c123 = "last",
+      peg$c124 = peg$literalExpectation("last", false),
+      peg$c125 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c126 = "top",
+      peg$c127 = peg$literalExpectation("top", true),
+      peg$c128 = function(n) { return n},
+      peg$c129 = "-flush",
+      peg$c130 = peg$literalExpectation("-flush", false),
+      peg$c131 = function(limit, flush, f) { return f },
+      peg$c132 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
@@ -426,93 +431,93 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c130 = "cut",
-      peg$c131 = peg$literalExpectation("cut", true),
-      peg$c132 = function(columns) {
+      peg$c133 = "cut",
+      peg$c134 = peg$literalExpectation("cut", true),
+      peg$c135 = function(columns) {
             return {"op": "CutProc", "fields": columns}
           },
-      peg$c133 = "pick",
-      peg$c134 = peg$literalExpectation("pick", true),
-      peg$c135 = function(columns) {
+      peg$c136 = "pick",
+      peg$c137 = peg$literalExpectation("pick", true),
+      peg$c138 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c136 = "drop",
-      peg$c137 = peg$literalExpectation("drop", true),
-      peg$c138 = function(columns) {
+      peg$c139 = "drop",
+      peg$c140 = peg$literalExpectation("drop", true),
+      peg$c141 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c139 = "head",
-      peg$c140 = peg$literalExpectation("head", true),
-      peg$c141 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c142 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c143 = "tail",
-      peg$c144 = peg$literalExpectation("tail", true),
-      peg$c145 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c146 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c147 = "filter",
-      peg$c148 = peg$literalExpectation("filter", true),
-      peg$c149 = function(op) {
+      peg$c142 = "head",
+      peg$c143 = peg$literalExpectation("head", true),
+      peg$c144 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c145 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c146 = "tail",
+      peg$c147 = peg$literalExpectation("tail", true),
+      peg$c148 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c149 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c150 = "filter",
+      peg$c151 = peg$literalExpectation("filter", true),
+      peg$c152 = function(op) {
             return op
           },
-      peg$c150 = "uniq",
-      peg$c151 = peg$literalExpectation("uniq", true),
-      peg$c152 = "-c",
-      peg$c153 = peg$literalExpectation("-c", false),
-      peg$c154 = function() {
+      peg$c153 = "uniq",
+      peg$c154 = peg$literalExpectation("uniq", true),
+      peg$c155 = "-c",
+      peg$c156 = peg$literalExpectation("-c", false),
+      peg$c157 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c155 = function() {
+      peg$c158 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c156 = "put",
-      peg$c157 = peg$literalExpectation("put", true),
-      peg$c158 = function(columns) {
+      peg$c159 = "put",
+      peg$c160 = peg$literalExpectation("put", true),
+      peg$c161 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c159 = "rename",
-      peg$c160 = peg$literalExpectation("rename", true),
-      peg$c161 = function(first, cl) { return cl },
-      peg$c162 = function(first, rest) {
+      peg$c162 = "rename",
+      peg$c163 = peg$literalExpectation("rename", true),
+      peg$c164 = function(first, cl) { return cl },
+      peg$c165 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c163 = "fuse",
-      peg$c164 = peg$literalExpectation("fuse", true),
-      peg$c165 = function() {
+      peg$c166 = "fuse",
+      peg$c167 = peg$literalExpectation("fuse", true),
+      peg$c168 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c166 = "shape",
-      peg$c167 = peg$literalExpectation("shape", true),
-      peg$c168 = function() {
+      peg$c169 = "shape",
+      peg$c170 = peg$literalExpectation("shape", true),
+      peg$c171 = function() {
             return {"op": "ShapeProc"}
           },
-      peg$c169 = "join",
-      peg$c170 = peg$literalExpectation("join", true),
-      peg$c171 = function(kind, leftKey, rightKey, columns) {
+      peg$c172 = "join",
+      peg$c173 = peg$literalExpectation("join", true),
+      peg$c174 = function(kind, leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "kind": kind, "left_key": leftKey, "right_key": rightKey, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c172 = function(kind, key, columns) {
+      peg$c175 = function(kind, key, columns) {
             let proc = {"op": "JoinProc", "kind": kind, "left_key": key, "right_key": key, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c173 = "inner",
-      peg$c174 = peg$literalExpectation("inner", true),
-      peg$c175 = function() { return "inner" },
-      peg$c176 = "left",
-      peg$c177 = peg$literalExpectation("left", true),
-      peg$c178 = function() { return "left" },
-      peg$c179 = "right",
-      peg$c180 = peg$literalExpectation("right", true),
-      peg$c181 = function() { return "right" },
-      peg$c182 = "taste",
-      peg$c183 = peg$literalExpectation("taste", true),
-      peg$c184 = function(e) {
+      peg$c176 = "inner",
+      peg$c177 = peg$literalExpectation("inner", true),
+      peg$c178 = function() { return "inner" },
+      peg$c179 = "left",
+      peg$c180 = peg$literalExpectation("left", true),
+      peg$c181 = function() { return "left" },
+      peg$c182 = "right",
+      peg$c183 = peg$literalExpectation("right", true),
+      peg$c184 = function() { return "right" },
+      peg$c185 = "taste",
+      peg$c186 = peg$literalExpectation("taste", true),
+      peg$c187 = function(e) {
             return {"op": "SequentialProc", "procs": [
               
             {"op": "GroupByProc",
@@ -548,9 +553,9 @@ function peg$parse(input, options) {
             "rhs": {"op": "Identifier", "name": "taste"}}]}]}
           
           },
-      peg$c185 = function(lval) { return lval},
-      peg$c186 = function() { return {"op":"RootRecord"} },
-      peg$c187 = function(first, rest) {
+      peg$c188 = function(lval) { return lval},
+      peg$c189 = function() { return {"op":"RootRecord"} },
+      peg$c190 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -559,41 +564,41 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c188 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c189 = "?",
-      peg$c190 = peg$literalExpectation("?", false),
-      peg$c191 = function(condition, thenClause, elseClause) {
+      peg$c191 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c192 = "?",
+      peg$c193 = peg$literalExpectation("?", false),
+      peg$c194 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c192 = function(first, comp, expr) { return [comp, expr] },
-      peg$c193 = "+",
-      peg$c194 = peg$literalExpectation("+", false),
-      peg$c195 = "-",
-      peg$c196 = peg$literalExpectation("-", false),
-      peg$c197 = "/",
-      peg$c198 = peg$literalExpectation("/", false),
-      peg$c199 = function(e) {
+      peg$c195 = function(first, comp, expr) { return [comp, expr] },
+      peg$c196 = "+",
+      peg$c197 = peg$literalExpectation("+", false),
+      peg$c198 = "-",
+      peg$c199 = peg$literalExpectation("-", false),
+      peg$c200 = "/",
+      peg$c201 = peg$literalExpectation("/", false),
+      peg$c202 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c200 = "not",
-      peg$c201 = peg$literalExpectation("not", false),
-      peg$c202 = "match",
-      peg$c203 = peg$literalExpectation("match", false),
-      peg$c204 = "select",
-      peg$c205 = peg$literalExpectation("select", false),
-      peg$c206 = function(args, methods) {
+      peg$c203 = "not",
+      peg$c204 = peg$literalExpectation("not", false),
+      peg$c205 = "match",
+      peg$c206 = peg$literalExpectation("match", false),
+      peg$c207 = "select",
+      peg$c208 = peg$literalExpectation("select", false),
+      peg$c209 = function(args, methods) {
             return {"op":"SelectExpr", "selectors":args, "methods": methods}
           },
-      peg$c207 = function(methods) { return methods },
-      peg$c208 = function(fn, args) {
+      peg$c210 = function(methods) { return methods },
+      peg$c211 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c209 = function(first, e) { return e },
-      peg$c210 = function() { return [] },
-      peg$c211 = function() {
+      peg$c212 = function(first, e) { return e },
+      peg$c213 = function() { return [] },
+      peg$c214 = function() {
             return {"op":"RootRecord"}
           },
-      peg$c212 = function(field) {
+      peg$c215 = function(field) {
             return {"op": "BinaryExpr", "operator":".",
                            
             "lhs":{"op":"RootRecord"},
@@ -602,11 +607,11 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c213 = "[",
-      peg$c214 = peg$literalExpectation("[", false),
-      peg$c215 = "]",
-      peg$c216 = peg$literalExpectation("]", false),
-      peg$c217 = function(expr) {
+      peg$c216 = "[",
+      peg$c217 = peg$literalExpectation("[", false),
+      peg$c218 = "]",
+      peg$c219 = peg$literalExpectation("]", false),
+      peg$c220 = function(expr) {
             return {"op": "BinaryExpr", "operator":"[",
                            
             "lhs":{"op":"RootRecord"},
@@ -615,320 +620,320 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c218 = function(from, to) {
+      peg$c221 = function(from, to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c219 = function(to) {
+      peg$c222 = function(to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c220 = function(from) {
+      peg$c223 = function(from) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs": null}]
           
           },
-      peg$c221 = function(expr) { return ["[", expr] },
-      peg$c222 = function(id) { return [".", id] },
-      peg$c223 = function(v) {
+      peg$c224 = function(expr) { return ["[", expr] },
+      peg$c225 = function(id) { return [".", id] },
+      peg$c226 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c224 = function(v) {
+      peg$c227 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c225 = function(v) {
+      peg$c228 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c226 = function(v) {
+      peg$c229 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c227 = function(v) {
+      peg$c230 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c228 = "true",
-      peg$c229 = peg$literalExpectation("true", false),
-      peg$c230 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c231 = "false",
-      peg$c232 = peg$literalExpectation("false", false),
-      peg$c233 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c234 = "null",
-      peg$c235 = peg$literalExpectation("null", false),
-      peg$c236 = function() { return {"op": "Literal", "type": "null", "value": ""} },
-      peg$c237 = function(typ) {
+      peg$c231 = "true",
+      peg$c232 = peg$literalExpectation("true", false),
+      peg$c233 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c234 = "false",
+      peg$c235 = peg$literalExpectation("false", false),
+      peg$c236 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c237 = "null",
+      peg$c238 = peg$literalExpectation("null", false),
+      peg$c239 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c240 = function(typ) {
             return {"op": "TypeExpr", "type": typ}
           },
-      peg$c238 = function(typ) { return typ},
-      peg$c239 = function(typ) { return typ },
-      peg$c240 = function() {
+      peg$c241 = function(typ) { return typ},
+      peg$c242 = function(typ) { return typ },
+      peg$c243 = function() {
             return {"op": "TypeNull"}
           },
-      peg$c241 = function(name, typ) {
+      peg$c244 = function(name, typ) {
             return {"op": "TypeDef", "name": name, "type": typ}
         },
-      peg$c242 = function(name) {
+      peg$c245 = function(name) {
             return {"op": "TypeName", "name": name}
           },
-      peg$c243 = function(u) { return u },
-      peg$c244 = function(types) {
+      peg$c246 = function(u) { return u },
+      peg$c247 = function(types) {
             return {"op": "TypeUnion", "types": types}
           },
-      peg$c245 = function(first, rest) {
+      peg$c248 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c246 = "{",
-      peg$c247 = peg$literalExpectation("{", false),
-      peg$c248 = "}",
-      peg$c249 = peg$literalExpectation("}", false),
-      peg$c250 = function(fields) {
+      peg$c249 = "{",
+      peg$c250 = peg$literalExpectation("{", false),
+      peg$c251 = "}",
+      peg$c252 = peg$literalExpectation("}", false),
+      peg$c253 = function(fields) {
             return {"op":"TypeRecord", "fields":fields}
           },
-      peg$c251 = function(typ) {
+      peg$c254 = function(typ) {
             return {"op":"TypeArray", "type":typ}
           },
-      peg$c252 = "|[",
-      peg$c253 = peg$literalExpectation("|[", false),
-      peg$c254 = "]|",
-      peg$c255 = peg$literalExpectation("]|", false),
-      peg$c256 = function(typ) {
+      peg$c255 = "|[",
+      peg$c256 = peg$literalExpectation("|[", false),
+      peg$c257 = "]|",
+      peg$c258 = peg$literalExpectation("]|", false),
+      peg$c259 = function(typ) {
             return {"op":"TypeSet", "type":typ}
           },
-      peg$c257 = "|{",
-      peg$c258 = peg$literalExpectation("|{", false),
-      peg$c259 = "}|",
-      peg$c260 = peg$literalExpectation("}|", false),
-      peg$c261 = function(keyType, valType) {
+      peg$c260 = "|{",
+      peg$c261 = peg$literalExpectation("|{", false),
+      peg$c262 = "}|",
+      peg$c263 = peg$literalExpectation("}|", false),
+      peg$c264 = function(keyType, valType) {
             return {"op":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c262 = "uint8",
-      peg$c263 = peg$literalExpectation("uint8", false),
-      peg$c264 = "uint16",
-      peg$c265 = peg$literalExpectation("uint16", false),
-      peg$c266 = "uint32",
-      peg$c267 = peg$literalExpectation("uint32", false),
-      peg$c268 = "uint64",
-      peg$c269 = peg$literalExpectation("uint64", false),
-      peg$c270 = "int8",
-      peg$c271 = peg$literalExpectation("int8", false),
-      peg$c272 = "int16",
-      peg$c273 = peg$literalExpectation("int16", false),
-      peg$c274 = "int32",
-      peg$c275 = peg$literalExpectation("int32", false),
-      peg$c276 = "int64",
-      peg$c277 = peg$literalExpectation("int64", false),
-      peg$c278 = "float64",
-      peg$c279 = peg$literalExpectation("float64", false),
-      peg$c280 = "bool",
-      peg$c281 = peg$literalExpectation("bool", false),
-      peg$c282 = "string",
-      peg$c283 = peg$literalExpectation("string", false),
-      peg$c284 = function() {
+      peg$c265 = "uint8",
+      peg$c266 = peg$literalExpectation("uint8", false),
+      peg$c267 = "uint16",
+      peg$c268 = peg$literalExpectation("uint16", false),
+      peg$c269 = "uint32",
+      peg$c270 = peg$literalExpectation("uint32", false),
+      peg$c271 = "uint64",
+      peg$c272 = peg$literalExpectation("uint64", false),
+      peg$c273 = "int8",
+      peg$c274 = peg$literalExpectation("int8", false),
+      peg$c275 = "int16",
+      peg$c276 = peg$literalExpectation("int16", false),
+      peg$c277 = "int32",
+      peg$c278 = peg$literalExpectation("int32", false),
+      peg$c279 = "int64",
+      peg$c280 = peg$literalExpectation("int64", false),
+      peg$c281 = "float64",
+      peg$c282 = peg$literalExpectation("float64", false),
+      peg$c283 = "bool",
+      peg$c284 = peg$literalExpectation("bool", false),
+      peg$c285 = "string",
+      peg$c286 = peg$literalExpectation("string", false),
+      peg$c287 = function() {
                 return {"op": "TypePrimitive", "name": text()}
               },
-      peg$c285 = "duration",
-      peg$c286 = peg$literalExpectation("duration", false),
-      peg$c287 = "time",
-      peg$c288 = peg$literalExpectation("time", false),
-      peg$c289 = "bytes",
-      peg$c290 = peg$literalExpectation("bytes", false),
-      peg$c291 = "bstring",
-      peg$c292 = peg$literalExpectation("bstring", false),
-      peg$c293 = "ip",
-      peg$c294 = peg$literalExpectation("ip", false),
-      peg$c295 = "net",
-      peg$c296 = peg$literalExpectation("net", false),
-      peg$c297 = "error",
-      peg$c298 = peg$literalExpectation("error", false),
-      peg$c299 = function(name, typ) {
+      peg$c288 = "duration",
+      peg$c289 = peg$literalExpectation("duration", false),
+      peg$c290 = "time",
+      peg$c291 = peg$literalExpectation("time", false),
+      peg$c292 = "bytes",
+      peg$c293 = peg$literalExpectation("bytes", false),
+      peg$c294 = "bstring",
+      peg$c295 = peg$literalExpectation("bstring", false),
+      peg$c296 = "ip",
+      peg$c297 = peg$literalExpectation("ip", false),
+      peg$c298 = "net",
+      peg$c299 = peg$literalExpectation("net", false),
+      peg$c300 = "error",
+      peg$c301 = peg$literalExpectation("error", false),
+      peg$c302 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c300 = "and",
-      peg$c301 = peg$literalExpectation("and", true),
-      peg$c302 = function() { return "and" },
-      peg$c303 = "or",
-      peg$c304 = peg$literalExpectation("or", true),
-      peg$c305 = function() { return "or" },
-      peg$c306 = peg$literalExpectation("in", true),
-      peg$c307 = function() { return "in" },
-      peg$c308 = peg$literalExpectation("not", true),
-      peg$c309 = function() { return "not" },
-      peg$c310 = "by",
-      peg$c311 = peg$literalExpectation("by", true),
-      peg$c312 = function() { return "by" },
-      peg$c313 = /^[A-Za-z_$]/,
-      peg$c314 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c315 = /^[0-9]/,
-      peg$c316 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c317 = function(id) { return {"op": "Identifier", "name": id} },
-      peg$c318 = function() {  return text() },
-      peg$c319 = "$",
-      peg$c320 = peg$literalExpectation("$", false),
-      peg$c321 = "\\",
-      peg$c322 = peg$literalExpectation("\\", false),
-      peg$c323 = function(id) { return id },
-      peg$c324 = peg$literalExpectation("and", false),
-      peg$c325 = "seconds",
-      peg$c326 = peg$literalExpectation("seconds", false),
-      peg$c327 = "second",
-      peg$c328 = peg$literalExpectation("second", false),
-      peg$c329 = "secs",
-      peg$c330 = peg$literalExpectation("secs", false),
-      peg$c331 = "sec",
-      peg$c332 = peg$literalExpectation("sec", false),
-      peg$c333 = "s",
-      peg$c334 = peg$literalExpectation("s", false),
-      peg$c335 = "minutes",
-      peg$c336 = peg$literalExpectation("minutes", false),
-      peg$c337 = "minute",
-      peg$c338 = peg$literalExpectation("minute", false),
-      peg$c339 = "mins",
-      peg$c340 = peg$literalExpectation("mins", false),
-      peg$c341 = "min",
-      peg$c342 = peg$literalExpectation("min", false),
-      peg$c343 = "m",
-      peg$c344 = peg$literalExpectation("m", false),
-      peg$c345 = "hours",
-      peg$c346 = peg$literalExpectation("hours", false),
-      peg$c347 = "hrs",
-      peg$c348 = peg$literalExpectation("hrs", false),
-      peg$c349 = "hr",
-      peg$c350 = peg$literalExpectation("hr", false),
-      peg$c351 = "h",
-      peg$c352 = peg$literalExpectation("h", false),
-      peg$c353 = "hour",
-      peg$c354 = peg$literalExpectation("hour", false),
-      peg$c355 = "days",
-      peg$c356 = peg$literalExpectation("days", false),
-      peg$c357 = "day",
-      peg$c358 = peg$literalExpectation("day", false),
-      peg$c359 = "d",
-      peg$c360 = peg$literalExpectation("d", false),
-      peg$c361 = "weeks",
-      peg$c362 = peg$literalExpectation("weeks", false),
-      peg$c363 = "week",
-      peg$c364 = peg$literalExpectation("week", false),
-      peg$c365 = "wks",
-      peg$c366 = peg$literalExpectation("wks", false),
-      peg$c367 = "wk",
-      peg$c368 = peg$literalExpectation("wk", false),
-      peg$c369 = "w",
-      peg$c370 = peg$literalExpectation("w", false),
-      peg$c371 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c372 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c373 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c374 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c375 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c376 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c377 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c378 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c379 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c380 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c381 = function(a, b) {
+      peg$c303 = "and",
+      peg$c304 = peg$literalExpectation("and", true),
+      peg$c305 = function() { return "and" },
+      peg$c306 = "or",
+      peg$c307 = peg$literalExpectation("or", true),
+      peg$c308 = function() { return "or" },
+      peg$c309 = peg$literalExpectation("in", true),
+      peg$c310 = function() { return "in" },
+      peg$c311 = peg$literalExpectation("not", true),
+      peg$c312 = function() { return "not" },
+      peg$c313 = "by",
+      peg$c314 = peg$literalExpectation("by", true),
+      peg$c315 = function() { return "by" },
+      peg$c316 = /^[A-Za-z_$]/,
+      peg$c317 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c318 = /^[0-9]/,
+      peg$c319 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c320 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c321 = function() {  return text() },
+      peg$c322 = "$",
+      peg$c323 = peg$literalExpectation("$", false),
+      peg$c324 = "\\",
+      peg$c325 = peg$literalExpectation("\\", false),
+      peg$c326 = function(id) { return id },
+      peg$c327 = peg$literalExpectation("and", false),
+      peg$c328 = "seconds",
+      peg$c329 = peg$literalExpectation("seconds", false),
+      peg$c330 = "second",
+      peg$c331 = peg$literalExpectation("second", false),
+      peg$c332 = "secs",
+      peg$c333 = peg$literalExpectation("secs", false),
+      peg$c334 = "sec",
+      peg$c335 = peg$literalExpectation("sec", false),
+      peg$c336 = "s",
+      peg$c337 = peg$literalExpectation("s", false),
+      peg$c338 = "minutes",
+      peg$c339 = peg$literalExpectation("minutes", false),
+      peg$c340 = "minute",
+      peg$c341 = peg$literalExpectation("minute", false),
+      peg$c342 = "mins",
+      peg$c343 = peg$literalExpectation("mins", false),
+      peg$c344 = "min",
+      peg$c345 = peg$literalExpectation("min", false),
+      peg$c346 = "m",
+      peg$c347 = peg$literalExpectation("m", false),
+      peg$c348 = "hours",
+      peg$c349 = peg$literalExpectation("hours", false),
+      peg$c350 = "hrs",
+      peg$c351 = peg$literalExpectation("hrs", false),
+      peg$c352 = "hr",
+      peg$c353 = peg$literalExpectation("hr", false),
+      peg$c354 = "h",
+      peg$c355 = peg$literalExpectation("h", false),
+      peg$c356 = "hour",
+      peg$c357 = peg$literalExpectation("hour", false),
+      peg$c358 = "days",
+      peg$c359 = peg$literalExpectation("days", false),
+      peg$c360 = "day",
+      peg$c361 = peg$literalExpectation("day", false),
+      peg$c362 = "d",
+      peg$c363 = peg$literalExpectation("d", false),
+      peg$c364 = "weeks",
+      peg$c365 = peg$literalExpectation("weeks", false),
+      peg$c366 = "week",
+      peg$c367 = peg$literalExpectation("week", false),
+      peg$c368 = "wks",
+      peg$c369 = peg$literalExpectation("wks", false),
+      peg$c370 = "wk",
+      peg$c371 = peg$literalExpectation("wk", false),
+      peg$c372 = "w",
+      peg$c373 = peg$literalExpectation("w", false),
+      peg$c374 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c375 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c376 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c377 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c378 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c379 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c380 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c381 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c382 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c383 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c384 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c382 = "::",
-      peg$c383 = peg$literalExpectation("::", false),
-      peg$c384 = function(a, b, d, e) {
+      peg$c385 = "::",
+      peg$c386 = peg$literalExpectation("::", false),
+      peg$c387 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c385 = function(a, b) {
+      peg$c388 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c386 = function(a, b) {
+      peg$c389 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c387 = function() {
+      peg$c390 = function() {
             return "::"
           },
-      peg$c388 = function(v) { return ":" + v },
-      peg$c389 = function(v) { return v + ":" },
-      peg$c390 = function(a, m) {
+      peg$c391 = function(v) { return ":" + v },
+      peg$c392 = function(v) { return v + ":" },
+      peg$c393 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c391 = function(a, m) {
+      peg$c394 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c392 = function(s) { return parseInt(s) },
-      peg$c393 = function() {
+      peg$c395 = function(s) { return parseInt(s) },
+      peg$c396 = function() {
             return text()
           },
-      peg$c394 = "e",
-      peg$c395 = peg$literalExpectation("e", true),
-      peg$c396 = /^[+\-]/,
-      peg$c397 = peg$classExpectation(["+", "-"], false, false),
-      peg$c398 = /^[0-9a-fA-F]/,
-      peg$c399 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c400 = "\"",
-      peg$c401 = peg$literalExpectation("\"", false),
-      peg$c402 = function(v) { return joinChars(v) },
-      peg$c403 = "'",
-      peg$c404 = peg$literalExpectation("'", false),
-      peg$c405 = peg$anyExpectation(),
-      peg$c406 = function(s) { return s },
-      peg$c407 = function(head, tail) { return head + joinChars(tail) },
-      peg$c408 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c409 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c410 = "x",
-      peg$c411 = peg$literalExpectation("x", false),
-      peg$c412 = function() { return "\\" + text() },
-      peg$c413 = "b",
-      peg$c414 = peg$literalExpectation("b", false),
-      peg$c415 = function() { return "\b" },
-      peg$c416 = "f",
-      peg$c417 = peg$literalExpectation("f", false),
-      peg$c418 = function() { return "\f" },
-      peg$c419 = "n",
-      peg$c420 = peg$literalExpectation("n", false),
-      peg$c421 = function() { return "\n" },
-      peg$c422 = "r",
-      peg$c423 = peg$literalExpectation("r", false),
-      peg$c424 = function() { return "\r" },
-      peg$c425 = "t",
-      peg$c426 = peg$literalExpectation("t", false),
-      peg$c427 = function() { return "\t" },
-      peg$c428 = "v",
-      peg$c429 = peg$literalExpectation("v", false),
-      peg$c430 = function() { return "\v" },
-      peg$c431 = function() { return "=" },
-      peg$c432 = function() { return "\\*" },
-      peg$c433 = "u",
-      peg$c434 = peg$literalExpectation("u", false),
-      peg$c435 = function(chars) {
+      peg$c397 = "e",
+      peg$c398 = peg$literalExpectation("e", true),
+      peg$c399 = /^[+\-]/,
+      peg$c400 = peg$classExpectation(["+", "-"], false, false),
+      peg$c401 = /^[0-9a-fA-F]/,
+      peg$c402 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c403 = "\"",
+      peg$c404 = peg$literalExpectation("\"", false),
+      peg$c405 = function(v) { return joinChars(v) },
+      peg$c406 = "'",
+      peg$c407 = peg$literalExpectation("'", false),
+      peg$c408 = peg$anyExpectation(),
+      peg$c409 = function(s) { return s },
+      peg$c410 = function(head, tail) { return head + joinChars(tail) },
+      peg$c411 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c412 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c413 = "x",
+      peg$c414 = peg$literalExpectation("x", false),
+      peg$c415 = function() { return "\\" + text() },
+      peg$c416 = "b",
+      peg$c417 = peg$literalExpectation("b", false),
+      peg$c418 = function() { return "\b" },
+      peg$c419 = "f",
+      peg$c420 = peg$literalExpectation("f", false),
+      peg$c421 = function() { return "\f" },
+      peg$c422 = "n",
+      peg$c423 = peg$literalExpectation("n", false),
+      peg$c424 = function() { return "\n" },
+      peg$c425 = "r",
+      peg$c426 = peg$literalExpectation("r", false),
+      peg$c427 = function() { return "\r" },
+      peg$c428 = "t",
+      peg$c429 = peg$literalExpectation("t", false),
+      peg$c430 = function() { return "\t" },
+      peg$c431 = "v",
+      peg$c432 = peg$literalExpectation("v", false),
+      peg$c433 = function() { return "\v" },
+      peg$c434 = function() { return "=" },
+      peg$c435 = function() { return "\\*" },
+      peg$c436 = "u",
+      peg$c437 = peg$literalExpectation("u", false),
+      peg$c438 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c436 = function(body) { return body },
-      peg$c437 = /^[^\/\\]/,
-      peg$c438 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c439 = "\\/",
-      peg$c440 = peg$literalExpectation("\\/", false),
-      peg$c441 = /^[\0-\x1F\\]/,
-      peg$c442 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c443 = peg$otherExpectation("whitespace"),
-      peg$c444 = "\t",
-      peg$c445 = peg$literalExpectation("\t", false),
-      peg$c446 = "\x0B",
-      peg$c447 = peg$literalExpectation("\x0B", false),
-      peg$c448 = "\f",
-      peg$c449 = peg$literalExpectation("\f", false),
-      peg$c450 = " ",
-      peg$c451 = peg$literalExpectation(" ", false),
-      peg$c452 = "\xA0",
-      peg$c453 = peg$literalExpectation("\xA0", false),
-      peg$c454 = "\uFEFF",
-      peg$c455 = peg$literalExpectation("\uFEFF", false),
-      peg$c456 = /^[\n\r\u2028\u2029]/,
-      peg$c457 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c458 = peg$otherExpectation("comment"),
-      peg$c459 = "/*",
-      peg$c460 = peg$literalExpectation("/*", false),
-      peg$c461 = "*/",
-      peg$c462 = peg$literalExpectation("*/", false),
-      peg$c463 = "//",
-      peg$c464 = peg$literalExpectation("//", false),
+      peg$c439 = function(body) { return body },
+      peg$c440 = /^[^\/\\]/,
+      peg$c441 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c442 = "\\/",
+      peg$c443 = peg$literalExpectation("\\/", false),
+      peg$c444 = /^[\0-\x1F\\]/,
+      peg$c445 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c446 = peg$otherExpectation("whitespace"),
+      peg$c447 = "\t",
+      peg$c448 = peg$literalExpectation("\t", false),
+      peg$c449 = "\x0B",
+      peg$c450 = peg$literalExpectation("\x0B", false),
+      peg$c451 = "\f",
+      peg$c452 = peg$literalExpectation("\f", false),
+      peg$c453 = " ",
+      peg$c454 = peg$literalExpectation(" ", false),
+      peg$c455 = "\xA0",
+      peg$c456 = peg$literalExpectation("\xA0", false),
+      peg$c457 = "\uFEFF",
+      peg$c458 = peg$literalExpectation("\uFEFF", false),
+      peg$c459 = /^[\n\r\u2028\u2029]/,
+      peg$c460 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c461 = peg$otherExpectation("comment"),
+      peg$c462 = "/*",
+      peg$c463 = peg$literalExpectation("/*", false),
+      peg$c464 = "*/",
+      peg$c465 = peg$literalExpectation("*/", false),
+      peg$c466 = "//",
+      peg$c467 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1524,28 +1529,46 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSwitchBranch() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    s1 = peg$parseSearchBoolean();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      s2 = peg$parseCaseToken();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c20) {
-          s3 = peg$c20;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c21); }
-        }
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseSequential();
+            s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c23(s1, s5);
-              s0 = s1;
+              if (input.substr(peg$currPos, 2) === peg$c20) {
+                s6 = peg$c20;
+                peg$currPos += 2;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c21); }
+              }
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parse__();
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parseSequential();
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c23(s4, s8);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1566,6 +1589,54 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseDefaultToken();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse__();
+          if (s3 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c20) {
+              s4 = peg$c20;
+              peg$currPos += 2;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c21); }
+            }
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parse__();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parseSequential();
+                if (s6 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c24(s6);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
 
     return s0;
   }
@@ -1577,11 +1648,11 @@ function peg$parse(input, options) {
     s1 = peg$parseSwitchBranch();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseSwitchTail();
+      s3 = peg$parseSwitchBranch();
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parseSwitchTail();
+          s3 = peg$parseSwitchBranch();
         }
       } else {
         s2 = peg$FAILED;
@@ -1611,50 +1682,29 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSwitchTail() {
-    var s0, s1, s2, s3, s4;
+  function peg$parseCaseToken() {
+    var s0;
 
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseCaseToken();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseSwitchBranch();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c22(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c25) {
+      s0 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
     } else {
-      peg$currPos = s0;
       s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c26); }
     }
 
     return s0;
   }
 
-  function peg$parseCaseToken() {
+  function peg$parseDefaultToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c24) {
-      s0 = peg$c24;
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c27) {
+      s0 = input.substr(peg$currPos, 7);
+      peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
 
     return s0;
@@ -1664,22 +1714,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c26) {
-      s1 = peg$c26;
+    if (input.substr(peg$currPos, 5) === peg$c29) {
+      s1 = peg$c29;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c27); }
+      if (peg$silentFails === 0) { peg$fail(peg$c30); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -1699,15 +1749,15 @@ function peg$parse(input, options) {
                   s8 = peg$parse__();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c30;
+                      s9 = peg$c33;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c34); }
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c32(s7);
+                      s1 = peg$c35(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1747,53 +1797,41 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c33) {
-        s1 = peg$c33;
+      if (input.substr(peg$currPos, 6) === peg$c36) {
+        s1 = peg$c36;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c28;
+            s3 = peg$c31;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseCaseToken();
+              s5 = peg$parseSwitch();
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
-                  s7 = peg$parseSwitch();
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s7 = peg$c33;
+                    peg$currPos++;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
+                  }
                   if (s7 !== peg$FAILED) {
-                    s8 = peg$parse__();
-                    if (s8 !== peg$FAILED) {
-                      if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c30;
-                        peg$currPos++;
-                      } else {
-                        s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c31); }
-                      }
-                      if (s9 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c35(s7);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c38(s5);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1840,7 +1878,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c36(s1);
+              s1 = peg$c39(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1866,7 +1904,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c37(s1);
+                s1 = peg$c40(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1892,7 +1930,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c38(s1);
+                  s1 = peg$c41(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1934,11 +1972,11 @@ function peg$parse(input, options) {
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s2 = peg$c30;
+            s2 = peg$c33;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$parseEOF();
@@ -2002,19 +2040,19 @@ function peg$parse(input, options) {
           s2 = peg$parseMultiplicativeOperator();
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s2 = peg$c39;
+              s2 = peg$c42;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+              if (peg$silentFails === 0) { peg$fail(peg$c43); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s2 = peg$c28;
+                s2 = peg$c31;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                if (peg$silentFails === 0) { peg$fail(peg$c32); }
               }
             }
           }
@@ -2043,12 +2081,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseByToken();
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c41) {
-          s2 = peg$c41;
+        if (input.substr(peg$currPos, 5) === peg$c44) {
+          s2 = peg$c44;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c45); }
         }
       }
       if (s2 !== peg$FAILED) {
@@ -2073,11 +2111,11 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c43;
+          s2 = peg$c46;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -2109,7 +2147,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s1, s2);
+        s1 = peg$c48(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2136,7 +2174,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchAnd();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c46(s4);
+            s1 = peg$c49(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2192,7 +2230,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchFactor();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c47(s1, s7);
+              s4 = peg$c50(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2239,7 +2277,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchFactor();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c47(s1, s7);
+                s4 = peg$c50(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2260,7 +2298,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c48(s1, s2);
+        s1 = peg$c51(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2296,11 +2334,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c49;
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2320,7 +2358,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51(s2);
+        s1 = peg$c54(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2337,11 +2375,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c28;
+            s1 = peg$c31;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -2351,15 +2389,15 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c30;
+                    s5 = peg$c33;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c52(s3);
+                    s1 = peg$c55(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -2393,11 +2431,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c53;
+      s1 = peg$c56;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -2409,7 +2447,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c55(s3, s5);
+              s1 = peg$c58(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2455,7 +2493,7 @@ function peg$parse(input, options) {
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c56(s1, s3, s5);
+                  s1 = peg$c59(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2492,15 +2530,15 @@ function peg$parse(input, options) {
               s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 42) {
-                  s5 = peg$c53;
+                  s5 = peg$c56;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c57); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c57(s1);
+                  s1 = peg$c60(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2563,7 +2601,7 @@ function peg$parse(input, options) {
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c58(s2);
+                s1 = peg$c61(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2580,11 +2618,11 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 42) {
-              s1 = peg$c53;
+              s1 = peg$c56;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              if (peg$silentFails === 0) { peg$fail(peg$c57); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
@@ -2599,7 +2637,7 @@ function peg$parse(input, options) {
               }
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c59();
+                s1 = peg$c62();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2626,7 +2664,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKeyWord();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c60(s1);
+        s1 = peg$c63(s1);
       }
       s0 = s1;
     }
@@ -2643,7 +2681,7 @@ function peg$parse(input, options) {
       s1 = peg$parseSearchGlob();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c61(s1);
+        s1 = peg$c64(s1);
       }
       s0 = s1;
     }
@@ -2668,25 +2706,25 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = [];
       if (input.charCodeAt(peg$currPos) === 42) {
-        s3 = peg$c53;
+        s3 = peg$c56;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
         if (input.charCodeAt(peg$currPos) === 42) {
-          s3 = peg$c53;
+          s3 = peg$c56;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c65(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2709,7 +2747,7 @@ function peg$parse(input, options) {
       s2 = peg$parseKeyWord();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c63(s1, s2);
+        s1 = peg$c66(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2732,21 +2770,21 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     if (input.charCodeAt(peg$currPos) === 42) {
-      s2 = peg$c53;
+      s2 = peg$c56;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
         if (input.charCodeAt(peg$currPos) === 42) {
-          s2 = peg$c53;
+          s2 = peg$c56;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
       }
     } else {
@@ -2754,7 +2792,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -2776,12 +2814,15 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$parseCaseToken();
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c65) {
-                  s0 = peg$c65;
-                  peg$currPos += 5;
-                } else {
-                  s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c66); }
+                s0 = peg$parseDefaultToken();
+                if (s0 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 5) === peg$c68) {
+                    s0 = peg$c68;
+                    peg$currPos += 5;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                  }
                 }
               }
             }
@@ -2805,52 +2846,52 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c6); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c67) {
-        s1 = peg$c67;
+      if (input.substr(peg$currPos, 2) === peg$c70) {
+        s1 = peg$c70;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c69) {
-          s1 = peg$c69;
+        if (input.substr(peg$currPos, 2) === peg$c72) {
+          s1 = peg$c72;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c71) {
-            s1 = peg$c71;
+          if (input.substr(peg$currPos, 2) === peg$c74) {
+            s1 = peg$c74;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c72); }
+            if (peg$silentFails === 0) { peg$fail(peg$c75); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c73;
+              s1 = peg$c76;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c77); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c75) {
-                s1 = peg$c75;
+              if (input.substr(peg$currPos, 2) === peg$c78) {
+                s1 = peg$c78;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                if (peg$silentFails === 0) { peg$fail(peg$c79); }
               }
               if (s1 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 62) {
-                  s1 = peg$c77;
+                  s1 = peg$c80;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c81); }
                 }
               }
             }
@@ -2860,7 +2901,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -2884,7 +2925,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchExprAdd();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2914,7 +2955,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchExprAdd();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2935,7 +2976,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2966,7 +3007,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchExprMul();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2996,7 +3037,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchExprMul();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3017,7 +3058,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3048,7 +3089,7 @@ function peg$parse(input, options) {
             s7 = peg$parseSearchExprCast();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3078,7 +3119,7 @@ function peg$parse(input, options) {
               s7 = peg$parseSearchExprCast();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3099,7 +3140,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3122,11 +3163,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c39;
+          s3 = peg$c42;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3134,7 +3175,7 @@ function peg$parse(input, options) {
             s5 = peg$parseCastType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81(s1, s5);
+              s1 = peg$c84(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3181,7 +3222,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c45(s1, s2);
+            s1 = peg$c48(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3216,7 +3257,7 @@ function peg$parse(input, options) {
           s4 = peg$parseLimitArg();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c82(s2, s3, s4);
+            s1 = peg$c85(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3264,7 +3305,7 @@ function peg$parse(input, options) {
               s5 = peg$parseLimitArg();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c83(s2, s3, s4, s5);
+                s1 = peg$c86(s2, s3, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3295,12 +3336,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c84) {
-      s1 = peg$c84;
+    if (input.substr(peg$currPos, 9) === peg$c87) {
+      s1 = peg$c87;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3316,7 +3357,7 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$c86;
+      s0 = peg$c89;
     }
 
     return s0;
@@ -3326,12 +3367,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c90) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3341,7 +3382,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c89(s3);
+            s1 = peg$c92(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3361,10 +3402,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90();
+        s1 = peg$c93();
       }
       s0 = s1;
     }
@@ -3383,7 +3424,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c91(s3);
+          s1 = peg$c94(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3407,22 +3448,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c92) {
-        s2 = peg$c92;
+      if (input.substr(peg$currPos, 4) === peg$c95) {
+        s2 = peg$c95;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c93); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c94) {
-            s4 = peg$c94;
+          if (input.substr(peg$currPos, 6) === peg$c97) {
+            s4 = peg$c97;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c95); }
+            if (peg$silentFails === 0) { peg$fail(peg$c98); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3430,7 +3471,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c96(s6);
+                s1 = peg$c99(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3458,10 +3499,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c97();
+        s1 = peg$c100();
       }
       s0 = s1;
     }
@@ -3478,7 +3519,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1);
+        s1 = peg$c101(s1);
       }
       s0 = s1;
     }
@@ -3497,11 +3538,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3509,7 +3550,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c99(s1, s7);
+              s4 = peg$c102(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3533,11 +3574,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3545,7 +3586,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c99(s1, s7);
+                s4 = peg$c102(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3601,7 +3642,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c100(s1, s5);
+              s1 = peg$c103(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3628,7 +3669,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c101(s1);
+        s1 = peg$c104(s1);
       }
       s0 = s1;
     }
@@ -3656,11 +3697,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c28;
+            s4 = peg$c31;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -3673,11 +3714,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c30;
+                    s8 = peg$c33;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$currPos;
@@ -3686,11 +3727,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c102;
+                        s12 = peg$c105;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c106); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3717,7 +3758,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c104(s2, s6, s10);
+                        s1 = peg$c107(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3783,12 +3824,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c105) {
-        s2 = peg$c105;
+      if (input.substr(peg$currPos, 5) === peg$c108) {
+        s2 = peg$c108;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3796,7 +3837,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c52(s4);
+            s1 = peg$c55(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3829,11 +3870,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3864,11 +3905,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3896,7 +3937,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c107(s1, s2);
+        s1 = peg$c110(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3964,12 +4005,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c108) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c111) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c109); }
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -3980,7 +4021,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c110(s2, s5);
+            s4 = peg$c113(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3995,7 +4036,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c111(s2, s3);
+          s1 = peg$c114(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4024,7 +4065,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c37(s4);
+        s3 = peg$c40(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -4042,7 +4083,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c37(s4);
+          s3 = peg$c40(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4055,7 +4096,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c112(s1);
+      s1 = peg$c115(s1);
     }
     s0 = s1;
 
@@ -4066,55 +4107,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c113) {
-      s1 = peg$c113;
+    if (input.substr(peg$currPos, 2) === peg$c116) {
+      s1 = peg$c116;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      if (peg$silentFails === 0) { peg$fail(peg$c117); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c115();
+      s1 = peg$c118();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c116) {
-        s1 = peg$c116;
+      if (input.substr(peg$currPos, 6) === peg$c119) {
+        s1 = peg$c119;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c118) {
-            s4 = peg$c118;
+          if (input.substr(peg$currPos, 5) === peg$c121) {
+            s4 = peg$c121;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c119); }
+            if (peg$silentFails === 0) { peg$fail(peg$c122); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c120) {
-              s4 = peg$c120;
+            if (input.substr(peg$currPos, 4) === peg$c123) {
+              s4 = peg$c123;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c124); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c64();
+            s4 = peg$c67();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c122(s3);
+            s1 = peg$c125(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4137,12 +4178,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c123) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c126) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4151,7 +4192,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c125(s4);
+          s3 = peg$c128(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4168,12 +4209,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c126) {
-            s5 = peg$c126;
+          if (input.substr(peg$currPos, 6) === peg$c129) {
+            s5 = peg$c129;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4196,7 +4237,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c128(s2, s3, s6);
+              s5 = peg$c131(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4211,7 +4252,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c129(s2, s3, s4);
+            s1 = peg$c132(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4237,44 +4278,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c130) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c133) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c131); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c132(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsePickProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c133) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c134); }
@@ -4303,7 +4309,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseDropProc() {
+  function peg$parsePickProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -4317,10 +4323,45 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseFieldExprs();
+        s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c138(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDropProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFieldExprs();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c141(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4342,12 +4383,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4355,7 +4396,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c141(s3);
+          s1 = peg$c144(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4371,16 +4412,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c142();
+        s1 = peg$c145();
       }
       s0 = s1;
     }
@@ -4392,12 +4433,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c146) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c147); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4405,7 +4446,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145(s3);
+          s1 = peg$c148(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4421,16 +4462,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c146) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146();
+        s1 = peg$c149();
       }
       s0 = s1;
     }
@@ -4442,12 +4483,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c150) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4455,7 +4496,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149(s3);
+          s1 = peg$c152(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4480,7 +4521,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c38(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
 
@@ -4491,26 +4532,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c152) {
-          s3 = peg$c152;
+        if (input.substr(peg$currPos, 2) === peg$c155) {
+          s3 = peg$c155;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c153); }
+          if (peg$silentFails === 0) { peg$fail(peg$c156); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c154();
+          s1 = peg$c157();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4526,16 +4567,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c153) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c154); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c155();
+        s1 = peg$c158();
       }
       s0 = s1;
     }
@@ -4547,12 +4588,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c159) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4560,7 +4601,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c158(s3);
+          s1 = peg$c161(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4582,12 +4623,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c159) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c162) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c160); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4599,11 +4640,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c43;
+              s7 = peg$c46;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+              if (peg$silentFails === 0) { peg$fail(peg$c47); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -4611,7 +4652,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c161(s3, s9);
+                  s6 = peg$c164(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4635,11 +4676,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c43;
+                s7 = peg$c46;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                if (peg$silentFails === 0) { peg$fail(peg$c47); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -4647,7 +4688,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c161(s3, s9);
+                    s6 = peg$c164(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4668,7 +4709,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c162(s3, s4);
+            s1 = peg$c165(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4694,12 +4735,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c164); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4708,11 +4749,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s5 = peg$c28;
+          s5 = peg$c31;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -4734,7 +4775,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c165();
+        s1 = peg$c168();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4752,16 +4793,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c166) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c169) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      if (peg$silentFails === 0) { peg$fail(peg$c170); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c168();
+      s1 = peg$c171();
     }
     s0 = s1;
 
@@ -4774,12 +4815,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseJoinKind();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c169) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
         s2 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c170); }
+        if (peg$silentFails === 0) { peg$fail(peg$c173); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4820,7 +4861,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c171(s1, s4, s8, s9);
+                      s1 = peg$c174(s1, s4, s8, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4862,12 +4903,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parseJoinKind();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c169) {
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
           s2 = input.substr(peg$currPos, 4);
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4894,7 +4935,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c172(s1, s4, s5);
+                s1 = peg$c175(s1, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4925,18 +4966,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c173) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c176) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c174); }
+      if (peg$silentFails === 0) { peg$fail(peg$c177); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c175();
+        s1 = peg$c178();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4948,18 +4989,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c176) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c179) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c178();
+          s1 = peg$c181();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4971,18 +5012,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c179) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c182) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c180); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c181();
+            s1 = peg$c184();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4994,10 +5035,10 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$c86;
+          s1 = peg$c89;
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175();
+            s1 = peg$c178();
           }
           s0 = s1;
         }
@@ -5014,25 +5055,25 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c28;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c30;
+            s3 = peg$c33;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c52(s2);
+            s1 = peg$c55(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5055,18 +5096,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c182) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseTasteExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c184(s2);
+        s1 = peg$c187(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5089,7 +5130,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c185(s2);
+        s1 = peg$c188(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5101,10 +5142,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c186();
+        s1 = peg$c189();
       }
       s0 = s1;
     }
@@ -5123,11 +5164,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5158,11 +5199,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5190,7 +5231,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c187(s1, s2);
+        s1 = peg$c190(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5215,11 +5256,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5250,11 +5291,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5282,7 +5323,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c187(s1, s2);
+        s1 = peg$c190(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5317,7 +5358,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c188(s1, s5);
+              s1 = peg$c191(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5360,11 +5401,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c189;
+          s3 = peg$c192;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -5374,11 +5415,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c39;
+                  s7 = peg$c42;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c40); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c43); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -5386,7 +5427,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c191(s1, s5, s9);
+                      s1 = peg$c194(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5448,7 +5489,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5478,7 +5519,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5499,7 +5540,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5530,7 +5571,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5560,7 +5601,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5581,7 +5622,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5612,7 +5653,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c192(s1, s5, s7);
+              s4 = peg$c195(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5642,7 +5683,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c192(s1, s5, s7);
+                s4 = peg$c195(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5663,7 +5704,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5689,17 +5730,17 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c6); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c67) {
-        s1 = peg$c67;
+      if (input.substr(peg$currPos, 2) === peg$c70) {
+        s1 = peg$c70;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -5712,16 +5753,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c69) {
-        s1 = peg$c69;
+      if (input.substr(peg$currPos, 2) === peg$c72) {
+        s1 = peg$c72;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
       }
       s0 = s1;
     }
@@ -5746,7 +5787,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5776,7 +5817,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5797,7 +5838,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5815,43 +5856,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c71) {
-      s1 = peg$c71;
+    if (input.substr(peg$currPos, 2) === peg$c74) {
+      s1 = peg$c74;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
+      if (peg$silentFails === 0) { peg$fail(peg$c75); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c73;
+        s1 = peg$c76;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c75) {
-          s1 = peg$c75;
+        if (input.substr(peg$currPos, 2) === peg$c78) {
+          s1 = peg$c78;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c77;
+            s1 = peg$c80;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c81); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -5875,7 +5916,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5905,7 +5946,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5926,7 +5967,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5945,24 +5986,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c193;
+      s1 = peg$c196;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c197); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c195;
+        s1 = peg$c198;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -5986,7 +6027,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c79(s1, s5, s7);
+              s4 = peg$c82(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6016,7 +6057,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c79(s1, s5, s7);
+                s4 = peg$c82(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6037,7 +6078,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1, s2);
+        s1 = peg$c83(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6056,24 +6097,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c53;
+      s1 = peg$c56;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c197;
+        s1 = peg$c200;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -6085,11 +6126,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c49;
+      s1 = peg$c52;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6097,7 +6138,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c199(s3);
+          s1 = peg$c202(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6127,11 +6168,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c39;
+          s3 = peg$c42;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6139,7 +6180,7 @@ function peg$parse(input, options) {
             s5 = peg$parseCastType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81(s1, s5);
+              s1 = peg$c84(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6188,7 +6229,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c45(s1, s2);
+              s1 = peg$c48(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6220,11 +6261,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -6248,28 +6289,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c200) {
-      s0 = peg$c200;
+    if (input.substr(peg$currPos, 3) === peg$c203) {
+      s0 = peg$c203;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c201); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c202) {
-        s0 = peg$c202;
+      if (input.substr(peg$currPos, 5) === peg$c205) {
+        s0 = peg$c205;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c203); }
+        if (peg$silentFails === 0) { peg$fail(peg$c206); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c204) {
-          s0 = peg$c204;
+        if (input.substr(peg$currPos, 6) === peg$c207) {
+          s0 = peg$c207;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -6290,36 +6331,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c202) {
-      s1 = peg$c202;
+    if (input.substr(peg$currPos, 5) === peg$c205) {
+      s1 = peg$c205;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c203); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c30;
+              s5 = peg$c33;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c34); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c52(s4);
+              s1 = peg$c55(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6349,22 +6390,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c204) {
-      s1 = peg$c204;
+    if (input.substr(peg$currPos, 6) === peg$c207) {
+      s1 = peg$c207;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -6374,17 +6415,17 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c30;
+                  s7 = peg$c33;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c34); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parseMethods();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c206(s5, s8);
+                    s1 = peg$c209(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6438,15 +6479,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c207(s1);
+      s1 = peg$c210(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c86;
+      s1 = peg$c89;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90();
+        s1 = peg$c93();
       }
       s0 = s1;
     }
@@ -6461,11 +6502,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c102;
+        s2 = peg$c105;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6473,7 +6514,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFunction();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c36(s4);
+            s1 = peg$c39(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6515,11 +6556,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c28;
+            s4 = peg$c31;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -6529,15 +6570,15 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c30;
+                    s8 = peg$c33;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c208(s2, s6);
+                    s1 = peg$c211(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6586,11 +6627,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c43;
+          s5 = peg$c46;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -6598,7 +6639,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c209(s1, s7);
+              s4 = peg$c212(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6622,11 +6663,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c43;
+            s5 = peg$c46;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -6634,7 +6675,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c209(s1, s7);
+                s4 = peg$c212(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6670,7 +6711,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c210();
+        s1 = peg$c213();
       }
       s0 = s1;
     }
@@ -6692,7 +6733,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s1, s2);
+        s1 = peg$c48(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6714,7 +6755,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c45(s1, s2);
+          s1 = peg$c48(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6727,15 +6768,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s1 = peg$c102;
+          s1 = peg$c105;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c106); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c211();
+          s1 = peg$c214();
         }
         s0 = s1;
       }
@@ -6749,17 +6790,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c102;
+      s1 = peg$c105;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c103); }
+      if (peg$silentFails === 0) { peg$fail(peg$c106); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c212(s2);
+        s1 = peg$c215(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6772,33 +6813,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c102;
+        s1 = peg$c105;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c213;
+          s2 = peg$c216;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+          if (peg$silentFails === 0) { peg$fail(peg$c217); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c215;
+              s4 = peg$c218;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c216); }
+              if (peg$silentFails === 0) { peg$fail(peg$c219); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c217(s3);
+              s1 = peg$c220(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6826,11 +6867,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c213;
+      s1 = peg$c216;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -6838,11 +6879,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c39;
+            s4 = peg$c42;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c40); }
+            if (peg$silentFails === 0) { peg$fail(peg$c43); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -6850,15 +6891,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c215;
+                  s7 = peg$c218;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c219); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c218(s2, s6);
+                  s1 = peg$c221(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6891,21 +6932,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c213;
+        s1 = peg$c216;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c214); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c39;
+            s3 = peg$c42;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c40); }
+            if (peg$silentFails === 0) { peg$fail(peg$c43); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -6913,15 +6954,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c215;
+                  s6 = peg$c218;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c219); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c219(s5);
+                  s1 = peg$c222(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6950,11 +6991,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c213;
+          s1 = peg$c216;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+          if (peg$silentFails === 0) { peg$fail(peg$c217); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -6962,25 +7003,25 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c39;
+                s4 = peg$c42;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c40); }
+                if (peg$silentFails === 0) { peg$fail(peg$c43); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c215;
+                    s6 = peg$c218;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c219); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c220(s2);
+                    s1 = peg$c223(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7009,25 +7050,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c213;
+            s1 = peg$c216;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c214); }
+            if (peg$silentFails === 0) { peg$fail(peg$c217); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c215;
+                s3 = peg$c218;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                if (peg$silentFails === 0) { peg$fail(peg$c219); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c221(s2);
+                s1 = peg$c224(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7044,21 +7085,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c102;
+              s1 = peg$c105;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c103); }
+              if (peg$silentFails === 0) { peg$fail(peg$c106); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c102;
+                s3 = peg$c105;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -7071,7 +7112,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c222(s3);
+                  s1 = peg$c225(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7100,11 +7141,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c28;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7114,15 +7155,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c30;
+                s5 = peg$c33;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                if (peg$silentFails === 0) { peg$fail(peg$c34); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c52(s3);
+                s1 = peg$c55(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7188,7 +7229,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c60(s1);
+      s1 = peg$c63(s1);
     }
     s0 = s1;
 
@@ -7213,7 +7254,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223(s1);
+        s1 = peg$c226(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7245,7 +7286,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s1);
+        s1 = peg$c227(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7260,7 +7301,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s1);
+        s1 = peg$c227(s1);
       }
       s0 = s1;
     }
@@ -7286,7 +7327,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c225(s1);
+        s1 = peg$c228(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7301,7 +7342,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c225(s1);
+        s1 = peg$c228(s1);
       }
       s0 = s1;
     }
@@ -7316,7 +7357,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c226(s1);
+      s1 = peg$c229(s1);
     }
     s0 = s1;
 
@@ -7330,7 +7371,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c227(s1);
+      s1 = peg$c230(s1);
     }
     s0 = s1;
 
@@ -7341,30 +7382,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c228) {
-      s1 = peg$c228;
+    if (input.substr(peg$currPos, 4) === peg$c231) {
+      s1 = peg$c231;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c230();
+      s1 = peg$c233();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c231) {
-        s1 = peg$c231;
+      if (input.substr(peg$currPos, 5) === peg$c234) {
+        s1 = peg$c234;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c232); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233();
+        s1 = peg$c236();
       }
       s0 = s1;
     }
@@ -7376,16 +7417,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c234) {
-      s1 = peg$c234;
+    if (input.substr(peg$currPos, 4) === peg$c237) {
+      s1 = peg$c237;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c236();
+      s1 = peg$c239();
     }
     s0 = s1;
 
@@ -7399,7 +7440,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeExternal();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c237(s1);
+      s1 = peg$c240(s1);
     }
     s0 = s1;
 
@@ -7432,11 +7473,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c28;
+          s3 = peg$c31;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -7446,15 +7487,15 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c30;
+                  s7 = peg$c33;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c34); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c238(s5);
+                  s1 = peg$c241(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7497,11 +7538,11 @@ function peg$parse(input, options) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c28;
+            s3 = peg$c31;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
@@ -7511,15 +7552,15 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s7 = peg$c30;
+                    s7 = peg$c33;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c239(s5);
+                    s1 = peg$c242(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7567,7 +7608,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c239(s1);
+              s1 = peg$c242(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7599,16 +7640,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c234) {
-      s1 = peg$c234;
+    if (input.substr(peg$currPos, 4) === peg$c237) {
+      s1 = peg$c237;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c243();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7630,11 +7671,11 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s5 = peg$c28;
+                  s5 = peg$c31;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c32); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse__();
@@ -7644,15 +7685,15 @@ function peg$parse(input, options) {
                       s8 = peg$parse__();
                       if (s8 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 41) {
-                          s9 = peg$c30;
+                          s9 = peg$c33;
                           peg$currPos++;
                         } else {
                           s9 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c34); }
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c241(s1, s7);
+                          s1 = peg$c244(s1, s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7695,17 +7736,17 @@ function peg$parse(input, options) {
           s1 = peg$parseIdentifierName();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c242(s1);
+            s1 = peg$c245(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 40) {
-              s1 = peg$c28;
+              s1 = peg$c31;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c29); }
+              if (peg$silentFails === 0) { peg$fail(peg$c32); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parse__();
@@ -7713,15 +7754,15 @@ function peg$parse(input, options) {
                 s3 = peg$parseTypeUnion();
                 if (s3 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s4 = peg$c30;
+                    s4 = peg$c33;
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
                   }
                   if (s4 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c243(s3);
+                    s1 = peg$c246(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7754,7 +7795,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c244(s1);
+      s1 = peg$c247(s1);
     }
     s0 = s1;
 
@@ -7779,7 +7820,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245(s1, s2);
+        s1 = peg$c248(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7800,11 +7841,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c43;
+        s2 = peg$c46;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7812,7 +7853,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c239(s4);
+            s1 = peg$c242(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7839,11 +7880,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c246;
+      s1 = peg$c249;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7853,15 +7894,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c248;
+              s5 = peg$c251;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c252); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c250(s3);
+              s1 = peg$c253(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7886,11 +7927,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c213;
+        s1 = peg$c216;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c214); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7900,15 +7941,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c215;
+                s5 = peg$c218;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                if (peg$silentFails === 0) { peg$fail(peg$c219); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c251(s3);
+                s1 = peg$c254(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7932,12 +7973,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c252) {
-          s1 = peg$c252;
+        if (input.substr(peg$currPos, 2) === peg$c255) {
+          s1 = peg$c255;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+          if (peg$silentFails === 0) { peg$fail(peg$c256); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -7946,16 +7987,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c254) {
-                  s5 = peg$c254;
+                if (input.substr(peg$currPos, 2) === peg$c257) {
+                  s5 = peg$c257;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c255); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c258); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c256(s3);
+                  s1 = peg$c259(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7979,12 +8020,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c257) {
-            s1 = peg$c257;
+          if (input.substr(peg$currPos, 2) === peg$c260) {
+            s1 = peg$c260;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c258); }
+            if (peg$silentFails === 0) { peg$fail(peg$c261); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -7994,11 +8035,11 @@ function peg$parse(input, options) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s5 = peg$c43;
+                    s5 = peg$c46;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c47); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse__();
@@ -8007,16 +8048,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c259) {
-                            s9 = peg$c259;
+                          if (input.substr(peg$currPos, 2) === peg$c262) {
+                            s9 = peg$c262;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c260); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c263); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c261(s3, s7);
+                            s1 = peg$c264(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8076,92 +8117,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c262) {
-      s1 = peg$c262;
+    if (input.substr(peg$currPos, 5) === peg$c265) {
+      s1 = peg$c265;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c264) {
-        s1 = peg$c264;
+      if (input.substr(peg$currPos, 6) === peg$c267) {
+        s1 = peg$c267;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c266) {
-          s1 = peg$c266;
+        if (input.substr(peg$currPos, 6) === peg$c269) {
+          s1 = peg$c269;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c267); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c268) {
-            s1 = peg$c268;
+          if (input.substr(peg$currPos, 6) === peg$c271) {
+            s1 = peg$c271;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c270) {
-              s1 = peg$c270;
+            if (input.substr(peg$currPos, 4) === peg$c273) {
+              s1 = peg$c273;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c271); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c272) {
-                s1 = peg$c272;
+              if (input.substr(peg$currPos, 5) === peg$c275) {
+                s1 = peg$c275;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c273); }
+                if (peg$silentFails === 0) { peg$fail(peg$c276); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c274) {
-                  s1 = peg$c274;
+                if (input.substr(peg$currPos, 5) === peg$c277) {
+                  s1 = peg$c277;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c275); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c278); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c276) {
-                    s1 = peg$c276;
+                  if (input.substr(peg$currPos, 5) === peg$c279) {
+                    s1 = peg$c279;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c277); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c280); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c278) {
-                      s1 = peg$c278;
+                    if (input.substr(peg$currPos, 7) === peg$c281) {
+                      s1 = peg$c281;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c282); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c280) {
-                        s1 = peg$c280;
+                      if (input.substr(peg$currPos, 4) === peg$c283) {
+                        s1 = peg$c283;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c284); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c282) {
-                          s1 = peg$c282;
+                        if (input.substr(peg$currPos, 6) === peg$c285) {
+                          s1 = peg$c285;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c286); }
                         }
                       }
                     }
@@ -8175,7 +8216,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c284();
+      s1 = peg$c287();
     }
     s0 = s1;
 
@@ -8186,52 +8227,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c285) {
-      s1 = peg$c285;
+    if (input.substr(peg$currPos, 8) === peg$c288) {
+      s1 = peg$c288;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c289); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c287) {
-        s1 = peg$c287;
+      if (input.substr(peg$currPos, 4) === peg$c290) {
+        s1 = peg$c290;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c291); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c289) {
-          s1 = peg$c289;
+        if (input.substr(peg$currPos, 5) === peg$c292) {
+          s1 = peg$c292;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+          if (peg$silentFails === 0) { peg$fail(peg$c293); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c291) {
-            s1 = peg$c291;
+          if (input.substr(peg$currPos, 7) === peg$c294) {
+            s1 = peg$c294;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c292); }
+            if (peg$silentFails === 0) { peg$fail(peg$c295); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c293) {
-              s1 = peg$c293;
+            if (input.substr(peg$currPos, 2) === peg$c296) {
+              s1 = peg$c296;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c294); }
+              if (peg$silentFails === 0) { peg$fail(peg$c297); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c295) {
-                s1 = peg$c295;
+              if (input.substr(peg$currPos, 3) === peg$c298) {
+                s1 = peg$c298;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c296); }
+                if (peg$silentFails === 0) { peg$fail(peg$c299); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -8242,12 +8283,12 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c297) {
-                    s1 = peg$c297;
+                  if (input.substr(peg$currPos, 5) === peg$c300) {
+                    s1 = peg$c300;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c301); }
                   }
                 }
               }
@@ -8258,7 +8299,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c284();
+      s1 = peg$c287();
     }
     s0 = s1;
 
@@ -8279,7 +8320,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245(s1, s2);
+        s1 = peg$c248(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8300,11 +8341,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 44) {
-        s2 = peg$c43;
+        s2 = peg$c46;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -8312,7 +8353,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c239(s4);
+            s1 = peg$c242(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8343,11 +8384,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c39;
+          s3 = peg$c42;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -8355,7 +8396,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c299(s1, s5);
+              s1 = peg$c302(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8396,29 +8437,9 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c300) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c303) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c302();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c303) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c304); }
@@ -8432,20 +8453,40 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseInToken() {
+  function peg$parseOrToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c69) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c306) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c306); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c307();
+      s1 = peg$c308();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseInToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c72) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c310();
     }
     s0 = s1;
 
@@ -8456,29 +8497,9 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c200) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c203) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c308); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c309();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseByToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c310) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c311); }
@@ -8492,15 +8513,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseByToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c313) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c315();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c313.test(input.charAt(peg$currPos))) {
+    if (peg$c316.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
 
     return s0;
@@ -8511,12 +8552,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c315.test(input.charAt(peg$currPos))) {
+      if (peg$c318.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c316); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
     }
 
@@ -8530,7 +8571,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c317(s1);
+      s1 = peg$c320(s1);
     }
     s0 = s1;
 
@@ -8585,7 +8626,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c318();
+          s1 = peg$c321();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8602,31 +8643,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c319;
+        s1 = peg$c322;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c321;
+          s1 = peg$c324;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c323(s2);
+            s1 = peg$c326(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8647,7 +8688,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c64();
+            s1 = peg$c67();
           }
           s0 = s1;
         }
@@ -8688,12 +8729,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c300) {
-                s3 = peg$c300;
+              if (input.substr(peg$currPos, 3) === peg$c303) {
+                s3 = peg$c303;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                if (peg$silentFails === 0) { peg$fail(peg$c327); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -8738,44 +8779,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c325) {
-      s0 = peg$c325;
+    if (input.substr(peg$currPos, 7) === peg$c328) {
+      s0 = peg$c328;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+      if (peg$silentFails === 0) { peg$fail(peg$c329); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c327) {
-        s0 = peg$c327;
+      if (input.substr(peg$currPos, 6) === peg$c330) {
+        s0 = peg$c330;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c331); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c329) {
-          s0 = peg$c329;
+        if (input.substr(peg$currPos, 4) === peg$c332) {
+          s0 = peg$c332;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c330); }
+          if (peg$silentFails === 0) { peg$fail(peg$c333); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c331) {
-            s0 = peg$c331;
+          if (input.substr(peg$currPos, 3) === peg$c334) {
+            s0 = peg$c334;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c332); }
+            if (peg$silentFails === 0) { peg$fail(peg$c335); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c333;
+              s0 = peg$c336;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c334); }
+              if (peg$silentFails === 0) { peg$fail(peg$c337); }
             }
           }
         }
@@ -8788,44 +8829,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c335) {
-      s0 = peg$c335;
+    if (input.substr(peg$currPos, 7) === peg$c338) {
+      s0 = peg$c338;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c337) {
-        s0 = peg$c337;
+      if (input.substr(peg$currPos, 6) === peg$c340) {
+        s0 = peg$c340;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c338); }
+        if (peg$silentFails === 0) { peg$fail(peg$c341); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c339) {
-          s0 = peg$c339;
+        if (input.substr(peg$currPos, 4) === peg$c342) {
+          s0 = peg$c342;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c340); }
+          if (peg$silentFails === 0) { peg$fail(peg$c343); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c341) {
-            s0 = peg$c341;
+          if (input.substr(peg$currPos, 3) === peg$c344) {
+            s0 = peg$c344;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c342); }
+            if (peg$silentFails === 0) { peg$fail(peg$c345); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c343;
+              s0 = peg$c346;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c347); }
             }
           }
         }
@@ -8838,44 +8879,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c345) {
-      s0 = peg$c345;
+    if (input.substr(peg$currPos, 5) === peg$c348) {
+      s0 = peg$c348;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c347) {
-        s0 = peg$c347;
+      if (input.substr(peg$currPos, 3) === peg$c350) {
+        s0 = peg$c350;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c348); }
+        if (peg$silentFails === 0) { peg$fail(peg$c351); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c349) {
-          s0 = peg$c349;
+        if (input.substr(peg$currPos, 2) === peg$c352) {
+          s0 = peg$c352;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c350); }
+          if (peg$silentFails === 0) { peg$fail(peg$c353); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c351;
+            s0 = peg$c354;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c352); }
+            if (peg$silentFails === 0) { peg$fail(peg$c355); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c353) {
-              s0 = peg$c353;
+            if (input.substr(peg$currPos, 4) === peg$c356) {
+              s0 = peg$c356;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c354); }
+              if (peg$silentFails === 0) { peg$fail(peg$c357); }
             }
           }
         }
@@ -8888,28 +8929,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c355) {
-      s0 = peg$c355;
+    if (input.substr(peg$currPos, 4) === peg$c358) {
+      s0 = peg$c358;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c357) {
-        s0 = peg$c357;
+      if (input.substr(peg$currPos, 3) === peg$c360) {
+        s0 = peg$c360;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c358); }
+        if (peg$silentFails === 0) { peg$fail(peg$c361); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c359;
+          s0 = peg$c362;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          if (peg$silentFails === 0) { peg$fail(peg$c363); }
         }
       }
     }
@@ -8920,44 +8961,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c361) {
-      s0 = peg$c361;
+    if (input.substr(peg$currPos, 5) === peg$c364) {
+      s0 = peg$c364;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c362); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c363) {
-        s0 = peg$c363;
+      if (input.substr(peg$currPos, 4) === peg$c366) {
+        s0 = peg$c366;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c364); }
+        if (peg$silentFails === 0) { peg$fail(peg$c367); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c365) {
-          s0 = peg$c365;
+        if (input.substr(peg$currPos, 3) === peg$c368) {
+          s0 = peg$c368;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c366); }
+          if (peg$silentFails === 0) { peg$fail(peg$c369); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c367) {
-            s0 = peg$c367;
+          if (input.substr(peg$currPos, 2) === peg$c370) {
+            s0 = peg$c370;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c368); }
+            if (peg$silentFails === 0) { peg$fail(peg$c371); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c369;
+              s0 = peg$c372;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c370); }
+              if (peg$silentFails === 0) { peg$fail(peg$c373); }
             }
           }
         }
@@ -8971,16 +9012,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c327) {
-      s1 = peg$c327;
+    if (input.substr(peg$currPos, 6) === peg$c330) {
+      s1 = peg$c330;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c331); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371();
+      s1 = peg$c374();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8992,7 +9033,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c372(s1);
+            s1 = peg$c375(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9015,16 +9056,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c337) {
-      s1 = peg$c337;
+    if (input.substr(peg$currPos, 6) === peg$c340) {
+      s1 = peg$c340;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c373();
+      s1 = peg$c376();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9036,7 +9077,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c374(s1);
+            s1 = peg$c377(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9059,16 +9100,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c353) {
-      s1 = peg$c353;
+    if (input.substr(peg$currPos, 4) === peg$c356) {
+      s1 = peg$c356;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375();
+      s1 = peg$c378();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9080,7 +9121,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c376(s1);
+            s1 = peg$c379(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9103,16 +9144,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c357) {
-      s1 = peg$c357;
+    if (input.substr(peg$currPos, 3) === peg$c360) {
+      s1 = peg$c360;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377();
+      s1 = peg$c380();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9124,7 +9165,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c378(s1);
+            s1 = peg$c381(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9147,16 +9188,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c363) {
-      s1 = peg$c363;
+    if (input.substr(peg$currPos, 4) === peg$c366) {
+      s1 = peg$c366;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379();
+      s1 = peg$c382();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9168,7 +9209,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c380(s1);
+            s1 = peg$c383(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9194,37 +9235,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c102;
+        s2 = peg$c105;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c102;
+            s4 = peg$c105;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c103); }
+            if (peg$silentFails === 0) { peg$fail(peg$c106); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c102;
+                s6 = peg$c105;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c64();
+                  s1 = peg$c67();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9268,11 +9309,11 @@ function peg$parse(input, options) {
     s3 = peg$parseHex();
     if (s3 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s4 = peg$c39;
+        s4 = peg$c42;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parseHex();
@@ -9282,11 +9323,11 @@ function peg$parse(input, options) {
           s7 = peg$parseHexDigit();
           if (s7 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s7 = peg$c39;
+              s7 = peg$c42;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+              if (peg$silentFails === 0) { peg$fail(peg$c43); }
             }
           }
           peg$silentFails--;
@@ -9358,7 +9399,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c381(s1, s2);
+        s1 = peg$c384(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9379,12 +9420,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c382) {
-            s3 = peg$c382;
+          if (input.substr(peg$currPos, 2) === peg$c385) {
+            s3 = peg$c385;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c383); }
+            if (peg$silentFails === 0) { peg$fail(peg$c386); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -9397,7 +9438,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c384(s1, s2, s4, s5);
+                s1 = peg$c387(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9421,12 +9462,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c382) {
-          s1 = peg$c382;
+        if (input.substr(peg$currPos, 2) === peg$c385) {
+          s1 = peg$c385;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c383); }
+          if (peg$silentFails === 0) { peg$fail(peg$c386); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -9439,7 +9480,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c385(s2, s3);
+              s1 = peg$c388(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9464,16 +9505,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c382) {
-                s3 = peg$c382;
+              if (input.substr(peg$currPos, 2) === peg$c385) {
+                s3 = peg$c385;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                if (peg$silentFails === 0) { peg$fail(peg$c386); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c386(s1, s2);
+                s1 = peg$c389(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9489,16 +9530,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c382) {
-              s1 = peg$c382;
+            if (input.substr(peg$currPos, 2) === peg$c385) {
+              s1 = peg$c385;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c383); }
+              if (peg$silentFails === 0) { peg$fail(peg$c386); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c387();
+              s1 = peg$c390();
             }
             s0 = s1;
           }
@@ -9525,17 +9566,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c39;
+      s1 = peg$c42;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c40); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s2);
+        s1 = peg$c391(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9556,15 +9597,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c39;
+        s2 = peg$c42;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c389(s1);
+        s1 = peg$c392(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9585,17 +9626,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c197;
+        s2 = peg$c200;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c390(s1, s3);
+          s1 = peg$c393(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9620,17 +9661,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c197;
+        s2 = peg$c200;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s1, s3);
+          s1 = peg$c394(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9655,7 +9696,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c392(s1);
+      s1 = peg$c395(s1);
     }
     s0 = s1;
 
@@ -9678,22 +9719,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c315.test(input.charAt(peg$currPos))) {
+    if (peg$c318.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c315.test(input.charAt(peg$currPos))) {
+        if (peg$c318.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c316); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
       }
     } else {
@@ -9701,7 +9742,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -9713,17 +9754,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9742,33 +9783,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c315.test(input.charAt(peg$currPos))) {
+      if (peg$c318.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c316); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c315.test(input.charAt(peg$currPos))) {
+          if (peg$c318.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c316); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
         }
       } else {
@@ -9776,30 +9817,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c102;
+          s3 = peg$c105;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c106); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c315.test(input.charAt(peg$currPos))) {
+          if (peg$c318.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c316); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c315.test(input.charAt(peg$currPos))) {
+              if (peg$c318.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
             }
           } else {
@@ -9812,7 +9853,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c393();
+              s1 = peg$c396();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9837,41 +9878,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c195;
+        s1 = peg$c198;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c102;
+          s2 = peg$c105;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c103); }
+          if (peg$silentFails === 0) { peg$fail(peg$c106); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c315.test(input.charAt(peg$currPos))) {
+          if (peg$c318.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c316); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c315.test(input.charAt(peg$currPos))) {
+              if (peg$c318.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
             }
           } else {
@@ -9884,7 +9925,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c393();
+              s1 = peg$c396();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9911,20 +9952,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c394) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c397) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c398); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c396.test(input.charAt(peg$currPos))) {
+      if (peg$c399.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c397); }
+        if (peg$silentFails === 0) { peg$fail(peg$c400); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -9966,7 +10007,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -9976,12 +10017,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c398.test(input.charAt(peg$currPos))) {
+    if (peg$c401.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c399); }
+      if (peg$silentFails === 0) { peg$fail(peg$c402); }
     }
 
     return s0;
@@ -9992,11 +10033,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10007,15 +10048,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c403;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c402(s2);
+          s1 = peg$c405(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10032,11 +10073,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c403;
+        s1 = peg$c406;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c404); }
+        if (peg$silentFails === 0) { peg$fail(peg$c407); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -10047,15 +10088,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c403;
+            s3 = peg$c406;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c404); }
+            if (peg$silentFails === 0) { peg$fail(peg$c407); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c402(s2);
+            s1 = peg$c405(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10081,11 +10122,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c400;
+      s2 = peg$c403;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10103,11 +10144,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10120,17 +10161,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c321;
+        s1 = peg$c324;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c406(s2);
+          s1 = peg$c409(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10159,7 +10200,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c407(s1, s2);
+        s1 = peg$c410(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10177,16 +10218,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c408.test(input.charAt(peg$currPos))) {
+    if (peg$c411.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c412); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -10201,12 +10242,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c315.test(input.charAt(peg$currPos))) {
+      if (peg$c318.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c316); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
     }
 
@@ -10218,11 +10259,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c321;
+      s1 = peg$c324;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -10231,7 +10272,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c406(s2);
+        s1 = peg$c409(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10252,11 +10293,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c403;
+      s2 = peg$c406;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c407); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10274,11 +10315,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64();
+        s1 = peg$c67();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10291,17 +10332,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c321;
+        s1 = peg$c324;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c406(s2);
+          s1 = peg$c409(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10321,11 +10362,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c410;
+      s1 = peg$c413;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c414); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -10333,7 +10374,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c412();
+          s1 = peg$c415();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10361,110 +10402,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c403;
+      s0 = peg$c406;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c407); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c400;
+        s0 = peg$c403;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c401); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c321;
+          s0 = peg$c324;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c413;
+            s1 = peg$c416;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c414); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c415();
+            s1 = peg$c418();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c416;
+              s1 = peg$c419;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c417); }
+              if (peg$silentFails === 0) { peg$fail(peg$c420); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c418();
+              s1 = peg$c421();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c419;
+                s1 = peg$c422;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c421();
+                s1 = peg$c424();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c422;
+                  s1 = peg$c425;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c424();
+                  s1 = peg$c427();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c425;
+                    s1 = peg$c428;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c429); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c427();
+                    s1 = peg$c430();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c428;
+                      s1 = peg$c431;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c432); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c430();
+                      s1 = peg$c433();
                     }
                     s0 = s1;
                   }
@@ -10492,30 +10533,30 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c431();
+      s1 = peg$c434();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c53;
+        s1 = peg$c56;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c432();
+        s1 = peg$c435();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c396.test(input.charAt(peg$currPos))) {
+        if (peg$c399.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c397); }
+          if (peg$silentFails === 0) { peg$fail(peg$c400); }
         }
       }
     }
@@ -10528,11 +10569,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c433;
+      s1 = peg$c436;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c434); }
+      if (peg$silentFails === 0) { peg$fail(peg$c437); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -10564,7 +10605,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c435(s2);
+        s1 = peg$c438(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10577,19 +10618,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c433;
+        s1 = peg$c436;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+        if (peg$silentFails === 0) { peg$fail(peg$c437); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c246;
+          s2 = peg$c249;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+          if (peg$silentFails === 0) { peg$fail(peg$c250); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -10648,15 +10689,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c248;
+              s4 = peg$c251;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c252); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c435(s3);
+              s1 = peg$c438(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10684,25 +10725,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c197;
+      s1 = peg$c200;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c201); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c197;
+          s3 = peg$c200;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c201); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c436(s2);
+          s1 = peg$c439(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10725,39 +10766,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c437.test(input.charAt(peg$currPos))) {
+    if (peg$c440.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c438); }
+      if (peg$silentFails === 0) { peg$fail(peg$c441); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c439) {
-        s2 = peg$c439;
+      if (input.substr(peg$currPos, 2) === peg$c442) {
+        s2 = peg$c442;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c440); }
+        if (peg$silentFails === 0) { peg$fail(peg$c443); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c437.test(input.charAt(peg$currPos))) {
+        if (peg$c440.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c438); }
+          if (peg$silentFails === 0) { peg$fail(peg$c441); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c439) {
-            s2 = peg$c439;
+          if (input.substr(peg$currPos, 2) === peg$c442) {
+            s2 = peg$c442;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c440); }
+            if (peg$silentFails === 0) { peg$fail(peg$c443); }
           }
         }
       }
@@ -10766,7 +10807,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c64();
+      s1 = peg$c67();
     }
     s0 = s1;
 
@@ -10776,12 +10817,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c441.test(input.charAt(peg$currPos))) {
+    if (peg$c444.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+      if (peg$silentFails === 0) { peg$fail(peg$c445); }
     }
 
     return s0;
@@ -10839,7 +10880,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
 
     return s0;
@@ -10850,51 +10891,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c444;
+      s0 = peg$c447;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c445); }
+      if (peg$silentFails === 0) { peg$fail(peg$c448); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c446;
+        s0 = peg$c449;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c447); }
+        if (peg$silentFails === 0) { peg$fail(peg$c450); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c448;
+          s0 = peg$c451;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c449); }
+          if (peg$silentFails === 0) { peg$fail(peg$c452); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c450;
+            s0 = peg$c453;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c451); }
+            if (peg$silentFails === 0) { peg$fail(peg$c454); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c452;
+              s0 = peg$c455;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c453); }
+              if (peg$silentFails === 0) { peg$fail(peg$c456); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c454;
+                s0 = peg$c457;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c455); }
+                if (peg$silentFails === 0) { peg$fail(peg$c458); }
               }
             }
           }
@@ -10904,7 +10945,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+      if (peg$silentFails === 0) { peg$fail(peg$c446); }
     }
 
     return s0;
@@ -10913,12 +10954,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c456.test(input.charAt(peg$currPos))) {
+    if (peg$c459.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c457); }
+      if (peg$silentFails === 0) { peg$fail(peg$c460); }
     }
 
     return s0;
@@ -10932,7 +10973,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
 
     return s0;
@@ -10942,24 +10983,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c459) {
-      s1 = peg$c459;
+    if (input.substr(peg$currPos, 2) === peg$c462) {
+      s1 = peg$c462;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c460); }
+      if (peg$silentFails === 0) { peg$fail(peg$c463); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c461) {
-        s5 = peg$c461;
+      if (input.substr(peg$currPos, 2) === peg$c464) {
+        s5 = peg$c464;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c462); }
+        if (peg$silentFails === 0) { peg$fail(peg$c465); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -10986,12 +11027,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c461) {
-          s5 = peg$c461;
+        if (input.substr(peg$currPos, 2) === peg$c464) {
+          s5 = peg$c464;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c462); }
+          if (peg$silentFails === 0) { peg$fail(peg$c465); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -11015,12 +11056,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c461) {
-          s3 = peg$c461;
+        if (input.substr(peg$currPos, 2) === peg$c464) {
+          s3 = peg$c464;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c462); }
+          if (peg$silentFails === 0) { peg$fail(peg$c465); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -11045,12 +11086,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c463) {
-      s1 = peg$c463;
+    if (input.substr(peg$currPos, 2) === peg$c466) {
+      s1 = peg$c466;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11168,7 +11209,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -92,30 +92,30 @@ Parallel
 ParallelTail
   = __ "=>" __ ch:Sequential { RETURN(ch) }
 
-
 SwitchBranch
-  = filter:SearchBoolean __ "=>" __ proc:Sequential {
-    RETURN(MAP("filter": filter, "proc": proc))
-  }
+  = __ CaseToken _ filter:SearchBoolean __ "=>" __ proc:Sequential {
+      RETURN(MAP("filter": filter, "proc": proc))
+    }
+  / __ DefaultToken __ "=>" __ proc:Sequential {
+      RETURN(MAP("filter": MAP("op": "Literal", "type": "bool", "value": "true"), "proc": proc))
+    }
 
 Switch
-  = first:SwitchBranch rest:SwitchTail+ {
+  = first:SwitchBranch rest:SwitchBranch+ {
       RETURN(PREPEND(first, rest))
     }
   / first:SwitchBranch {
       RETURN(ARRAY(first))
     }
 
-SwitchTail
-  = __ CaseToken __ ch:SwitchBranch { RETURN(ch) }
-
-CaseToken = "case"
+CaseToken = "case"i
+DefaultToken = "default"i
 
 Operation
   = "split" __ "(" __ "=>" __ procArray:Parallel __ ")" {
       RETURN(MAP("op": "ParallelProc", "procs": procArray))
     }
-  / "switch" __ "(" __ CaseToken __ caseArray:Switch __ ")" {
+  / "switch" __ "(" __ caseArray:Switch __ ")" {
       RETURN(MAP("op": "SwitchProc", "cases": caseArray))
     }
   / Operator
@@ -221,6 +221,7 @@ SearchGuard
   / InToken
   / ByToken
   / CaseToken
+  / DefaultToken
   / "type("
 
 /// === Search-embedded Expression Context ===


### PR DESCRIPTION
This commit adds a default case for a Z switch statement where
default is the same as a true match.  This means the default
statement must come last for it to work correctly.  We could
consider making the default case logically last, but I propose
we get this in so Phil can use it and we create an issue for
this if we want it.

Closes #2322 
