### PR TITLE
create uniform naming conventions for AST

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -22,24 +22,24 @@ type Proc interface {
 
 // Id refers to a syntax element analogous to a programming language identifier.
 type Id struct {
-	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 	Name string `json:"name"`
 }
 
 type Path struct {
-	Op   string   `json:"op" unpack:""`
+	Kind string   `json:"kind" unpack:""`
 	Name []string `json:"name"`
 }
 
 type Ref struct {
-	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 	Name string `json:"name"`
 }
 
 // Root refers to the outer record being operated upon.  Field accesses
 // typically begin with the LHS of a "." expression set to a Root.
 type Root struct {
-	Op string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 }
 
 type Expr interface {
@@ -52,20 +52,20 @@ type Expr interface {
 // the native Go types) and value is a string representation of that value that
 // must conform to the provided type.
 type Literal struct {
-	Op    string `json:"op" unpack:""`
+	Kind  string `json:"kind" unpack:""`
 	Type  string `json:"type"`
 	Value string `json:"value"`
 }
 
 type Search struct {
-	Op    string  `json:"op" unpack:""`
+	Kind  string  `json:"kind" unpack:""`
 	Text  string  `json:"text"`
 	Value Literal `json:"value"`
 }
 
 type UnaryExpr struct {
-	Op      string `json:"op" unpack:""`
-	Kind    string `json:"kind"`
+	Kind    string `json:"kind" unpack:""`
+	Op      string `json:"op"`
 	Operand Expr   `json:"operand"`
 }
 
@@ -74,20 +74,20 @@ type UnaryExpr struct {
 // comparisons (=, !=, <, <=, >, >=), index operatons (on arrays, sets, and records)
 // with kind "[" and a dot expression (".") (on records).
 type BinaryExpr struct {
-	Op   string `json:"op" unpack:""`
-	Kind string `json:"kind"`
+	Kind string `json:"kind" unpack:""`
+	Op   string `json:"op"`
 	LHS  Expr   `json:"lhs"`
 	RHS  Expr   `json:"rhs"`
 }
 
 type SelectExpr struct {
-	Op        string `json:"op" unpack:""`
+	Kind      string `json:"kind" unpack:""`
 	Selectors []Expr `json:"selectors"`
 	Methods   []Call `json:"methods"`
 }
 
 type Conditional struct {
-	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 	Cond Expr   `json:"cond"`
 	Then Expr   `json:"then"`
 	Else Expr   `json:"else"`
@@ -101,15 +101,22 @@ type Conditional struct {
 // a function call has the standard semantics where it takes one or more arguments
 // and returns a result.
 type Call struct {
-	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 	Name string `json:"name"`
 	Args []Expr `json:"args"`
 }
 
 type Cast struct {
-	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 	Expr Expr   `json:"expr"`
 	Type Type   `json:"type"`
+}
+
+type SeqExpr struct {
+	Kind      string   `json:"kind" unpack:""`
+	Name      string   `json:"name"`
+	Selectors []Expr   `json:"selectors"`
+	Methods   []Method `json:"methods"`
 }
 
 func (*UnaryExpr) exprNode()   {}
@@ -124,10 +131,11 @@ func (*Id) exprNode()          {}
 func (*Path) exprNode()        {}
 func (*Ref) exprNode()         {}
 func (*Root) exprNode()        {}
-func (*Assignment) exprNode()  {}
-func (*Agg) exprNode()         {}
-func (*SeqExpr) exprNode()     {}
-func (*TypeValue) exprNode()   {}
+
+func (*Assignment) exprNode() {}
+func (*Agg) exprNode()        {}
+func (*SeqExpr) exprNode()    {}
+func (*TypeValue) exprNode()  {}
 
 // ----------------------------------------------------------------------------
 // Procs
@@ -141,13 +149,13 @@ type (
 	// and each subsequent proc processes the output records from the
 	// previous proc.
 	Sequential struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Procs []Proc `json:"procs"`
 	}
 	// A Parallel proc represents a set of procs that each get
 	// a stream of records from their parent.
 	Parallel struct {
-		Op string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		// If non-zero, MergeBy contains the field name on
 		// which the branches of this parallel proc should be
 		// merged in the order indicated by MergeReverse.
@@ -159,7 +167,7 @@ type (
 	// A Switch proc represents a set of procs that each get
 	// a stream of records from their parent.
 	Switch struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Cases []Case `json:"cases"`
 		// If non-zero, MergeField contains the field name on
 		// which the branches of this parallel proc should be
@@ -169,7 +177,7 @@ type (
 	}
 	// A Sort proc represents a proc that sorts records.
 	Sort struct {
-		Op         string `json:"op" unpack:""`
+		Kind       string `json:"kind" unpack:""`
 		Args       []Expr `json:"args"`
 		SortDir    int    `json:"sortdir"`
 		NullsFirst bool   `json:"nullsfirst"`
@@ -178,50 +186,50 @@ type (
 	// input record where each removed field matches one of the named fields
 	// sending each such modified record to its output in the order received.
 	Cut struct {
-		Op   string       `json:"op" unpack:""`
+		Kind string       `json:"kind" unpack:""`
 		Args []Assignment `json:"args"`
 	}
 	// A Pick proc is like a Cut but skips records that do not
 	// match all of the field expressions.
 	Pick struct {
-		Op   string       `json:"op" unpack:""`
+		Kind string       `json:"kind" unpack:""`
 		Args []Assignment `json:"args"`
 	}
 	// A Drop proc represents a proc that removes fields from each
 	// input record.
 	Drop struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Args []Expr `json:"args"`
 	}
 	// A Head proc represents a proc that forwards the indicated number
 	// of records then terminates.
 	Head struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Count int    `json:"count"`
 	}
 	// A Tail proc represents a proc that reads all its records from its
 	// input transmits the final number of records indicated by the count.
 	Tail struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Count int    `json:"count"`
 	}
 	// A Filter proc represents a proc that discards all records that do
 	// not match the indicfated filter and forwards all that match to its output.
 	Filter struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Expr Expr   `json:"expr"`
 	}
 	// A Pass proc represents a passthrough proc that mirrors
 	// incoming Pull()s on its parent and returns the result.
 	Pass struct {
-		Op string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 	}
 	// A Uniq proc represents a proc that discards any record that matches
 	// the previous record transmitted.  The Cflag causes the output records
 	// to contain a new field called count that contains the number of matched
 	// records in that set, similar to the unix shell command uniq.
 	Uniq struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Cflag bool   `json:"cflag"`
 	}
 	// A Summarize proc represents a proc that consumes all the records
@@ -242,7 +250,7 @@ type (
 	// output result; likewise, if PartialsIn is true, the proc will
 	// expect partial results as input.
 	Summarize struct {
-		Op           string       `json:"op" unpack:""`
+		Kind         string       `json:"kind" unpack:""`
 		Duration     Duration     `json:"duration"`
 		InputSortDir int          `json:"input_sort_dir,omitempty"`
 		Limit        int          `json:"limit"`
@@ -257,31 +265,31 @@ type (
 	// the top N of the sort.
 	// - It has an option (Flush) to sort and emit on every batch.
 	Top struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Limit int    `json:"limit"`
 		Args  []Expr `json:"args"`
 		Flush bool   `json:"flush"`
 	}
 	Put struct {
-		Op   string       `json:"op" unpack:""`
+		Kind string       `json:"kind" unpack:""`
 		Args []Assignment `json:"args"`
 	}
 
 	// A Rename proc represents a proc that renames fields.
 	Rename struct {
-		Op   string       `json:"op" unpack:""`
+		Kind string       `json:"kind" unpack:""`
 		Args []Assignment `json:"args"`
 	}
 
 	// A Fuse proc represents a proc that turns a zng stream into a dataframe.
 	Fuse struct {
-		Op string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 	}
 
 	// A Join proc represents a proc that joins two zng streams.
 	Join struct {
-		Op       string       `json:"op" unpack:""`
-		Kind     string       `json:"kind"`
+		Kind     string       `json:"kind" unpack:""`
+		Style    string       `json:"style"`
 		LeftKey  Expr         `json:"left_key"`
 		RightKey Expr         `json:"right_key"`
 		Args     []Assignment `json:"args"`
@@ -291,28 +299,21 @@ type (
 	// smuggled in as fake procs.  When we refactor this AST into a parser AST
 	// proper and a separate kernel DSL, we will clean this up.
 	Const struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Name string `json:"name"`
 		Expr Expr   `json:"expr"`
 	}
 
 	TypeProc struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Name string `json:"name"`
 		Type Type   `json:"type"`
 	}
 
 	Shape struct {
-		Op string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 	}
 )
-
-type SeqExpr struct {
-	Op        string   `json:"op" unpack:""`
-	Name      string   `json:"name"`
-	Selectors []Expr   `json:"selectors"`
-	Methods   []Method `json:"methods"`
-}
 
 type Method struct {
 	Name string `json:"name"`
@@ -325,9 +326,9 @@ type Case struct {
 }
 
 type Assignment struct {
-	Op  string `json:"op" unpack:""`
-	LHS Expr   `json:"lhs"`
-	RHS Expr   `json:"rhs"`
+	Kind string `json:"kind" unpack:""`
+	LHS  Expr   `json:"lhs"`
+	RHS  Expr   `json:"rhs"`
 }
 
 //XXX TBD: chance to nano.Duration
@@ -387,7 +388,7 @@ func (*Shape) ProcNode()      {}
 // upon a function of the record, e.g., count() counts up records without
 // looking into them.
 type Agg struct {
-	Op    string `json:"op" unpack:""`
+	Kind  string `json:"kind" unpack:""`
 	Name  string `json:"name"`
 	Expr  Expr   `json:"expr"`
 	Where Expr   `json:"where"`
@@ -396,7 +397,7 @@ type Agg struct {
 func DotExprToFieldPath(e Expr) *Path {
 	switch e := e.(type) {
 	case *BinaryExpr:
-		if e.Kind == "." {
+		if e.Op == "." {
 			lhs := DotExprToFieldPath(e.LHS)
 			if lhs == nil {
 				return nil
@@ -408,7 +409,7 @@ func DotExprToFieldPath(e Expr) *Path {
 			lhs.Name = append(lhs.Name, id.Name)
 			return lhs
 		}
-		if e.Kind == "[" {
+		if e.Op == "[" {
 			lhs := DotExprToFieldPath(e.LHS)
 			if lhs == nil {
 				return nil
@@ -421,9 +422,9 @@ func DotExprToFieldPath(e Expr) *Path {
 			return lhs
 		}
 	case *Id:
-		return &Path{Op: "Path", Name: []string{e.Name}}
+		return &Path{Kind: "Path", Name: []string{e.Name}}
 	case *Root:
-		return &Path{Op: "Path", Name: []string{}}
+		return &Path{Kind: "Path", Name: []string{}}
 	}
 	// This includes a null Expr, which can happen if the AST is missing
 	// a field or sets it to null.
@@ -449,15 +450,15 @@ func FieldsOf(e Expr) []field.Static {
 }
 
 func NewDotExpr(f field.Static) Expr {
-	lhs := Expr(&Root{Op: "Root"})
+	lhs := Expr(&Root{Kind: "Root"})
 	for _, name := range f {
 		rhs := &Id{
-			Op:   "Id",
+			Kind: "Id",
 			Name: name,
 		}
 		lhs = &BinaryExpr{
-			Op:   "BinaryExpr",
-			Kind: ".",
+			Kind: "BinaryExpr",
+			Op:   ".",
 			LHS:  lhs,
 			RHS:  rhs,
 		}
@@ -466,7 +467,7 @@ func NewDotExpr(f field.Static) Expr {
 }
 
 func NewAggAssignment(kind string, lval field.Static, arg field.Static) Assignment {
-	agg := &Agg{Op: "Agg", Name: kind}
+	agg := &Agg{Kind: "Agg", Name: kind}
 	if arg != nil {
 		agg.Expr = NewDotExpr(arg)
 	}
@@ -475,9 +476,9 @@ func NewAggAssignment(kind string, lval field.Static, arg field.Static) Assignme
 		lhs = field.New(kind)
 	}
 	return Assignment{
-		Op:  "Assignment",
-		LHS: NewDotExpr(lhs),
-		RHS: agg,
+		Kind: "Assignment",
+		LHS:  NewDotExpr(lhs),
+		RHS:  agg,
 	}
 }
 
@@ -497,7 +498,7 @@ func FanIn(p Proc) int {
 
 func FilterToProc(e Expr) *Filter {
 	return &Filter{
-		Op:   "Filter",
+		Kind: "Filter",
 		Expr: e,
 	}
 }

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -20,16 +20,13 @@ type Proc interface {
 	ProcNode()
 }
 
-// Identifier refers to a syntax element analogous to a programming language
-// identifier.  It is currently used exclusively as the RHS of a BinaryExpr "."
-// expression though it may have future uses (e.g., enum names or externally
-// referred to data e.g, maps to do external joins).
-type Identifier struct {
+// Id refers to a syntax element analogous to a programming language identifier.
+type Id struct {
 	Op   string `json:"op" unpack:""`
 	Name string `json:"name"`
 }
 
-type FieldPath struct {
+type Path struct {
 	Op   string   `json:"op" unpack:""`
 	Name []string `json:"name"`
 }
@@ -39,13 +36,13 @@ type Ref struct {
 	Name string `json:"name"`
 }
 
-// RootRecord refers to the outer record being operated upon.  Field accesses
-// typically begin with the LHS of a "." expression set to a RootRecord.
-type RootRecord struct {
+// Root refers to the outer record being operated upon.  Field accesses
+// typically begin with the LHS of a "." expression set to a Root.
+type Root struct {
 	Op string `json:"op" unpack:""`
 }
 
-type Expression interface {
+type Expr interface {
 	exprNode()
 }
 
@@ -66,76 +63,71 @@ type Search struct {
 	Value Literal `json:"value"`
 }
 
-type UnaryExpression struct {
-	Op       string     `json:"op" unpack:"UnaryExpr"`
-	Operator string     `json:"operator"`
-	Operand  Expression `json:"operand"`
+type UnaryExpr struct {
+	Op      string `json:"op" unpack:""`
+	Kind    string `json:"kind"`
+	Operand Expr   `json:"operand"`
 }
 
-// A BinaryExpression is any expression of the form "operand operator operand"
+// A BinaryExpr is any expression of the form "lhs kind rhs"
 // including arithmetic (+, -, *, /), logical operators (and, or),
 // comparisons (=, !=, <, <=, >, >=), index operatons (on arrays, sets, and records)
-// with operator "[" and a dot expression (".") (on records).
-type BinaryExpression struct {
-	Op       string     `json:"op" unpack:"BinaryExpr"`
-	Operator string     `json:"operator"`
-	LHS      Expression `json:"lhs"`
-	RHS      Expression `json:"rhs"`
+// with kind "[" and a dot expression (".") (on records).
+type BinaryExpr struct {
+	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind"`
+	LHS  Expr   `json:"lhs"`
+	RHS  Expr   `json:"rhs"`
 }
 
-type SelectExpression struct {
-	Op        string         `json:"op" unpack:"SelectExpr"`
-	Selectors []Expression   `json:"selectors"`
-	Methods   []FunctionCall `json:"methods"`
+type SelectExpr struct {
+	Op        string `json:"op" unpack:""`
+	Selectors []Expr `json:"selectors"`
+	Methods   []Call `json:"methods"`
 }
 
-type ConditionalExpression struct {
-	Op        string     `json:"op" unpack:"ConditionalExpr"`
-	Condition Expression `json:"condition"`
-	Then      Expression `json:"then"`
-	Else      Expression `json:"else"`
+type Conditional struct {
+	Op   string `json:"op" unpack:""`
+	Cond Expr   `json:"cond"`
+	Then Expr   `json:"then"`
+	Else Expr   `json:"else"`
 }
 
-// A FunctionCall represents different things dependending on its context.
+// A Call represents different things dependending on its context.
 // As a proc, it is either a group-by with no group-by keys and no duration,
 // or a filter with a function that is boolean valued.  This is determined
 // by the compiler rather than the syntax tree based on the specific functions
 // and aggregators that are defined at compile time.  In expression context,
 // a function call has the standard semantics where it takes one or more arguments
 // and returns a result.
-type FunctionCall struct {
-	Op       string       `json:"op" unpack:""`
-	Function string       `json:"function"`
-	Args     []Expression `json:"args"`
-}
-
-type CastExpression struct {
-	Op   string     `json:"op" unpack:"CastExpr"`
-	Expr Expression `json:"expr"`
-	Type Type       `json:"type"`
-}
-
-type TypeExpr struct {
+type Call struct {
 	Op   string `json:"op" unpack:""`
+	Name string `json:"name"`
+	Args []Expr `json:"args"`
+}
+
+type Cast struct {
+	Op   string `json:"op" unpack:""`
+	Expr Expr   `json:"expr"`
 	Type Type   `json:"type"`
 }
 
-func (*UnaryExpression) exprNode()       {}
-func (*BinaryExpression) exprNode()      {}
-func (*SelectExpression) exprNode()      {}
-func (*ConditionalExpression) exprNode() {}
-func (*Search) exprNode()                {}
-func (*FunctionCall) exprNode()          {}
-func (*CastExpression) exprNode()        {}
-func (*TypeExpr) exprNode()              {}
-func (*Literal) exprNode()               {}
-func (*Identifier) exprNode()            {}
-func (*FieldPath) exprNode()             {}
-func (*Ref) exprNode()                   {}
-func (*RootRecord) exprNode()            {}
-func (*Assignment) exprNode()            {}
-func (*Reducer) exprNode()               {}
-func (*SeqExpr) exprNode()               {}
+func (*UnaryExpr) exprNode()   {}
+func (*BinaryExpr) exprNode()  {}
+func (*SelectExpr) exprNode()  {}
+func (*Conditional) exprNode() {}
+func (*Search) exprNode()      {}
+func (*Call) exprNode()        {}
+func (*Cast) exprNode()        {}
+func (*Literal) exprNode()     {}
+func (*Id) exprNode()          {}
+func (*Path) exprNode()        {}
+func (*Ref) exprNode()         {}
+func (*Root) exprNode()        {}
+func (*Assignment) exprNode()  {}
+func (*Agg) exprNode()         {}
+func (*SeqExpr) exprNode()     {}
+func (*TypeValue) exprNode()   {}
 
 // ----------------------------------------------------------------------------
 // Procs
@@ -144,167 +136,164 @@ func (*SeqExpr) exprNode()               {}
 // and produces records as output.
 //
 type (
-	// A SequentialProc node represents a set of procs that receive
+	// A Sequential proc represents a set of procs that receive
 	// a stream of records from their parent into the first proc
 	// and each subsequent proc processes the output records from the
 	// previous proc.
-	SequentialProc struct {
+	Sequential struct {
 		Op    string `json:"op" unpack:""`
 		Procs []Proc `json:"procs"`
 	}
-	// A ParallelProc node represents a set of procs that each get
+	// A Parallel proc represents a set of procs that each get
 	// a stream of records from their parent.
-	ParallelProc struct {
+	Parallel struct {
 		Op string `json:"op" unpack:""`
-		// If non-zero, MergeOrderField contains the field name on
+		// If non-zero, MergeBy contains the field name on
 		// which the branches of this parallel proc should be
-		// merged in the order indicated by MergeOrderReverse.
-		MergeOrderField   field.Static `json:"merge_order_field,omitempty"`
-		MergeOrderReverse bool         `json:"merge_order_reverse,omitempty"`
-		Procs             []Proc       `json:"procs"`
+		// merged in the order indicated by MergeReverse.
+		// XXX merge_by should be a list of expressions
+		MergeBy      field.Static `json:"merge_by,omitempty"`
+		MergeReverse bool         `json:"merge_reverse,omitempty"`
+		Procs        []Proc       `json:"procs"`
 	}
-	// A SwitchProc node represents a set of procs that each get
+	// A Switch proc represents a set of procs that each get
 	// a stream of records from their parent.
-	SwitchProc struct {
-		Op    string       `json:"op" unpack:""`
-		Cases []SwitchCase `json:"cases"`
-		// If non-zero, MergeOrderField contains the field name on
+	Switch struct {
+		Op    string `json:"op" unpack:""`
+		Cases []Case `json:"cases"`
+		// If non-zero, MergeField contains the field name on
 		// which the branches of this parallel proc should be
-		// merged in the order indicated by MergeOrderReverse.
-		MergeOrderField   field.Static `json:"merge_order_field,omitempty"`
-		MergeOrderReverse bool         `json:"merge_order_reverse,omitempty"`
+		// merged in the order indicated by MergeReverse.
+		MergeBy      field.Static `json:"merge_by,omitempty"`
+		MergeReverse bool         `json:"merge_reverse,omitempty"`
 	}
-	// A SortProc node represents a proc that sorts records.
-	SortProc struct {
-		Op         string       `json:"op" unpack:""`
-		Fields     []Expression `json:"fields"`
-		SortDir    int          `json:"sortdir"`
-		NullsFirst bool         `json:"nullsfirst"`
+	// A Sort proc represents a proc that sorts records.
+	Sort struct {
+		Op         string `json:"op" unpack:""`
+		Args       []Expr `json:"args"`
+		SortDir    int    `json:"sortdir"`
+		NullsFirst bool   `json:"nullsfirst"`
 	}
-	// A CutProc node represents a proc that removes fields from each
+	// A Cut proc represents a proc that removes fields from each
 	// input record where each removed field matches one of the named fields
 	// sending each such modified record to its output in the order received.
-	CutProc struct {
-		Op     string       `json:"op" unpack:""`
-		Fields []Assignment `json:"fields"`
+	Cut struct {
+		Op   string       `json:"op" unpack:""`
+		Args []Assignment `json:"args"`
 	}
-	// A PickProc is like a CutProc but skips records that do not
+	// A Pick proc is like a Cut but skips records that do not
 	// match all of the field expressions.
-	PickProc struct {
-		Op     string       `json:"op" unpack:""`
-		Fields []Assignment `json:"fields"`
+	Pick struct {
+		Op   string       `json:"op" unpack:""`
+		Args []Assignment `json:"args"`
 	}
-	// A DropProc node represents a proc that removes fields from each
+	// A Drop proc represents a proc that removes fields from each
 	// input record.
-	DropProc struct {
-		Op     string       `json:"op" unpack:""`
-		Fields []Expression `json:"fields"`
+	Drop struct {
+		Op   string `json:"op" unpack:""`
+		Args []Expr `json:"args"`
 	}
-	// A HeadProc node represents a proc that forwards the indicated number
+	// A Head proc represents a proc that forwards the indicated number
 	// of records then terminates.
-	HeadProc struct {
+	Head struct {
 		Op    string `json:"op" unpack:""`
 		Count int    `json:"count"`
 	}
-	// A TailProc node represents a proc that reads all its records from its
+	// A Tail proc represents a proc that reads all its records from its
 	// input transmits the final number of records indicated by the count.
-	TailProc struct {
+	Tail struct {
 		Op    string `json:"op" unpack:""`
 		Count int    `json:"count"`
 	}
-	// A FilterProc node represents a proc that discards all records that do
+	// A Filter proc represents a proc that discards all records that do
 	// not match the indicfated filter and forwards all that match to its output.
-	FilterProc struct {
-		Op     string     `json:"op" unpack:""`
-		Filter Expression `json:"filter"`
+	Filter struct {
+		Op   string `json:"op" unpack:""`
+		Expr Expr   `json:"expr"`
 	}
-	// A PassProc node represents a passthrough proc that mirrors
+	// A Pass proc represents a passthrough proc that mirrors
 	// incoming Pull()s on its parent and returns the result.
-	PassProc struct {
+	Pass struct {
 		Op string `json:"op" unpack:""`
 	}
-	// A UniqProc node represents a proc that discards any record that matches
+	// A Uniq proc represents a proc that discards any record that matches
 	// the previous record transmitted.  The Cflag causes the output records
 	// to contain a new field called count that contains the number of matched
 	// records in that set, similar to the unix shell command uniq.
-	UniqProc struct {
+	Uniq struct {
 		Op    string `json:"op" unpack:""`
 		Cflag bool   `json:"cflag"`
 	}
-	// A GroupByProc node represents a proc that consumes all the records
+	// A Summarize proc represents a proc that consumes all the records
 	// in its input, partitions the records into groups based on the values
 	// of the fields specified in the keys field (where the first key is the
-	// primary grouping key), and applies reducers (if any) to each group. If the
+	// primary grouping key), and applies aggregators (if any) to each group. If the
 	// Duration field is non-zero, then the groups are further partioned by time
 	// into bins of the duration.  In this case, the primary grouping key is ts.
 	// The InputSortDir field indicates that input is sorted (with
 	// direction indicated by the sign of the field) in the primary
-	// grouping key. In this case, the proc outputs the reducer
+	// grouping key. In this case, the proc outputs the aggregation
 	// results from each key as they complete so that large inputs
 	// are processed and streamed efficiently.
 	// The Limit field specifies the number of different groups that can be
 	// aggregated over. When absent, the runtime defaults to an
 	// appropriate value.
-	// If EmitPart is true, the proc will produce decomposed
-	// output results, using the reducer.ResultPart()
-	// method. Likewise, if ConsumePart is true, the proc will
-	// expect decomposed inputs, using the reducer.ResultPart()
-	// method. It is an error for either of these flags to be true
-	// if any reducer in Reducers is non-decomposable.
-	GroupByProc struct {
+	// If PartialsOut is true, the proc will produce partial aggregation
+	// output result; likewise, if PartialsIn is true, the proc will
+	// expect partial results as input.
+	Summarize struct {
 		Op           string       `json:"op" unpack:""`
 		Duration     Duration     `json:"duration"`
 		InputSortDir int          `json:"input_sort_dir,omitempty"`
 		Limit        int          `json:"limit"`
 		Keys         []Assignment `json:"keys"`
-		Reducers     []Assignment `json:"reducers"`
-		ConsumePart  bool         `json:"consume_part,omitempty"`
-		EmitPart     bool         `json:"emit_part,omitempty"`
+		Aggs         []Assignment `json:"aggs"`
+		PartialsIn   bool         `json:"partials_in,omitempty"`
+		PartialsOut  bool         `json:"partials_out,omitempty"`
 	}
-	// TopProc is similar to proc.SortProc with a few key differences:
+	// A Top proc is similar to a Sort with a few key differences:
 	// - It only sorts in descending order.
 	// - It utilizes a MaxHeap, immediately discarding records that are not in
 	// the top N of the sort.
-	// - It has a hidden option (FlushEvery) to sort and emit on every batch.
-	TopProc struct {
-		Op     string       `json:"op" unpack:""`
-		Limit  int          `json:"limit"`
-		Fields []Expression `json:"fields"`
-		Flush  bool         `json:"flush"`
+	// - It has an option (Flush) to sort and emit on every batch.
+	Top struct {
+		Op    string `json:"op" unpack:""`
+		Limit int    `json:"limit"`
+		Args  []Expr `json:"args"`
+		Flush bool   `json:"flush"`
+	}
+	Put struct {
+		Op   string       `json:"op" unpack:""`
+		Args []Assignment `json:"args"`
 	}
 
-	PutProc struct {
-		Op      string       `json:"op" unpack:""`
-		Clauses []Assignment `json:"clauses"`
+	// A Rename proc represents a proc that renames fields.
+	Rename struct {
+		Op   string       `json:"op" unpack:""`
+		Args []Assignment `json:"args"`
 	}
 
-	// A RenameProc node represents a proc that renames fields.
-	RenameProc struct {
-		Op     string       `json:"op" unpack:""`
-		Fields []Assignment `json:"fields"`
-	}
-
-	// A FuseProc node represents a proc that turns a zng stream into a dataframe.
-	FuseProc struct {
+	// A Fuse proc represents a proc that turns a zng stream into a dataframe.
+	Fuse struct {
 		Op string `json:"op" unpack:""`
 	}
 
-	// A JoinProc node represents a proc that joins two zng streams.
-	JoinProc struct {
+	// A Join proc represents a proc that joins two zng streams.
+	Join struct {
 		Op       string       `json:"op" unpack:""`
 		Kind     string       `json:"kind"`
-		LeftKey  Expression   `json:"left_key"`
-		RightKey Expression   `json:"right_key"`
-		Clauses  []Assignment `json:"clauses"`
+		LeftKey  Expr         `json:"left_key"`
+		RightKey Expr         `json:"right_key"`
+		Args     []Assignment `json:"args"`
 	}
 
 	// XXX This is a quick and dirty way to get constants into Z.  They are
 	// smuggled in as fake procs.  When we refactor this AST into a parser AST
 	// proper and a separate kernel DSL, we will clean this up.
-	ConstProc struct {
-		Op   string     `json:"op" unpack:""`
-		Name string     `json:"name"`
-		Expr Expression `json:"expr"`
+	Const struct {
+		Op   string `json:"op" unpack:""`
+		Name string `json:"name"`
+		Expr Expr   `json:"expr"`
 	}
 
 	TypeProc struct {
@@ -313,32 +302,32 @@ type (
 		Type Type   `json:"type"`
 	}
 
-	ShapeProc struct {
+	Shape struct {
 		Op string `json:"op" unpack:""`
 	}
 )
 
 type SeqExpr struct {
-	Op        string       `json:"op" unpack:""`
-	Name      string       `json:"name"`
-	Selectors []Expression `json:"selectors"`
-	Methods   []Method     `json:"methods"`
+	Op        string   `json:"op" unpack:""`
+	Name      string   `json:"name"`
+	Selectors []Expr   `json:"selectors"`
+	Methods   []Method `json:"methods"`
 }
 
 type Method struct {
-	Name string       `json:"name"`
-	Args []Expression `json:"args"`
+	Name string `json:"name"`
+	Args []Expr `json:"args"`
 }
 
-type SwitchCase struct {
-	Filter Expression `json:"filter"`
-	Proc   Proc       `json:"proc"`
+type Case struct {
+	Expr Expr `json:"expr"`
+	Proc Proc `json:"proc"`
 }
 
 type Assignment struct {
-	Op  string     `json:"op" unpack:""`
-	LHS Expression `json:"lhs"`
-	RHS Expression `json:"rhs"`
+	Op  string `json:"op" unpack:""`
+	LHS Expr   `json:"lhs"`
+	RHS Expr   `json:"rhs"`
 }
 
 //XXX TBD: chance to nano.Duration
@@ -368,58 +357,58 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (*SequentialProc) ProcNode() {}
-func (*ParallelProc) ProcNode()   {}
-func (*SwitchProc) ProcNode()     {}
-func (*SortProc) ProcNode()       {}
-func (*CutProc) ProcNode()        {}
-func (*PickProc) ProcNode()       {}
-func (*DropProc) ProcNode()       {}
-func (*HeadProc) ProcNode()       {}
-func (*TailProc) ProcNode()       {}
-func (*PassProc) ProcNode()       {}
-func (*FilterProc) ProcNode()     {}
-func (*UniqProc) ProcNode()       {}
-func (*GroupByProc) ProcNode()    {}
-func (*TopProc) ProcNode()        {}
-func (*PutProc) ProcNode()        {}
-func (*RenameProc) ProcNode()     {}
-func (*FuseProc) ProcNode()       {}
-func (*JoinProc) ProcNode()       {}
-func (*ConstProc) ProcNode()      {}
-func (*TypeProc) ProcNode()       {}
-func (*FunctionCall) ProcNode()   {}
-func (*ShapeProc) ProcNode()      {}
+func (*Sequential) ProcNode() {}
+func (*Parallel) ProcNode()   {}
+func (*Switch) ProcNode()     {}
+func (*Sort) ProcNode()       {}
+func (*Cut) ProcNode()        {}
+func (*Pick) ProcNode()       {}
+func (*Drop) ProcNode()       {}
+func (*Head) ProcNode()       {}
+func (*Tail) ProcNode()       {}
+func (*Pass) ProcNode()       {}
+func (*Filter) ProcNode()     {}
+func (*Uniq) ProcNode()       {}
+func (*Summarize) ProcNode()  {}
+func (*Top) ProcNode()        {}
+func (*Put) ProcNode()        {}
+func (*Rename) ProcNode()     {}
+func (*Fuse) ProcNode()       {}
+func (*Join) ProcNode()       {}
+func (*Const) ProcNode()      {}
+func (*TypeProc) ProcNode()   {}
+func (*Call) ProcNode()       {}
+func (*Shape) ProcNode()      {}
 
-// A Reducer is an AST node that represents a reducer function.  The Operator
+// An Agg is an AST node that represents a aggregate function.  The Name
 // field indicates the aggregation method while the Expr field indicates
 // an expression applied to the incoming records that is operated upon by them
-// reducer function.  If Expr isn't present, then the reducer doesn't act upon
-// a function of the record, e.g., count() counts up records without looking
-// into them.
-type Reducer struct {
-	Op       string     `json:"op" unpack:""`
-	Operator string     `json:"operator"`
-	Expr     Expression `json:"expr"`
-	Where    Expression `json:"where"`
+// aggregate function.  If Expr isn't present, then the aggregator doesn't act
+// upon a function of the record, e.g., count() counts up records without
+// looking into them.
+type Agg struct {
+	Op    string `json:"op" unpack:""`
+	Name  string `json:"name"`
+	Expr  Expr   `json:"expr"`
+	Where Expr   `json:"where"`
 }
 
-func DotExprToFieldPath(e Expression) *FieldPath {
+func DotExprToFieldPath(e Expr) *Path {
 	switch e := e.(type) {
-	case *BinaryExpression:
-		if e.Operator == "." {
+	case *BinaryExpr:
+		if e.Kind == "." {
 			lhs := DotExprToFieldPath(e.LHS)
 			if lhs == nil {
 				return nil
 			}
-			id, ok := e.RHS.(*Identifier)
+			id, ok := e.RHS.(*Id)
 			if !ok {
 				return nil
 			}
 			lhs.Name = append(lhs.Name, id.Name)
 			return lhs
 		}
-		if e.Operator == "[" {
+		if e.Kind == "[" {
 			lhs := DotExprToFieldPath(e.LHS)
 			if lhs == nil {
 				return nil
@@ -431,17 +420,17 @@ func DotExprToFieldPath(e Expression) *FieldPath {
 			lhs.Name = append(lhs.Name, id.Value)
 			return lhs
 		}
-	case *Identifier:
-		return &FieldPath{Op: "FieldPath", Name: []string{e.Name}}
-	case *RootRecord:
-		return &FieldPath{Op: "FieldPath", Name: []string{}}
+	case *Id:
+		return &Path{Op: "Path", Name: []string{e.Name}}
+	case *Root:
+		return &Path{Op: "Path", Name: []string{}}
 	}
 	// This includes a null Expr, which can happen if the AST is missing
 	// a field or sets it to null.
 	return nil
 }
 
-func FieldsOf(e Expression) []field.Static {
+func FieldsOf(e Expr) []field.Static {
 	switch e := e.(type) {
 	default:
 		if f := DotExprToFieldPath(e); f != nil {
@@ -450,7 +439,7 @@ func FieldsOf(e Expression) []field.Static {
 		return nil
 	case *Assignment:
 		return append(FieldsOf(e.LHS), FieldsOf(e.RHS)...)
-	case *SelectExpression:
+	case *SelectExpr:
 		var fields []field.Static
 		for _, selector := range e.Selectors {
 			fields = append(fields, FieldsOf(selector)...)
@@ -459,60 +448,60 @@ func FieldsOf(e Expression) []field.Static {
 	}
 }
 
-func NewDotExpr(f field.Static) Expression {
-	lhs := Expression(&RootRecord{Op: "RootRecord"})
+func NewDotExpr(f field.Static) Expr {
+	lhs := Expr(&Root{Op: "Root"})
 	for _, name := range f {
-		rhs := &Identifier{
-			Op:   "Identifier",
+		rhs := &Id{
+			Op:   "Id",
 			Name: name,
 		}
-		lhs = &BinaryExpression{
-			Op:       "BinaryExpr",
-			Operator: ".",
-			LHS:      lhs,
-			RHS:      rhs,
+		lhs = &BinaryExpr{
+			Op:   "BinaryExpr",
+			Kind: ".",
+			LHS:  lhs,
+			RHS:  rhs,
 		}
 	}
 	return lhs
 }
 
-func NewReducerAssignment(op string, lval field.Static, arg field.Static) Assignment {
-	reducer := &Reducer{Op: "Reducer", Operator: op}
+func NewAggAssignment(kind string, lval field.Static, arg field.Static) Assignment {
+	agg := &Agg{Op: "Agg", Name: kind}
 	if arg != nil {
-		reducer.Expr = NewDotExpr(arg)
+		agg.Expr = NewDotExpr(arg)
 	}
 	lhs := lval
 	if lhs == nil {
-		lhs = field.New(op)
+		lhs = field.New(kind)
 	}
 	return Assignment{
 		Op:  "Assignment",
 		LHS: NewDotExpr(lhs),
-		RHS: reducer,
+		RHS: agg,
 	}
 }
 
 func FanIn(p Proc) int {
 	first := p
-	if seq, ok := first.(*SequentialProc); ok {
+	if seq, ok := first.(*Sequential); ok {
 		first = seq.Procs[0]
 	}
-	if p, ok := first.(*ParallelProc); ok {
+	if p, ok := first.(*Parallel); ok {
 		return len(p.Procs)
 	}
-	if _, ok := first.(*JoinProc); ok {
+	if _, ok := first.(*Join); ok {
 		return 2
 	}
 	return 1
 }
 
-func FilterToProc(e Expression) *FilterProc {
-	return &FilterProc{
-		Op:     "FilterProc",
-		Filter: e,
+func FilterToProc(e Expr) *Filter {
+	return &Filter{
+		Op:   "Filter",
+		Expr: e,
 	}
 }
 
-func (f *FieldPath) String() string {
-	return field.Static(f.Name).String()
+func (p *Path) String() string {
+	return field.Static(p.Name).String()
 }

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -9,50 +9,49 @@ import (
 var unpacker = unpack.New(
 	Array{},
 	Assignment{},
-	BinaryExpression{},
-	CastExpression{},
+	BinaryExpr{},
+	Call{},
+	Cast{},
 	CastValue{},
-	ConditionalExpression{},
-	ConstProc{},
-	CutProc{},
+	Conditional{},
+	Const{},
+	Cut{},
 	DefValue{},
-	DropProc{},
+	Drop{},
 	Enum{},
-	FieldPath{},
-	FilterProc{},
-	FunctionCall{},
-	FuseProc{},
-	GroupByProc{},
-	HeadProc{},
-	Identifier{},
+	Filter{},
+	Fuse{},
+	Summarize{},
+	Head{},
+	Id{},
 	ImpliedValue{},
-	JoinProc{},
+	Join{},
 	Literal{},
 	Map{},
-	ShapeProc{},
-	ParallelProc{},
-	PassProc{},
-	PickProc{},
+	Shape{},
+	Parallel{},
+	Pass{},
+	Path{},
+	Pick{},
 	Primitive{},
-	PutProc{},
+	Put{},
 	Record{},
-	Reducer{},
+	Agg{},
 	Ref{},
-	RenameProc{},
-	RootRecord{},
+	Rename{},
+	Root{},
 	Search{},
-	SelectExpression{},
+	SelectExpr{},
 	SeqExpr{},
-	SequentialProc{},
+	Sequential{},
 	Set{},
-	SortProc{},
-	SwitchProc{},
-	TailProc{},
-	TopProc{},
+	Sort{},
+	Switch{},
+	Tail{},
+	Top{},
 	TypeArray{},
 	TypeDef{},
 	TypeEnum{},
-	TypeExpr{},
 	TypeMap{},
 	TypeName{},
 	TypeNull{},
@@ -62,8 +61,8 @@ var unpacker = unpack.New(
 	TypeSet{},
 	TypeUnion{},
 	TypeValue{},
-	UnaryExpression{},
-	UniqProc{},
+	UnaryExpr{},
+	Uniq{},
 )
 
 func UnpackJSON(buf []byte) (interface{}, error) {
@@ -98,12 +97,12 @@ func UnpackMapAsProc(m interface{}) (Proc, error) {
 	return proc, nil
 }
 
-func UnpackMapAsExpr(m interface{}) (Expression, error) {
+func UnpackMapAsExpr(m interface{}) (Expr, error) {
 	object, err := unpacker.UnpackMap(m)
 	if object == nil || err != nil {
 		return nil, err
 	}
-	e, ok := object.(Expression)
+	e, ok := object.(Expr)
 	if !ok {
 		return nil, errors.New("ast.UnpackMapAsExpr: not an expression")
 	}

--- a/compiler/ast/zson.go
+++ b/compiler/ast/zson.go
@@ -4,25 +4,19 @@ type Value interface {
 	valueNode()
 }
 
-const (
-	ImpliedValueOp = "implied_value"
-	CastValueOp    = "cast_value"
-	DefValueOp     = "def_value"
-)
-
 type ImpliedValue struct {
-	Op string `json:"op" unpack:""`
-	Of Any    `json:"of"`
+	Kind string `json:"kind" unpack:""`
+	Of   Any    `json:"of"`
 }
 
 type DefValue struct {
-	Op       string `json:"op" unpack:""`
+	Kind     string `json:"kind" unpack:""`
 	Of       Any    `json:"of"`
 	TypeName string `json:"type_name"`
 }
 
 type CastValue struct {
-	Op   string `json:"op" unpack:""`
+	Kind string `json:"kind" unpack:""`
 	Of   Value  `json:"of"`
 	Type Type   `json:"type"`
 }
@@ -37,12 +31,12 @@ type Any interface {
 
 type (
 	Primitive struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Type string `json:"type"`
 		Text string `json:"text"`
 	}
 	Record struct {
-		Op     string  `json:"op" unpack:""`
+		Kind   string  `json:"Kind" unpack:""`
 		Fields []Field `json:"fields"`
 	}
 	Field struct {
@@ -50,19 +44,19 @@ type (
 		Value Value  `json:"value"`
 	}
 	Array struct {
-		Op       string  `json:"op" unpack:""`
+		Kind     string  `json:"kind" unpack:""`
 		Elements []Value `json:"elements"`
 	}
 	Set struct {
-		Op       string  `json:"op" unpack:""`
+		Kind     string  `json:"kind" unpack:""`
 		Elements []Value `json:"elements"`
 	}
 	Enum struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Name string `json:"name"`
 	}
 	Map struct {
-		Op      string  `json:"op" unpack:""`
+		Kind    string  `json:"kind" unpack:""`
 		Entries []Entry `json:"entries"`
 	}
 	Entry struct {
@@ -70,7 +64,7 @@ type (
 		Value Value `json:"value"`
 	}
 	TypeValue struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Value Type   `json:"value"`
 	}
 )
@@ -89,11 +83,11 @@ type Type interface {
 
 type (
 	TypePrimitive struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Name string `json:"name"`
 	}
 	TypeRecord struct {
-		Op     string      `json:"op" unpack:""`
+		Kind   string      `json:"kind" unpack:""`
 		Fields []TypeField `json:"fields"`
 	}
 	TypeField struct {
@@ -101,37 +95,37 @@ type (
 		Type Type   `json:"type"`
 	}
 	TypeArray struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Type Type   `json:"type"`
 	}
 	TypeSet struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Type Type   `json:"type"`
 	}
 	TypeUnion struct {
-		Op    string `json:"op" unpack:""`
+		Kind  string `json:"kind" unpack:""`
 		Types []Type `json:"types"`
 	}
 	// Enum has just the elements and relies on the semantic checker
 	// to determine a type from the decorator either within or from above.
 	TypeEnum struct {
-		Op       string  `json:"op" unpack:""`
+		Kind     string  `json:"kind" unpack:""`
 		Elements []Field `json:"elements"`
 	}
 	TypeMap struct {
-		Op      string `json:"op" unpack:""`
+		Kind    string `json:"kind" unpack:""`
 		KeyType Type   `json:"key_type"`
 		ValType Type   `json:"val_type"`
 	}
 	TypeNull struct {
-		Op string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 	}
 	TypeName struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Name string `json:"name"`
 	}
 	TypeDef struct {
-		Op   string `json:"op" unpack:""`
+		Kind string `json:"kind" unpack:""`
 		Name string `json:"name"`
 		Type Type   `json:"type"`
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -107,7 +107,7 @@ func (r *Runtime) AsProc() ast.Proc {
 	}
 	procs = append(procs, p)
 	return &ast.Sequential{
-		Op:    "Sequential",
+		Kind:  "Sequential",
 		Procs: procs,
 	}
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -106,8 +106,8 @@ func (r *Runtime) AsProc() ast.Proc {
 		procs = append(procs, p)
 	}
 	procs = append(procs, p)
-	return &ast.SequentialProc{
-		Op:    "SequentialProc",
+	return &ast.Sequential{
+		Op:    "Sequential",
 		Procs: procs,
 	}
 }
@@ -135,7 +135,7 @@ func ParseProc(z string) (ast.Proc, error) {
 	return ast.UnpackMapAsProc(parsed)
 }
 
-func ParseExpression(expr string) (ast.Expression, error) {
+func ParseExpression(expr string) (ast.Expr, error) {
 	m, err := zql.ParseZByRule("Expr", expr)
 	if err != nil {
 		return nil, err

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -77,13 +77,13 @@ func TestCompileMergeDone(t *testing.T) {
 	query, err := compiler.ParseProc("split(=>filter * =>head 1) | head 3")
 	require.NoError(t, err)
 
-	seq, ok := query.(*ast.SequentialProc)
+	seq, ok := query.(*ast.Sequential)
 	require.Equal(t, ok, true)
-	p, ok := seq.Procs[0].(*ast.ParallelProc)
+	p, ok := seq.Procs[0].(*ast.Parallel)
 	require.Equal(t, ok, true)
 
 	// Force the parallel proc to create a merge proc instead of combine.
-	p.MergeOrderField = field.New("k")
+	p.MergeBy = field.New("k")
 	runtime, err := compiler.CompileProc(query, pctx, []proc.Interface{src})
 	require.NoError(t, err)
 

--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -11,18 +11,18 @@ import (
 // encoding of a record matching e. (It may also return true for some byte
 // slices that do not match.) compileBufferFilter returns a nil pointer and nil
 // error if it cannot construct a useful filter.
-func CompileBufferFilter(e ast.Expression) (*expr.BufferFilter, error) {
+func CompileBufferFilter(e ast.Expr) (*expr.BufferFilter, error) {
 	switch e := e.(type) {
 	case *ast.SeqExpr:
 		if literal, op, ok := isCompareAny(e); ok && (op == "=" || op == "in") {
 			return newBufferFilterForLiteral(*literal)
 		}
 		return nil, nil
-	case *ast.BinaryExpression:
+	case *ast.BinaryExpr:
 		if literal, _ := isFieldEqualOrIn(e); literal != nil {
 			return newBufferFilterForLiteral(*literal)
 		}
-		if e.Operator == "and" {
+		if e.Kind == "and" {
 			left, err := CompileBufferFilter(e.LHS)
 			if err != nil {
 				return nil, err
@@ -39,7 +39,7 @@ func CompileBufferFilter(e ast.Expression) (*expr.BufferFilter, error) {
 			}
 			return expr.NewAndBufferFilter(left, right), nil
 		}
-		if e.Operator == "or" {
+		if e.Kind == "or" {
 			left, err := CompileBufferFilter(e.LHS)
 			if err != nil {
 				return nil, err
@@ -78,35 +78,35 @@ func CompileBufferFilter(e ast.Expression) (*expr.BufferFilter, error) {
 	}
 }
 
-func isIdOrRoot(e ast.Expression) bool {
-	if _, ok := e.(*ast.Identifier); ok {
+func isIdOrRoot(e ast.Expr) bool {
+	if _, ok := e.(*ast.Id); ok {
 		return true
 	}
-	_, ok := e.(*ast.RootRecord)
+	_, ok := e.(*ast.Root)
 	return ok
 }
 
-func isRootField(e ast.Expression) bool {
+func isRootField(e ast.Expr) bool {
 	if isIdOrRoot(e) {
 		return true
 	}
-	b, ok := e.(*ast.BinaryExpression)
-	if !ok || b.Operator != "." {
+	b, ok := e.(*ast.BinaryExpr)
+	if !ok || b.Kind != "." {
 		return false
 	}
-	if _, ok := b.LHS.(*ast.RootRecord); !ok {
+	if _, ok := b.LHS.(*ast.Root); !ok {
 		return false
 	}
-	_, ok = b.RHS.(*ast.Identifier)
+	_, ok = b.RHS.(*ast.Id)
 	return ok
 }
 
-func isFieldEqualOrIn(e *ast.BinaryExpression) (*ast.Literal, string) {
-	if isRootField(e.LHS) && e.Operator == "=" {
+func isFieldEqualOrIn(e *ast.BinaryExpr) (*ast.Literal, string) {
+	if isRootField(e.LHS) && e.Kind == "=" {
 		if literal, ok := e.RHS.(*ast.Literal); ok {
 			return literal, "="
 		}
-	} else if isRootField(e.RHS) && e.Operator == "in" {
+	} else if isRootField(e.RHS) && e.Kind == "in" {
 		if literal, ok := e.LHS.(*ast.Literal); ok && literal.Type != "net" {
 			return literal, "in"
 		}
@@ -123,38 +123,38 @@ func isCompareAny(seq *ast.SeqExpr) (*ast.Literal, string, bool) {
 	if len(method.Args) != 1 || method.Name != "map" {
 		return nil, "", false
 	}
-	pred, ok := method.Args[0].(*ast.BinaryExpression)
+	pred, ok := method.Args[0].(*ast.BinaryExpr)
 	if !ok {
 		return nil, "", false
 	}
-	if pred.Operator == "=" {
+	if pred.Kind == "=" {
 		if !isDollar(pred.LHS) {
 			return nil, "", false
 		}
 		if rhs, ok := pred.RHS.(*ast.Literal); ok && rhs.Type != "net" {
-			return rhs, pred.Operator, true
+			return rhs, pred.Kind, true
 		}
-	} else if pred.Operator == "in" {
+	} else if pred.Kind == "in" {
 		if !isDollar(pred.RHS) {
 			return nil, "", false
 		}
 		if lhs, ok := pred.LHS.(*ast.Literal); ok && lhs.Type != "net" {
-			return lhs, pred.Operator, true
+			return lhs, pred.Kind, true
 		}
 	}
 	return nil, "", false
 }
 
-func isSelectAll(e ast.Expression) bool {
-	s, ok := e.(*ast.SelectExpression)
+func isSelectAll(e ast.Expr) bool {
+	s, ok := e.(*ast.SelectExpr)
 	if !ok || len(s.Selectors) != 1 {
 		return false
 	}
-	_, ok = s.Selectors[0].(*ast.RootRecord)
+	_, ok = s.Selectors[0].(*ast.Root)
 	return ok
 }
 
-func isDollar(e ast.Expression) bool {
+func isDollar(e ast.Expr) bool {
 	if ref, ok := e.(*ast.Ref); ok && ref.Name == "$" {
 		return true
 	}

--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -22,7 +22,7 @@ func CompileBufferFilter(e ast.Expr) (*expr.BufferFilter, error) {
 		if literal, _ := isFieldEqualOrIn(e); literal != nil {
 			return newBufferFilterForLiteral(*literal)
 		}
-		if e.Kind == "and" {
+		if e.Op == "and" {
 			left, err := CompileBufferFilter(e.LHS)
 			if err != nil {
 				return nil, err
@@ -39,7 +39,7 @@ func CompileBufferFilter(e ast.Expr) (*expr.BufferFilter, error) {
 			}
 			return expr.NewAndBufferFilter(left, right), nil
 		}
-		if e.Kind == "or" {
+		if e.Op == "or" {
 			left, err := CompileBufferFilter(e.LHS)
 			if err != nil {
 				return nil, err
@@ -91,7 +91,7 @@ func isRootField(e ast.Expr) bool {
 		return true
 	}
 	b, ok := e.(*ast.BinaryExpr)
-	if !ok || b.Kind != "." {
+	if !ok || b.Op != "." {
 		return false
 	}
 	if _, ok := b.LHS.(*ast.Root); !ok {
@@ -102,11 +102,11 @@ func isRootField(e ast.Expr) bool {
 }
 
 func isFieldEqualOrIn(e *ast.BinaryExpr) (*ast.Literal, string) {
-	if isRootField(e.LHS) && e.Kind == "=" {
+	if isRootField(e.LHS) && e.Op == "=" {
 		if literal, ok := e.RHS.(*ast.Literal); ok {
 			return literal, "="
 		}
-	} else if isRootField(e.RHS) && e.Kind == "in" {
+	} else if isRootField(e.RHS) && e.Op == "in" {
 		if literal, ok := e.LHS.(*ast.Literal); ok && literal.Type != "net" {
 			return literal, "in"
 		}
@@ -127,19 +127,19 @@ func isCompareAny(seq *ast.SeqExpr) (*ast.Literal, string, bool) {
 	if !ok {
 		return nil, "", false
 	}
-	if pred.Kind == "=" {
+	if pred.Op == "=" {
 		if !isDollar(pred.LHS) {
 			return nil, "", false
 		}
 		if rhs, ok := pred.RHS.(*ast.Literal); ok && rhs.Type != "net" {
-			return rhs, pred.Kind, true
+			return rhs, pred.Op, true
 		}
-	} else if pred.Kind == "in" {
+	} else if pred.Op == "in" {
 		if !isDollar(pred.RHS) {
 			return nil, "", false
 		}
 		if lhs, ok := pred.LHS.(*ast.Literal); ok && lhs.Type != "net" {
-			return lhs, pred.Kind, true
+			return lhs, pred.Op, true
 		}
 	}
 	return nil, "", false

--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/zson"
 )
 
-var Root = &ast.Path{Op: "Path", Name: []string{}}
+var Root = &ast.Path{Kind: "Path", Name: []string{}}
 
 // compileExpr compiles the given Expression into an object
 // that evaluates the expression against a provided Record.  It returns an
@@ -111,14 +111,14 @@ func CompileExprs(zctx *resolver.Context, scope *Scope, nodes []ast.Expr) ([]exp
 }
 
 func compileBinary(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr) (expr.Evaluator, error) {
-	if slice, ok := e.RHS.(*ast.BinaryExpr); ok && slice.Kind == ":" {
+	if slice, ok := e.RHS.(*ast.BinaryExpr); ok && slice.Op == ":" {
 		return compileSlice(zctx, scope, e.LHS, slice)
 	}
 	lhs, err := compileExpr(zctx, scope, e.LHS)
 	if err != nil {
 		return nil, err
 	}
-	if e.Kind == "." {
+	if e.Op == "." {
 		// We should change this to DotExpr.  See issue #2255.
 		id, ok := e.RHS.(*ast.Id)
 		if !ok {
@@ -130,7 +130,7 @@ func compileBinary(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr) (exp
 	if err != nil {
 		return nil, err
 	}
-	switch op := e.Kind; op {
+	switch op := e.Op; op {
 	case "and", "or":
 		return compileLogical(lhs, rhs, op)
 	case "in":
@@ -222,11 +222,11 @@ func compileMethod(zctx *resolver.Context, scope *Scope, src expr.Generator, met
 	}
 }
 
-func compileUnary(zctx *resolver.Context, scope *Scope, node ast.UnaryExpr) (expr.Evaluator, error) {
-	if node.Kind != "!" {
-		return nil, fmt.Errorf("unknown unary operator %s\n", node.Kind)
+func compileUnary(zctx *resolver.Context, scope *Scope, unary ast.UnaryExpr) (expr.Evaluator, error) {
+	if unary.Op != "!" {
+		return nil, fmt.Errorf("unknown unary operator %s\n", unary.Op)
 	}
-	e, err := compileExpr(zctx, scope, node.Operand)
+	e, err := compileExpr(zctx, scope, unary.Operand)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/zson"
 )
 
-var RootField = &ast.FieldPath{Op: "FieldPath", Name: []string{}}
+var Root = &ast.Path{Op: "Path", Name: []string{}}
 
 // compileExpr compiles the given Expression into an object
 // that evaluates the expression against a provided Record.  It returns an
@@ -46,18 +46,18 @@ var RootField = &ast.FieldPath{Op: "FieldPath", Name: []string{}}
 // TBD: string values and net.IP address do not need to be copied because they
 // are allocated by go libraries and temporary buffers are not used.  This will
 // change down the road when we implement no-allocation string and IP conversion.
-func compileExpr(zctx *resolver.Context, scope *Scope, e ast.Expression) (expr.Evaluator, error) {
+func compileExpr(zctx *resolver.Context, scope *Scope, e ast.Expr) (expr.Evaluator, error) {
 	if e == nil {
 		return nil, errors.New("null expression not allowed")
 	}
 	switch e := e.(type) {
 	case *ast.Literal:
 		return expr.NewLiteral(*e)
-	case *ast.Identifier:
+	case *ast.Id:
 		// This should be converted in the semantic pass but it can come
 		// over the network from a worker, so we check again.
 		return nil, fmt.Errorf("Z kernel compiler: encountered AST identifier for '%s'", e.Name)
-	case *ast.RootRecord:
+	case *ast.Root:
 		return nil, fmt.Errorf("Z kernel compiler: encountered AST root record")
 	case *ast.Ref:
 		// If the reference refers to a named variable in scope (like "$"),
@@ -68,22 +68,22 @@ func compileExpr(zctx *resolver.Context, scope *Scope, e ast.Expression) (expr.E
 			return expr.NewVar(ref), nil
 		}
 		return nil, fmt.Errorf("unknown reference: '%s'", e.Name)
-	case *ast.FieldPath:
+	case *ast.Path:
 		return expr.NewDotExpr(field.Static(e.Name)), nil
-	case *ast.UnaryExpression:
+	case *ast.UnaryExpr:
 		return compileUnary(zctx, scope, *e)
-	case *ast.SelectExpression:
+	case *ast.SelectExpr:
 		return nil, errors.New("Z kernel: encountered select expression")
-	case *ast.BinaryExpression:
+	case *ast.BinaryExpr:
 		return compileBinary(zctx, scope, e)
-	case *ast.ConditionalExpression:
+	case *ast.Conditional:
 		return compileConditional(zctx, scope, *e)
-	case *ast.FunctionCall:
+	case *ast.Call:
 		return compileCall(zctx, scope, *e)
-	case *ast.CastExpression:
+	case *ast.Cast:
 		return compileCast(zctx, scope, *e)
-	case *ast.TypeExpr:
-		return compileTypeExpr(zctx, scope, *e)
+	case *ast.TypeValue:
+		return compileTypeValue(zctx, scope, e)
 	case *ast.SeqExpr:
 		return compileSeqExpr(zctx, scope, e)
 	default:
@@ -91,14 +91,14 @@ func compileExpr(zctx *resolver.Context, scope *Scope, e ast.Expression) (expr.E
 	}
 }
 
-func compileExprWithEmpty(zctx *resolver.Context, scope *Scope, e ast.Expression) (expr.Evaluator, error) {
+func compileExprWithEmpty(zctx *resolver.Context, scope *Scope, e ast.Expr) (expr.Evaluator, error) {
 	if e == nil {
 		return nil, nil
 	}
 	return compileExpr(zctx, scope, e)
 }
 
-func CompileExprs(zctx *resolver.Context, scope *Scope, nodes []ast.Expression) ([]expr.Evaluator, error) {
+func CompileExprs(zctx *resolver.Context, scope *Scope, nodes []ast.Expr) ([]expr.Evaluator, error) {
 	var exprs []expr.Evaluator
 	for k := range nodes {
 		e, err := compileExpr(zctx, scope, nodes[k])
@@ -110,17 +110,17 @@ func CompileExprs(zctx *resolver.Context, scope *Scope, nodes []ast.Expression) 
 	return exprs, nil
 }
 
-func compileBinary(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpression) (expr.Evaluator, error) {
-	if slice, ok := e.RHS.(*ast.BinaryExpression); ok && slice.Operator == ":" {
+func compileBinary(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr) (expr.Evaluator, error) {
+	if slice, ok := e.RHS.(*ast.BinaryExpr); ok && slice.Kind == ":" {
 		return compileSlice(zctx, scope, e.LHS, slice)
 	}
 	lhs, err := compileExpr(zctx, scope, e.LHS)
 	if err != nil {
 		return nil, err
 	}
-	if e.Operator == "." {
+	if e.Kind == "." {
 		// We should change this to DotExpr.  See issue #2255.
-		id, ok := e.RHS.(*ast.Identifier)
+		id, ok := e.RHS.(*ast.Id)
 		if !ok {
 			return nil, fmt.Errorf("Z kernel: RHS of dot operator is not a name")
 		}
@@ -130,7 +130,7 @@ func compileBinary(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpression
 	if err != nil {
 		return nil, err
 	}
-	switch op := e.Operator; op {
+	switch op := e.Kind; op {
 	case "and", "or":
 		return compileLogical(lhs, rhs, op)
 	case "in":
@@ -150,7 +150,7 @@ func compileBinary(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpression
 	}
 }
 
-func compileSlice(zctx *resolver.Context, scope *Scope, container ast.Expression, slice *ast.BinaryExpression) (expr.Evaluator, error) {
+func compileSlice(zctx *resolver.Context, scope *Scope, container ast.Expr, slice *ast.BinaryExpr) (expr.Evaluator, error) {
 	from, err := compileExprWithEmpty(zctx, scope, slice.LHS)
 	if err != nil {
 		return nil, err
@@ -222,9 +222,9 @@ func compileMethod(zctx *resolver.Context, scope *Scope, src expr.Generator, met
 	}
 }
 
-func compileUnary(zctx *resolver.Context, scope *Scope, node ast.UnaryExpression) (expr.Evaluator, error) {
-	if node.Operator != "!" {
-		return nil, fmt.Errorf("unknown unary operator %s\n", node.Operator)
+func compileUnary(zctx *resolver.Context, scope *Scope, node ast.UnaryExpr) (expr.Evaluator, error) {
+	if node.Kind != "!" {
+		return nil, fmt.Errorf("unknown unary operator %s\n", node.Kind)
 	}
 	e, err := compileExpr(zctx, scope, node.Operand)
 	if err != nil {
@@ -244,8 +244,8 @@ func compileLogical(lhs, rhs expr.Evaluator, operator string) (expr.Evaluator, e
 	}
 }
 
-func compileConditional(zctx *resolver.Context, scope *Scope, node ast.ConditionalExpression) (expr.Evaluator, error) {
-	predicate, err := compileExpr(zctx, scope, node.Condition)
+func compileConditional(zctx *resolver.Context, scope *Scope, node ast.Conditional) (expr.Evaluator, error) {
+	predicate, err := compileExpr(zctx, scope, node.Cond)
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +260,8 @@ func compileConditional(zctx *resolver.Context, scope *Scope, node ast.Condition
 	return expr.NewConditional(predicate, thenExpr, elseExpr), nil
 }
 
-func compileDotExpr(zctx *resolver.Context, scope *Scope, lhs, rhs ast.Expression) (expr.Evaluator, error) {
-	id, ok := rhs.(*ast.Identifier)
+func compileDotExpr(zctx *resolver.Context, scope *Scope, lhs, rhs ast.Expr) (expr.Evaluator, error) {
+	id, ok := rhs.(*ast.Id)
 	if !ok {
 		return nil, errors.New("rhs of dot expression is not an identifier")
 	}
@@ -272,7 +272,7 @@ func compileDotExpr(zctx *resolver.Context, scope *Scope, lhs, rhs ast.Expressio
 	return expr.NewDotAccess(record, id.Name), nil
 }
 
-func compileCast(zctx *resolver.Context, scope *Scope, node ast.CastExpression) (expr.Evaluator, error) {
+func compileCast(zctx *resolver.Context, scope *Scope, node ast.Cast) (expr.Evaluator, error) {
 	e, err := compileExpr(zctx, scope, node.Expr)
 	if err != nil {
 		return nil, err
@@ -285,8 +285,8 @@ func compileCast(zctx *resolver.Context, scope *Scope, node ast.CastExpression) 
 	return expr.NewCast(e, typ)
 }
 
-func compileLval(e ast.Expression) (field.Static, error) {
-	if e, ok := e.(*ast.FieldPath); ok {
+func compileLval(e ast.Expr) (field.Static, error) {
+	if e, ok := e.(*ast.Path); ok {
 		return field.Static(e.Name), nil
 	}
 	return nil, errors.New("invalid expression on lhs of assignment")
@@ -317,7 +317,7 @@ func CompileAssignments(dsts []field.Static, srcs []field.Static) ([]field.Stati
 	return fields, resolvers
 }
 
-func compileCutter(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (*expr.Cutter, error) {
+func compileCutter(zctx *resolver.Context, scope *Scope, node ast.Call) (*expr.Cutter, error) {
 	var lhs []field.Static
 	var rhs []expr.Evaluator
 	for _, expr := range node.Args {
@@ -363,10 +363,10 @@ func isShaperFunc(name string) bool {
 	return shaperOps(name) != 0
 }
 
-func compileShaper(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (*expr.Shaper, error) {
+func compileShaper(zctx *resolver.Context, scope *Scope, node ast.Call) (*expr.Shaper, error) {
 	args := node.Args
 	if len(args) == 1 {
-		args = append([]ast.Expression{RootField}, args...)
+		args = append([]ast.Expr{Root}, args...)
 	}
 	if len(args) < 2 {
 		return nil, function.ErrTooFewArgs
@@ -382,52 +382,52 @@ func compileShaper(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) 
 	if err != nil {
 		return nil, err
 	}
-	return expr.NewShaper(zctx, field, ev, shaperOps(node.Function))
+	return expr.NewShaper(zctx, field, ev, shaperOps(node.Name))
 }
 
-func compileCall(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (expr.Evaluator, error) {
+func compileCall(zctx *resolver.Context, scope *Scope, call ast.Call) (expr.Evaluator, error) {
 	// For now, we special case stateful functions here.  We shuold generalize this
 	// as we will add many more stateful functions and also resolve this
 	// the changes to create running aggegation functions from reducers.
 	// XXX See issue #1259.
 	switch {
-	case node.Function == "cut":
-		cut, err := compileCutter(zctx, scope, node)
+	case call.Name == "cut":
+		cut, err := compileCutter(zctx, scope, call)
 		if err != nil {
 			return nil, err
 		}
 		cut.AllowPartialCuts()
 		return cut, nil
-	case node.Function == "pick":
-		return compileCutter(zctx, scope, node)
-	case node.Function == "exists":
-		exprs, err := compileExprs(zctx, scope, node.Args)
+	case call.Name == "pick":
+		return compileCutter(zctx, scope, call)
+	case call.Name == "exists":
+		exprs, err := compileExprs(zctx, scope, call.Args)
 		if err != nil {
 			return nil, fmt.Errorf("exists: bad argument: %w", err)
 		}
 		return expr.NewExists(zctx, exprs), nil
-	case node.Function == "unflatten":
+	case call.Name == "unflatten":
 		return expr.NewUnflattener(zctx), nil
-	case isShaperFunc(node.Function):
-		return compileShaper(zctx, scope, node)
+	case isShaperFunc(call.Name):
+		return compileShaper(zctx, scope, call)
 	}
-	nargs := len(node.Args)
-	fn, root, err := function.New(zctx.Context, node.Function, nargs)
+	nargs := len(call.Args)
+	fn, root, err := function.New(zctx.Context, call.Name, nargs)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", node.Function, err)
+		return nil, fmt.Errorf("%s: %w", call.Name, err)
 	}
-	args := node.Args
+	args := call.Args
 	if root {
-		args = append([]ast.Expression{RootField}, args...)
+		args = append([]ast.Expr{Root}, args...)
 	}
 	exprs, err := compileExprs(zctx, scope, args)
 	if err != nil {
-		return nil, fmt.Errorf("%s: bad argument: %w", node.Function, err)
+		return nil, fmt.Errorf("%s: bad argument: %w", call.Name, err)
 	}
 	return expr.NewCall(zctx, fn, exprs), nil
 }
 
-func compileExprs(zctx *resolver.Context, scope *Scope, in []ast.Expression) ([]expr.Evaluator, error) {
+func compileExprs(zctx *resolver.Context, scope *Scope, in []ast.Expr) ([]expr.Evaluator, error) {
 	out := make([]expr.Evaluator, 0, len(in))
 	for _, e := range in {
 		ev, err := compileExpr(zctx, scope, e)
@@ -439,8 +439,8 @@ func compileExprs(zctx *resolver.Context, scope *Scope, in []ast.Expression) ([]
 	return out, nil
 }
 
-func compileTypeExpr(zctx *resolver.Context, scope *Scope, t ast.TypeExpr) (expr.Evaluator, error) {
-	if typ, ok := t.Type.(*ast.TypeName); ok {
+func compileTypeValue(zctx *resolver.Context, scope *Scope, t *ast.TypeValue) (expr.Evaluator, error) {
+	if typ, ok := t.Value.(*ast.TypeName); ok {
 		// We currently support dynamic type names only for
 		// top-level type names.  By dynamic, we mean typedefs that
 		// come from the data instead of the Z.  For dynamic type
@@ -450,7 +450,7 @@ func compileTypeExpr(zctx *resolver.Context, scope *Scope, t ast.TypeExpr) (expr
 		// See issue #2182.
 		return expr.NewTypeFunc(zctx, typ.Name), nil
 	}
-	typ, err := zson.TranslateType(zctx.Context, t.Type)
+	typ, err := zson.TranslateType(zctx.Context, t.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/kernel/filter.go
+++ b/compiler/kernel/filter.go
@@ -9,8 +9,8 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-func compileCompareField(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpression) (expr.Filter, error) {
-	if e.Operator == "in" {
+func compileCompareField(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr) (expr.Filter, error) {
+	if e.Kind == "in" {
 		literal, ok := e.LHS.(*ast.Literal)
 		if !ok {
 			return nil, nil
@@ -31,7 +31,7 @@ func compileCompareField(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr
 	if !ok {
 		return nil, nil
 	}
-	comparison, err := expr.Comparison(e.Operator, *literal)
+	comparison, err := expr.Comparison(e.Kind, *literal)
 	if err != nil {
 		// If this fails, return no match instead of the error and
 		// let later-on code detect the error as this could be a
@@ -74,11 +74,11 @@ func compileSearch(node *ast.Search) (expr.Filter, error) {
 	return expr.SearchRecordOther(node.Text, node.Value)
 }
 
-func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expression) (expr.Filter, error) {
+func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expr) (expr.Filter, error) {
 	switch v := node.(type) {
-	case *ast.UnaryExpression:
-		if v.Operator != "!" {
-			return nil, fmt.Errorf("unknown unary operator: %s", v.Operator)
+	case *ast.UnaryExpr:
+		if v.Kind != "!" {
+			return nil, fmt.Errorf("unknown unary operator: %s", v.Kind)
 		}
 		e, err := CompileFilter(zctx, scope, v.Operand)
 		if err != nil {
@@ -106,8 +106,8 @@ func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expression) (e
 	case *ast.Search:
 		return compileSearch(v)
 
-	case *ast.BinaryExpression:
-		if v.Operator == "and" {
+	case *ast.BinaryExpr:
+		if v.Kind == "and" {
 			left, err := CompileFilter(zctx, scope, v.LHS)
 			if err != nil {
 				return nil, err
@@ -118,7 +118,7 @@ func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expression) (e
 			}
 			return expr.LogicalAnd(left, right), nil
 		}
-		if v.Operator == "or" {
+		if v.Kind == "or" {
 			left, err := CompileFilter(zctx, scope, v.LHS)
 			if err != nil {
 				return nil, err
@@ -134,7 +134,7 @@ func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expression) (e
 		}
 		return compileExprPredicate(zctx, scope, v)
 
-	case *ast.FunctionCall:
+	case *ast.Call:
 		return compileExprPredicate(zctx, scope, v)
 	case *ast.SeqExpr:
 		if f, err := compileCompareAny(v); f != nil || err != nil {
@@ -147,7 +147,7 @@ func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expression) (e
 	}
 }
 
-func compileExprPredicate(zctx *resolver.Context, scope *Scope, e ast.Expression) (expr.Filter, error) {
+func compileExprPredicate(zctx *resolver.Context, scope *Scope, e ast.Expr) (expr.Filter, error) {
 	predicate, err := compileExpr(zctx, scope, e)
 	if err != nil {
 		return nil, err

--- a/compiler/kernel/filter.go
+++ b/compiler/kernel/filter.go
@@ -10,7 +10,7 @@ import (
 )
 
 func compileCompareField(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr) (expr.Filter, error) {
-	if e.Kind == "in" {
+	if e.Op == "in" {
 		literal, ok := e.LHS.(*ast.Literal)
 		if !ok {
 			return nil, nil
@@ -31,7 +31,7 @@ func compileCompareField(zctx *resolver.Context, scope *Scope, e *ast.BinaryExpr
 	if !ok {
 		return nil, nil
 	}
-	comparison, err := expr.Comparison(e.Kind, *literal)
+	comparison, err := expr.Comparison(e.Op, *literal)
 	if err != nil {
 		// If this fails, return no match instead of the error and
 		// let later-on code detect the error as this could be a
@@ -77,8 +77,8 @@ func compileSearch(node *ast.Search) (expr.Filter, error) {
 func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expr) (expr.Filter, error) {
 	switch v := node.(type) {
 	case *ast.UnaryExpr:
-		if v.Kind != "!" {
-			return nil, fmt.Errorf("unknown unary operator: %s", v.Kind)
+		if v.Op != "!" {
+			return nil, fmt.Errorf("unknown unary operator: %s", v.Op)
 		}
 		e, err := CompileFilter(zctx, scope, v.Operand)
 		if err != nil {
@@ -107,7 +107,7 @@ func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expr) (expr.Fi
 		return compileSearch(v)
 
 	case *ast.BinaryExpr:
-		if v.Kind == "and" {
+		if v.Op == "and" {
 			left, err := CompileFilter(zctx, scope, v.LHS)
 			if err != nil {
 				return nil, err
@@ -118,7 +118,7 @@ func CompileFilter(zctx *resolver.Context, scope *Scope, node ast.Expr) (expr.Fi
 			}
 			return expr.LogicalAnd(left, right), nil
 		}
-		if v.Kind == "or" {
+		if v.Op == "or" {
 			left, err := CompileFilter(zctx, scope, v.LHS)
 			if err != nil {
 				return nil, err

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -361,7 +361,7 @@ func Compile(custom Hook, node ast.Proc, pctx *proc.Context, scope *Scope, paren
 		inner := true
 		leftParent := parents[0]
 		rightParent := parents[1]
-		switch node.Kind {
+		switch node.Style {
 		case "left":
 			inner = false
 		case "right":
@@ -370,7 +370,7 @@ func Compile(custom Hook, node ast.Proc, pctx *proc.Context, scope *Scope, paren
 			leftParent, rightParent = rightParent, leftParent
 		case "inner":
 		default:
-			return nil, fmt.Errorf("unknown kind of join: '%s'", node.Kind)
+			return nil, fmt.Errorf("unknown kind of join: '%s'", node.Style)
 		}
 		join, err := join.New(pctx, inner, leftParent, rightParent, leftKey, rightKey, lhs, rhs)
 		if err != nil {

--- a/compiler/semantic/ast.go
+++ b/compiler/semantic/ast.go
@@ -9,7 +9,7 @@ type AST struct {
 	entry   ast.Proc
 	unopt   ast.Proc
 	consts  []ast.Proc
-	filter  ast.Expression
+	filter  ast.Expr
 	sortKey field.Static
 	sortRev bool
 }
@@ -29,7 +29,7 @@ func (a *AST) Consts() []ast.Proc {
 	return a.consts
 }
 
-func (a *AST) Filter() ast.Expression {
+func (a *AST) Filter() ast.Expr {
 	return a.filter
 }
 

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/expr/agg"
 )
 
-func semExpr(scope *Scope, e ast.Expression) (ast.Expression, error) {
+func semExpr(scope *Scope, e ast.Expr) (ast.Expr, error) {
 	switch e := e.(type) {
 	case nil:
 		return nil, errors.New("semantic analysis: illegal null value encountered in AST")
@@ -20,7 +20,7 @@ func semExpr(scope *Scope, e ast.Expression) (ast.Expression, error) {
 			}
 		}
 		return e, nil
-	case *ast.Identifier:
+	case *ast.Id:
 		// We use static scoping here to see if an identifier is
 		// a "var" reference to the name or a field access
 		// and transform the ast node appropriately.  The semantic AST
@@ -36,26 +36,26 @@ func semExpr(scope *Scope, e ast.Expression) (ast.Expression, error) {
 			return &ast.Ref{"Ref", "$"}, nil
 		}
 		return semField(scope, e)
-	case *ast.RootRecord:
+	case *ast.Root:
 		return semField(scope, e)
 	case *ast.Search:
 		return e, nil
-	case *ast.UnaryExpression:
+	case *ast.UnaryExpr:
 		expr, err := semExpr(scope, e.Operand)
 		if err != nil {
 			return nil, err
 		}
-		return &ast.UnaryExpression{
-			Op:       "UnaryExpr",
-			Operator: e.Operator,
-			Operand:  expr,
+		return &ast.UnaryExpr{
+			Op:      "UnaryExpr",
+			Kind:    e.Kind,
+			Operand: expr,
 		}, nil
-	case *ast.SelectExpression:
+	case *ast.SelectExpr:
 		return nil, errors.New("select expression found outside of generator context")
-	case *ast.BinaryExpression:
+	case *ast.BinaryExpr:
 		return semBinary(scope, e)
-	case *ast.ConditionalExpression:
-		cond, err := semExpr(scope, e.Condition)
+	case *ast.Conditional:
+		cond, err := semExpr(scope, e.Cond)
 		if err != nil {
 			return nil, err
 		}
@@ -67,57 +67,57 @@ func semExpr(scope *Scope, e ast.Expression) (ast.Expression, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &ast.ConditionalExpression{
-			Op:        "ConditionalExpr",
-			Condition: cond,
-			Then:      thenExpr,
-			Else:      elseExpr,
+		return &ast.Conditional{
+			Op:   "Conditional",
+			Cond: cond,
+			Then: thenExpr,
+			Else: elseExpr,
 		}, nil
-	case *ast.FunctionCall:
+	case *ast.Call:
 		return semCall(scope, e)
-	case *ast.CastExpression:
+	case *ast.Cast:
 		expr, err := semExpr(scope, e.Expr)
 		if err != nil {
 			return nil, err
 		}
-		return &ast.CastExpression{
-			Op:   "CastExpr",
+		return &ast.Cast{
+			Op:   "Cast",
 			Expr: expr,
 			Type: e.Type, //XXX
 		}, nil
-	case *ast.TypeExpr:
-		return &ast.TypeExpr{
-			Op:   "TypeExpr",
-			Type: e.Type, //XXX
+	case *ast.TypeValue:
+		return &ast.TypeValue{
+			Op:    "TypeValue",
+			Value: e.Value,
 		}, nil
-	case *ast.Reducer:
+	case *ast.Agg:
 		expr, err := semExprNullable(scope, e.Expr)
 		if err != nil {
 			return nil, err
 		}
-		if expr == nil && e.Operator != "count" {
-			return nil, fmt.Errorf("aggregator '%s' requires argument", e.Operator)
+		if expr == nil && e.Name != "count" {
+			return nil, fmt.Errorf("aggregator '%s' requires argument", e.Name)
 		}
 		where, err := semExprNullable(scope, e.Where)
 		if err != nil {
 			return nil, err
 		}
-		return &ast.Reducer{
-			Op:       "Reducer",
-			Operator: e.Operator,
-			Expr:     expr,
-			Where:    where,
+		return &ast.Agg{
+			Op:    "Agg",
+			Name:  e.Name,
+			Expr:  expr,
+			Where: where,
 		}, nil
 	}
 	return nil, fmt.Errorf("invalid expression type %T", e)
 }
 
-func semBinary(scope *Scope, e *ast.BinaryExpression) (ast.Expression, error) {
-	op := e.Operator
+func semBinary(scope *Scope, e *ast.BinaryExpr) (ast.Expr, error) {
+	op := e.Kind
 	if op == "." {
 		return semField(scope, e)
 	}
-	if slice, ok := e.RHS.(*ast.BinaryExpression); ok && slice.Operator == ":" {
+	if slice, ok := e.RHS.(*ast.BinaryExpr); ok && slice.Kind == ":" {
 		if op != "[" {
 			return nil, errors.New("slice outside of index operator")
 		}
@@ -129,11 +129,11 @@ func semBinary(scope *Scope, e *ast.BinaryExpression) (ast.Expression, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &ast.BinaryExpression{
-			Op:       "BinaryExpr",
-			Operator: "[",
-			LHS:      ref,
-			RHS:      slice,
+		return &ast.BinaryExpr{
+			Op:   "BinaryExpr",
+			Kind: "[",
+			LHS:  ref,
+			RHS:  slice,
 		}, nil
 	}
 	lhs, err := semExpr(scope, e.LHS)
@@ -144,15 +144,15 @@ func semBinary(scope *Scope, e *ast.BinaryExpression) (ast.Expression, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ast.BinaryExpression{
-		Op:       "BinaryExpr",
-		Operator: e.Operator,
-		LHS:      lhs,
-		RHS:      rhs,
+	return &ast.BinaryExpr{
+		Op:   "BinaryExpr",
+		Kind: e.Kind,
+		LHS:  lhs,
+		RHS:  rhs,
 	}, nil
 }
 
-func semSlice(scope *Scope, slice *ast.BinaryExpression) (*ast.BinaryExpression, error) {
+func semSlice(scope *Scope, slice *ast.BinaryExpr) (*ast.BinaryExpr, error) {
 	sliceFrom, err := semExprNullable(scope, slice.LHS)
 	if err != nil {
 		return nil, err
@@ -161,45 +161,45 @@ func semSlice(scope *Scope, slice *ast.BinaryExpression) (*ast.BinaryExpression,
 	if err != nil {
 		return nil, err
 	}
-	return &ast.BinaryExpression{
-		Op:       "BinaryExpr",
-		Operator: ":",
-		LHS:      sliceFrom,
-		RHS:      sliceTo,
+	return &ast.BinaryExpr{
+		Op:   "BinaryExpr",
+		Kind: ":",
+		LHS:  sliceFrom,
+		RHS:  sliceTo,
 	}, nil
 }
 
-func semExprNullable(scope *Scope, e ast.Expression) (ast.Expression, error) {
+func semExprNullable(scope *Scope, e ast.Expr) (ast.Expr, error) {
 	if e == nil {
 		return nil, nil
 	}
 	return semExpr(scope, e)
 }
 
-func semCall(scope *Scope, call *ast.FunctionCall) (ast.Expression, error) {
+func semCall(scope *Scope, call *ast.Call) (ast.Expr, error) {
 	if e, err := semSequence(scope, call); e != nil || err != nil {
 		return e, err
 	}
 	exprs, err := semExprs(scope, call.Args)
 	if err != nil {
-		return nil, fmt.Errorf("%s: bad argument: %w", call.Function, err)
+		return nil, fmt.Errorf("%s: bad argument: %w", call.Name, err)
 	}
-	return &ast.FunctionCall{
-		Op:       "FunctionCall",
-		Function: call.Function,
-		Args:     exprs,
+	return &ast.Call{
+		Op:   "Call",
+		Name: call.Name,
+		Args: exprs,
 	}, nil
 }
 
-func semSequence(scope *Scope, call *ast.FunctionCall) (*ast.SeqExpr, error) {
+func semSequence(scope *Scope, call *ast.Call) (*ast.SeqExpr, error) {
 	if len(call.Args) != 1 {
 		return nil, nil
 	}
-	sel, ok := call.Args[0].(*ast.SelectExpression)
+	sel, ok := call.Args[0].(*ast.SelectExpr)
 	if !ok {
 		return nil, nil
 	}
-	_, err := agg.NewPattern(call.Function)
+	_, err := agg.NewPattern(call.Name)
 	if err != nil {
 		return nil, nil
 	}
@@ -217,14 +217,14 @@ func semSequence(scope *Scope, call *ast.FunctionCall) (*ast.SeqExpr, error) {
 	}
 	return &ast.SeqExpr{
 		Op:        "SeqExpr",
-		Name:      call.Function,
+		Name:      call.Name,
 		Selectors: selectors,
 		Methods:   methods,
 	}, nil
 }
 
-func semMethod(scope *Scope, call ast.FunctionCall) (*ast.Method, error) {
-	switch call.Function {
+func semMethod(scope *Scope, call ast.Call) (*ast.Method, error) {
+	switch call.Name {
 	case "map":
 		if len(call.Args) != 1 {
 			return nil, errors.New("map() method requires one argument")
@@ -236,7 +236,7 @@ func semMethod(scope *Scope, call ast.FunctionCall) (*ast.Method, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &ast.Method{Name: "map", Args: []ast.Expression{e}}, nil
+		return &ast.Method{Name: "map", Args: []ast.Expr{e}}, nil
 	case "filter":
 		if len(call.Args) != 1 {
 			return nil, errors.New("filter() method requires one argument")
@@ -248,14 +248,14 @@ func semMethod(scope *Scope, call ast.FunctionCall) (*ast.Method, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &ast.Method{Name: "filter", Args: []ast.Expression{e}}, nil
+		return &ast.Method{Name: "filter", Args: []ast.Expr{e}}, nil
 	default:
-		return nil, fmt.Errorf("uknown method: %s", call.Function)
+		return nil, fmt.Errorf("uknown method: %s", call.Name)
 	}
 }
 
-func semExprs(scope *Scope, in []ast.Expression) ([]ast.Expression, error) {
-	exprs := make([]ast.Expression, 0, len(in))
+func semExprs(scope *Scope, in []ast.Expr) ([]ast.Expr, error) {
+	exprs := make([]ast.Expr, 0, len(in))
 	for _, e := range in {
 		expr, err := semExpr(scope, e)
 		if err != nil {
@@ -283,7 +283,7 @@ func semAssignment(scope *Scope, a ast.Assignment) (ast.Assignment, error) {
 	if err != nil {
 		return ast.Assignment{}, fmt.Errorf("rhs of assigment expression: %w", err)
 	}
-	var lhs ast.Expression
+	var lhs ast.Expr
 	if a.LHS != nil {
 		// XXX currently only support explicit field lvals
 		// (i.e., no assignments to array elements etc... instead
@@ -292,12 +292,12 @@ func semAssignment(scope *Scope, a ast.Assignment) (ast.Assignment, error) {
 		if err != nil {
 			return ast.Assignment{}, fmt.Errorf("lhs of assigment expression: %w", err)
 		}
-	} else if call, ok := a.RHS.(*ast.FunctionCall); ok {
-		lhs = &ast.FieldPath{"FieldPath", []string{call.Function}}
-	} else if r, ok := a.RHS.(*ast.Reducer); ok {
-		lhs = &ast.FieldPath{"FieldPath", []string{r.Operator}}
-	} else if _, ok := a.RHS.(*ast.RootRecord); ok {
-		lhs = &ast.FieldPath{"FieldPath", []string{"."}}
+	} else if call, ok := a.RHS.(*ast.Call); ok {
+		lhs = &ast.Path{"Path", []string{call.Name}}
+	} else if agg, ok := a.RHS.(*ast.Agg); ok {
+		lhs = &ast.Path{"Path", []string{agg.Name}}
+	} else if _, ok := a.RHS.(*ast.Root); ok {
+		lhs = &ast.Path{"Path", []string{"."}}
 	} else {
 		lhs, err = semField(scope, a.RHS)
 		if err != nil {
@@ -307,8 +307,8 @@ func semAssignment(scope *Scope, a ast.Assignment) (ast.Assignment, error) {
 	return ast.Assignment{"Assignment", lhs, rhs}, nil
 }
 
-func semFields(scope *Scope, exprs []ast.Expression) ([]ast.Expression, error) {
-	fields := make([]ast.Expression, 0, len(exprs))
+func semFields(scope *Scope, exprs []ast.Expr) ([]ast.Expr, error) {
+	fields := make([]ast.Expr, 0, len(exprs))
 	for _, e := range exprs {
 		f, err := semField(scope, e)
 		if err != nil {
@@ -321,30 +321,30 @@ func semFields(scope *Scope, exprs []ast.Expression) ([]ast.Expression, error) {
 
 // semField checks that an expression is a field refernce and converts it
 // to a field path if possible.  It will convert any references to Refs.
-func semField(scope *Scope, e ast.Expression) (ast.Expression, error) {
+func semField(scope *Scope, e ast.Expr) (ast.Expr, error) {
 	switch e := e.(type) {
-	case *ast.BinaryExpression:
-		if e.Operator == "." {
+	case *ast.BinaryExpr:
+		if e.Kind == "." {
 			lhs, err := semField(scope, e.LHS)
 			if err != nil {
 				return nil, err
 			}
-			id, ok := e.RHS.(*ast.Identifier)
+			id, ok := e.RHS.(*ast.Id)
 			if !ok {
 				return nil, errors.New("RHS of dot operator is not an identifier")
 			}
-			if lhs, ok := lhs.(*ast.FieldPath); ok {
+			if lhs, ok := lhs.(*ast.Path); ok {
 				lhs.Name = append(lhs.Name, id.Name)
 				return lhs, nil
 			}
-			return &ast.BinaryExpression{
-				Op:       "BinaryExpr",
-				Operator: ".",
-				LHS:      lhs,
-				RHS:      id,
+			return &ast.BinaryExpr{
+				Op:   "BinaryExpr",
+				Kind: ".",
+				LHS:  lhs,
+				RHS:  id,
 			}, nil
 		}
-		if e.Operator == "[" {
+		if e.Kind == "[" {
 			lhs, err := semField(scope, e.LHS)
 			if err != nil {
 				return nil, err
@@ -353,14 +353,14 @@ func semField(scope *Scope, e ast.Expression) (ast.Expression, error) {
 			if err != nil {
 				return nil, err
 			}
-			return &ast.BinaryExpression{
-				Op:       "BinaryExpr",
-				Operator: "[",
-				LHS:      lhs,
-				RHS:      rhs,
+			return &ast.BinaryExpr{
+				Op:   "BinaryExpr",
+				Kind: "[",
+				LHS:  lhs,
+				RHS:  rhs,
 			}, nil
 		}
-	case *ast.Identifier:
+	case *ast.Id:
 		if scope.Lookup(e.Name) != nil {
 			// For now, this could only be a literal but
 			// it may refer to other data types down the
@@ -370,9 +370,9 @@ func semField(scope *Scope, e ast.Expression) (ast.Expression, error) {
 		if e.Name == "$" {
 			return &ast.Ref{"Ref", "$"}, nil
 		}
-		return &ast.FieldPath{Op: "FieldPath", Name: []string{e.Name}}, nil
-	case *ast.RootRecord:
-		return &ast.FieldPath{Op: "FieldPath", Name: []string{}}, nil
+		return &ast.Path{Op: "Path", Name: []string{e.Name}}, nil
+	case *ast.Root:
+		return &ast.Path{Op: "Path", Name: []string{}}, nil
 	}
 	// This includes a null Expr, which can happen if the AST is missing
 	// a field or sets it to null.
@@ -383,30 +383,30 @@ func semField(scope *Scope, e ast.Expression) (ast.Expression, error) {
 // to a group-by or a filter-proc based on the name of the function.
 // This way, Z of the form `... | exists(...) | ...` can be distinguished
 // from `count()` by the name lookup here at compile time.
-func convertFunctionProc(call *ast.FunctionCall) (ast.Proc, error) {
-	if _, err := agg.NewPattern(call.Function); err != nil {
+func convertFunctionProc(call *ast.Call) (ast.Proc, error) {
+	if _, err := agg.NewPattern(call.Name); err != nil {
 		// Assume it's a valid function and convert.  If not,
 		// the compiler will report an unknown function error.
 		return ast.FilterToProc(call), nil
 	}
-	var e ast.Expression
+	var e ast.Expr
 	if len(call.Args) > 1 {
-		return nil, fmt.Errorf("%s: wrong number of arguments", call.Function)
+		return nil, fmt.Errorf("%s: wrong number of arguments", call.Name)
 	}
 	if len(call.Args) == 1 {
 		e = call.Args[0]
 	}
-	reducer := &ast.Reducer{
-		Op:       "Reducer",
-		Operator: call.Function,
-		Expr:     e,
+	agg := &ast.Agg{
+		Op:   "Agg",
+		Name: call.Name,
+		Expr: e,
 	}
-	return &ast.GroupByProc{
-		Op: "GroupByProc",
-		Reducers: []ast.Assignment{
+	return &ast.Summarize{
+		Op: "Summarize",
+		Aggs: []ast.Assignment{
 			{
 				Op:  "Assignment",
-				RHS: reducer,
+				RHS: agg,
 			},
 		},
 	}, nil

--- a/compiler/semantic/parallelize.go
+++ b/compiler/semantic/parallelize.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/field"
 )
 
-var passProc = &ast.Pass{Op: "Pass"}
+var passProc = &ast.Pass{Kind: "Pass"}
 
 //XXX
 func zbufDirInt(reversed bool) int {
@@ -23,7 +23,7 @@ func ensureSequentialProc(p ast.Proc) *ast.Sequential {
 		return p
 	}
 	return &ast.Sequential{
-		Op:    "Sequential",
+		Kind:  "Sequential",
 		Procs: []ast.Proc{p},
 	}
 }
@@ -58,7 +58,7 @@ func liftFilter(p ast.Proc) (ast.Expr, ast.Proc) {
 			rest := ast.Proc(passProc)
 			if len(seq.Procs) > 1 {
 				rest = &ast.Sequential{
-					Op:    "Sequential",
+					Kind:  "Sequential",
 					Procs: seq.Procs[1:],
 				}
 			}
@@ -192,7 +192,7 @@ func copyProc(p ast.Proc) ast.Proc {
 func buildSplitFlowgraph(branch, tail []ast.Proc, mergeField field.Static, reverse bool, N int) (*ast.Sequential, bool) {
 	if len(branch) == 0 {
 		return &ast.Sequential{
-			Op:    "Sequential",
+			Kind:  "Sequential",
 			Procs: tail,
 		}, false
 	}
@@ -200,22 +200,22 @@ func buildSplitFlowgraph(branch, tail []ast.Proc, mergeField field.Static, rever
 		// Insert a pass tail in order to force a merge of the
 		// parallel branches when compiling. (Trailing parallel branches are wired to
 		// a mux output).
-		tail = []ast.Proc{&ast.Pass{Op: "Pass"}}
+		tail = []ast.Proc{passProc}
 	}
 	pp := &ast.Parallel{
-		Op:           "Parallel",
+		Kind:         "Parallel",
 		Procs:        []ast.Proc{},
 		MergeBy:      mergeField,
 		MergeReverse: reverse,
 	}
 	for i := 0; i < N; i++ {
 		pp.Procs = append(pp.Procs, &ast.Sequential{
-			Op:    "Sequential",
+			Kind:  "Sequential",
 			Procs: copyProcs(branch),
 		})
 	}
 	return &ast.Sequential{
-		Op:    "Sequential",
+		Kind:  "Sequential",
 		Procs: append([]ast.Proc{pp}, tail...),
 	}, true
 }

--- a/compiler/semantic/parallelize.go
+++ b/compiler/semantic/parallelize.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/field"
 )
 
-var passProc = &ast.PassProc{Op: "PassProc"}
+var passProc = &ast.Pass{Op: "Pass"}
 
 //XXX
 func zbufDirInt(reversed bool) int {
@@ -18,12 +18,12 @@ func zbufDirInt(reversed bool) int {
 	return 1
 }
 
-func ensureSequentialProc(p ast.Proc) *ast.SequentialProc {
-	if p, ok := p.(*ast.SequentialProc); ok {
+func ensureSequentialProc(p ast.Proc) *ast.Sequential {
+	if p, ok := p.(*ast.Sequential); ok {
 		return p
 	}
-	return &ast.SequentialProc{
-		Op:    "SequentialProc",
+	return &ast.Sequential{
+		Op:    "Sequential",
 		Procs: []ast.Proc{p},
 	}
 }
@@ -31,7 +31,7 @@ func ensureSequentialProc(p ast.Proc) *ast.SequentialProc {
 func countConsts(procs []ast.Proc) int {
 	for k, p := range procs {
 		switch p.(type) {
-		case *ast.ConstProc, *ast.TypeProc:
+		case *ast.Const, *ast.TypeProc:
 			continue
 		default:
 			return k
@@ -44,25 +44,25 @@ func countConsts(procs []ast.Proc) int {
 // one is present, and returns its ast.Expression and the modified
 // flowgraph AST. If the flowgraph does not start with a filter, it
 // returns nil and the unmodified flowgraph.
-func liftFilter(p ast.Proc) (ast.Expression, ast.Proc) {
-	if fp, ok := p.(*ast.FilterProc); ok {
-		return fp.Filter, passProc
+func liftFilter(p ast.Proc) (ast.Expr, ast.Proc) {
+	if fp, ok := p.(*ast.Filter); ok {
+		return fp.Expr, passProc
 	}
-	seq, ok := p.(*ast.SequentialProc)
+	seq, ok := p.(*ast.Sequential)
 	if ok && len(seq.Procs) > 0 {
 		nc := countConsts(seq.Procs)
 		if nc != 0 {
 			panic("internal error: consts should have been removed from AST")
 		}
-		if fp, ok := seq.Procs[0].(*ast.FilterProc); ok {
+		if fp, ok := seq.Procs[0].(*ast.Filter); ok {
 			rest := ast.Proc(passProc)
 			if len(seq.Procs) > 1 {
-				rest = &ast.SequentialProc{
-					Op:    "SequentialProc",
+				rest = &ast.Sequential{
+					Op:    "Sequential",
 					Procs: seq.Procs[1:],
 				}
 			}
-			return fp.Filter, rest
+			return fp.Expr, rest
 		}
 	}
 	return nil, p
@@ -70,15 +70,15 @@ func liftFilter(p ast.Proc) (ast.Expression, ast.Proc) {
 
 // all fields should be turned into field paths by initial semantic pass
 
-func exprToField(e ast.Expression) field.Static {
-	f, ok := e.(*ast.FieldPath)
+func exprToField(e ast.Expr) field.Static {
+	f, ok := e.(*ast.Path)
 	if !ok {
 		return nil
 	}
 	return f.Name
 }
 
-func eq(e ast.Expression, b field.Static) bool {
+func eq(e ast.Expr, b field.Static) bool {
 	a := exprToField(e)
 	if a == nil {
 		return false
@@ -96,31 +96,31 @@ func eq(e ast.Expression, b field.Static) bool {
 // inputSortDir; otherwise, it returns false.
 func SetGroupByProcInputSortDir(p ast.Proc, inputSortField field.Static, inputSortDir int) bool {
 	switch p := p.(type) {
-	case *ast.CutProc:
+	case *ast.Cut:
 		// Return true if the output record contains inputSortField.
-		for _, f := range p.Fields {
+		for _, f := range p.Args {
 			if eq(f.RHS, inputSortField) {
 				return true
 			}
 		}
 		return false
-	case *ast.PickProc:
+	case *ast.Pick:
 		// Return true if the output record contains inputSortField.
-		for _, f := range p.Fields {
+		for _, f := range p.Args {
 			if eq(f.RHS, inputSortField) {
 				return true
 			}
 		}
 		return false
-	case *ast.DropProc:
+	case *ast.Drop:
 		// Return true if the output record contains inputSortField.
-		for _, e := range p.Fields {
+		for _, e := range p.Args {
 			if eq(e, inputSortField) {
 				return false
 			}
 		}
 		return true
-	case *ast.GroupByProc:
+	case *ast.Summarize:
 		// Set p.InputSortDir and return true if the first grouping key
 		// is inputSortField or an order-preserving function of it.
 		if len(p.Keys) > 0 && eq(p.Keys[0].LHS, inputSortField) {
@@ -129,13 +129,13 @@ func SetGroupByProcInputSortDir(p ast.Proc, inputSortField field.Static, inputSo
 				p.InputSortDir = inputSortDir
 				return true
 			}
-			if expr, ok := p.Keys[0].RHS.(*ast.FunctionCall); ok {
-				switch expr.Function {
+			if call, ok := p.Keys[0].RHS.(*ast.Call); ok {
+				switch call.Name {
 				case "ceil", "floor", "round", "trunc":
-					if len(expr.Args) == 0 {
+					if len(call.Args) == 0 {
 						return false
 					}
-					arg0 := exprToField(expr.Args[0])
+					arg0 := exprToField(call.Args[0])
 					if arg0 != nil && arg0.Equal(inputSortField) {
 						p.InputSortDir = inputSortDir
 						return true
@@ -144,22 +144,22 @@ func SetGroupByProcInputSortDir(p ast.Proc, inputSortField field.Static, inputSo
 			}
 		}
 		return false
-	case *ast.PutProc:
-		for _, c := range p.Clauses {
+	case *ast.Put:
+		for _, c := range p.Args {
 			lhs := exprToField(c.LHS)
 			if lhs != nil && lhs.Equal(inputSortField) {
 				return false
 			}
 		}
 		return true
-	case *ast.SequentialProc:
+	case *ast.Sequential:
 		for _, pp := range p.Procs {
 			if !SetGroupByProcInputSortDir(pp, inputSortField, inputSortDir) {
 				return false
 			}
 		}
 		return true
-	case *ast.FilterProc, *ast.HeadProc, *ast.PassProc, *ast.UniqProc, *ast.TailProc, *ast.FuseProc, *ast.ConstProc, *ast.TypeProc:
+	case *ast.Filter, *ast.Head, *ast.Pass, *ast.Uniq, *ast.Tail, *ast.Fuse, *ast.Const, *ast.TypeProc:
 		return true
 	default:
 		return false
@@ -189,10 +189,10 @@ func copyProc(p ast.Proc) ast.Proc {
 	return copy
 }
 
-func buildSplitFlowgraph(branch, tail []ast.Proc, mergeField field.Static, reverse bool, N int) (*ast.SequentialProc, bool) {
+func buildSplitFlowgraph(branch, tail []ast.Proc, mergeField field.Static, reverse bool, N int) (*ast.Sequential, bool) {
 	if len(branch) == 0 {
-		return &ast.SequentialProc{
-			Op:    "SequentialProc",
+		return &ast.Sequential{
+			Op:    "Sequential",
 			Procs: tail,
 		}, false
 	}
@@ -200,27 +200,27 @@ func buildSplitFlowgraph(branch, tail []ast.Proc, mergeField field.Static, rever
 		// Insert a pass tail in order to force a merge of the
 		// parallel branches when compiling. (Trailing parallel branches are wired to
 		// a mux output).
-		tail = []ast.Proc{&ast.PassProc{Op: "PassProc"}}
+		tail = []ast.Proc{&ast.Pass{Op: "Pass"}}
 	}
-	pp := &ast.ParallelProc{
-		Op:                "ParallelProc",
-		Procs:             []ast.Proc{},
-		MergeOrderField:   mergeField,
-		MergeOrderReverse: reverse,
+	pp := &ast.Parallel{
+		Op:           "Parallel",
+		Procs:        []ast.Proc{},
+		MergeBy:      mergeField,
+		MergeReverse: reverse,
 	}
 	for i := 0; i < N; i++ {
-		pp.Procs = append(pp.Procs, &ast.SequentialProc{
-			Op:    "SequentialProc",
+		pp.Procs = append(pp.Procs, &ast.Sequential{
+			Op:    "Sequential",
 			Procs: copyProcs(branch),
 		})
 	}
-	return &ast.SequentialProc{
-		Op:    "SequentialProc",
+	return &ast.Sequential{
+		Op:    "Sequential",
 		Procs: append([]ast.Proc{pp}, tail...),
 	}, true
 }
 
-func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortReversed bool) (*ast.SequentialProc, bool) {
+func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortReversed bool) (*ast.Sequential, bool) {
 	if p == nil {
 		panic("parallelize nil")
 	}
@@ -229,7 +229,7 @@ func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortRevers
 	orderSensitiveTail := true
 	for i := range seq.Procs {
 		switch seq.Procs[i].(type) {
-		case *ast.SortProc, *ast.GroupByProc:
+		case *ast.Sort, *ast.Summarize:
 			orderSensitiveTail = false
 			break
 		default:
@@ -238,19 +238,19 @@ func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortRevers
 	}
 	for i := range seq.Procs {
 		switch p := seq.Procs[i].(type) {
-		case *ast.FilterProc, *ast.PassProc, *ast.ConstProc, *ast.TypeProc:
+		case *ast.Filter, *ast.Pass, *ast.Const, *ast.TypeProc:
 			// Stateless procs: continue until we reach one of the procs below at
 			// which point we'll either split the flowgraph or see we can't and return it as-is.
 			continue
-		case *ast.CutProc, *ast.PickProc:
+		case *ast.Cut, *ast.Pick:
 			if inputSortField == nil || !orderSensitiveTail {
 				continue
 			}
 			var fields []ast.Assignment
-			if cut, ok := p.(*ast.CutProc); ok {
-				fields = cut.Fields
+			if cut, ok := p.(*ast.Cut); ok {
+				fields = cut.Args
 			} else {
-				fields = p.(*ast.PickProc).Fields
+				fields = p.(*ast.Pick).Args
 			}
 			var found bool
 			for _, f := range fields {
@@ -266,36 +266,36 @@ func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortRevers
 			if !found {
 				return buildSplitFlowgraph(seq.Procs[0:i], seq.Procs[i:], inputSortField, inputSortReversed, N)
 			}
-		case *ast.DropProc:
+		case *ast.Drop:
 			if inputSortField == nil || !orderSensitiveTail {
 				continue
 			}
-			for _, e := range p.Fields {
+			for _, e := range p.Args {
 				if eq(e, inputSortField) {
 					return buildSplitFlowgraph(seq.Procs[0:i], seq.Procs[i:], inputSortField, inputSortReversed, N)
 				}
 			}
 			continue
-		case *ast.PutProc:
+		case *ast.Put:
 			if inputSortField == nil || !orderSensitiveTail {
 				continue
 			}
-			for _, c := range p.Clauses {
+			for _, c := range p.Args {
 				if eq(c.LHS, inputSortField) {
 					return buildSplitFlowgraph(seq.Procs[0:i], seq.Procs[i:], inputSortField, inputSortReversed, N)
 				}
 			}
 			continue
-		case *ast.RenameProc:
+		case *ast.Rename:
 			if inputSortField == nil || !orderSensitiveTail {
 				continue
 			}
-			for _, f := range p.Fields {
+			for _, f := range p.Args {
 				if eq(f.LHS, inputSortField) {
 					return buildSplitFlowgraph(seq.Procs[0:i], seq.Procs[i:], inputSortField, inputSortReversed, N)
 				}
 			}
-		case *ast.GroupByProc:
+		case *ast.Summarize:
 			// To decompose the groupby, we split the flowgraph into branches that run up to and including a groupby,
 			// followed by a post-merge groupby that composes the results.
 			var mergeField field.Static
@@ -304,17 +304,17 @@ func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortRevers
 				mergeField = field.New("ts")
 			}
 			branch := copyProcs(seq.Procs[0 : i+1])
-			branch[len(branch)-1].(*ast.GroupByProc).EmitPart = true
+			branch[len(branch)-1].(*ast.Summarize).PartialsOut = true
 
-			composerGroupBy := copyProcs([]ast.Proc{p})[0].(*ast.GroupByProc)
-			composerGroupBy.ConsumePart = true
+			composerGroupBy := copyProcs([]ast.Proc{p})[0].(*ast.Summarize)
+			composerGroupBy.PartialsIn = true
 
 			return buildSplitFlowgraph(branch, append([]ast.Proc{composerGroupBy}, seq.Procs[i+1:]...), mergeField, inputSortReversed, N)
-		case *ast.SortProc:
+		case *ast.Sort:
 			dir := map[int]bool{-1: true, 1: false}[p.SortDir]
-			if len(p.Fields) == 1 {
+			if len(p.Args) == 1 {
 				// Single sort field: we can sort in each parallel branch, and then do an ordered merge.
-				mergeField := exprToField(p.Fields[0])
+				mergeField := exprToField(p.Args[0])
 				if mergeField == nil {
 					return seq, false
 				}
@@ -323,28 +323,28 @@ func parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortRevers
 				// Unknown or multiple sort fields: we sort after the merge point, which can be unordered.
 				return buildSplitFlowgraph(seq.Procs[0:i], seq.Procs[i:], nil, dir, N)
 			}
-		case *ast.ParallelProc:
+		case *ast.Parallel:
 			return seq, false
-		case *ast.HeadProc, *ast.TailProc:
+		case *ast.Head, *ast.Tail:
 			if inputSortField == nil {
 				// Unknown order: we can't parallelize because we can't maintain this unknown order at the merge point.
 				return seq, false
 			}
 			// put one head/tail on each parallel branch and one after the merge.
 			return buildSplitFlowgraph(seq.Procs[0:i+1], seq.Procs[i:], inputSortField, inputSortReversed, N)
-		case *ast.UniqProc, *ast.FuseProc:
+		case *ast.Uniq, *ast.Fuse:
 			if inputSortField == nil {
 				// Unknown order: we can't parallelize because we can't maintain this unknown order at the merge point.
 				return seq, false
 			}
 			// Split all the upstream procs into parallel branches, then merge and continue with this and any remaining procs.
 			return buildSplitFlowgraph(seq.Procs[0:i], seq.Procs[i:], inputSortField, inputSortReversed, N)
-		case *ast.SequentialProc:
+		case *ast.Sequential:
 			return seq, false
 			// XXX Joins can be parallelized but we need to write
 			// the code to parallelize the flow graph, which is a bit
 			// different from how group-bys are parallelized.
-		case *ast.JoinProc:
+		case *ast.Join:
 			return seq, false
 		default:
 			panic(fmt.Sprintf("proc type not handled: %T", p))

--- a/compiler/semantic/proc.go
+++ b/compiler/semantic/proc.go
@@ -22,15 +22,15 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 		keys := p.Keys
 		if duration := p.Duration.Seconds; duration != 0 {
 			durationKey := ast.Assignment{
-				Op:  "Assignment",
-				LHS: ast.NewDotExpr(field.New("ts")),
+				Kind: "Assignment",
+				LHS:  ast.NewDotExpr(field.New("ts")),
 				RHS: &ast.Call{
-					Op:   "Call",
+					Kind: "Call",
 					Name: "trunc",
 					Args: []ast.Expr{
 						ast.NewDotExpr(field.New("ts")),
 						&ast.Literal{
-							Op:    "Literal",
+							Kind:  "Literal",
 							Type:  "int64",
 							Value: strconv.Itoa(duration),
 						}},
@@ -59,7 +59,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 		// above we changed duration to the a trunc(ts) group-by key as the
 		// Duration field is used later by the parallelization operator.
 		return &ast.Summarize{
-			Op:           "Summarize",
+			Kind:         "Summarize",
 			Duration:     p.Duration,
 			InputSortDir: p.InputSortDir,
 			Limit:        p.Limit,
@@ -81,7 +81,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			procs = append(procs, converted)
 		}
 		return &ast.Parallel{
-			Op:           "Parallel",
+			Kind:         "Parallel",
 			MergeBy:      p.MergeBy,
 			MergeReverse: p.MergeReverse,
 			Procs:        procs,
@@ -99,7 +99,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			procs = append(procs, converted)
 		}
 		return &ast.Sequential{
-			Op:    "Sequential",
+			Kind:  "Sequential",
 			Procs: procs,
 		}, nil
 	case *ast.Switch:
@@ -117,7 +117,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			cases = append(cases, ast.Case{Expr: e, Proc: tr})
 		}
 		return &ast.Switch{
-			Op:           "Switch",
+			Kind:         "Switch",
 			Cases:        cases,
 			MergeBy:      p.MergeBy,
 			MergeReverse: p.MergeReverse,
@@ -136,7 +136,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, err
 		}
 		return &ast.Cut{
-			Op:   "Cut",
+			Kind: "Cut",
 			Args: assignments,
 		}, nil
 	case *ast.Pick:
@@ -145,7 +145,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, err
 		}
 		return &ast.Pick{
-			Op:   "Pick",
+			Kind: "Pick",
 			Args: assignments,
 		}, nil
 	case *ast.Drop:
@@ -157,7 +157,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, errors.New("drop: no fields given")
 		}
 		return &ast.Drop{
-			Op:   "Drop",
+			Kind: "Drop",
 			Args: args,
 		}, nil
 	case *ast.Sort:
@@ -166,7 +166,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, fmt.Errorf("sort: %w", err)
 		}
 		return &ast.Sort{
-			Op:         "Sort",
+			Kind:       "Sort",
 			Args:       exprs,
 			SortDir:    p.SortDir,
 			NullsFirst: p.NullsFirst,
@@ -177,7 +177,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			limit = 1
 		}
 		return &ast.Head{
-			Op:    "Head",
+			Kind:  "Head",
 			Count: limit,
 		}, nil
 	case *ast.Tail:
@@ -186,12 +186,12 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			limit = 1
 		}
 		return &ast.Tail{
-			Op:    "Tail",
+			Kind:  "Tail",
 			Count: limit,
 		}, nil
 	case *ast.Uniq:
 		return &ast.Uniq{
-			Op:    "Uniq",
+			Kind:  "Uniq",
 			Cflag: p.Cflag,
 		}, nil
 	case *ast.Pass:
@@ -202,7 +202,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, err
 		}
 		return &ast.Filter{
-			Op:   "Filter",
+			Kind: "Filter",
 			Expr: e,
 		}, nil
 	case *ast.Top:
@@ -214,7 +214,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, errors.New("top: no arguments given")
 		}
 		return &ast.Top{
-			Op:    "Top",
+			Kind:  "Top",
 			Args:  args,
 			Flush: p.Flush,
 			Limit: p.Limit,
@@ -225,7 +225,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, err
 		}
 		return &ast.Put{
-			Op:   "Put",
+			Kind: "Put",
 			Args: assignments,
 		}, nil
 	case *ast.Rename:
@@ -260,7 +260,7 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			assignments = append(assignments, ast.Assignment{"Assignment", dst, src})
 		}
 		return &ast.Rename{
-			Op:   "Rename",
+			Kind: "Rename",
 			Args: assignments,
 		}, nil
 	case *ast.Fuse:
@@ -279,8 +279,8 @@ func semProc(scope *Scope, p ast.Proc) (ast.Proc, error) {
 			return nil, err
 		}
 		return &ast.Join{
-			Op:       "Join",
-			Kind:     p.Kind,
+			Kind:     "Join",
+			Style:    p.Style,
 			LeftKey:  leftKey,
 			RightKey: rightKey,
 			Args:     assignments,
@@ -315,7 +315,7 @@ func semConsts(consts []ast.Proc, scope *Scope, p ast.Proc) ([]ast.Proc, error) 
 			return nil, err
 		}
 		converted := &ast.TypeProc{
-			Op:   "TypeProc",
+			Kind: "TypeProc",
 			Name: p.Name,
 			Type: typ,
 		}
@@ -327,7 +327,7 @@ func semConsts(consts []ast.Proc, scope *Scope, p ast.Proc) ([]ast.Proc, error) 
 			return nil, err
 		}
 		converted := &ast.Const{
-			Op:   "Const",
+			Kind: "Const",
 			Name: p.Name,
 			Expr: e,
 		}

--- a/expr/filter_test.go
+++ b/expr/filter_test.go
@@ -511,11 +511,11 @@ func TestFilters(t *testing.T) {
 
 }
 
-func filterProc(p ast.Proc) *ast.FilterProc {
-	if seq, ok := p.(*ast.SequentialProc); ok {
+func filterProc(p ast.Proc) *ast.Filter {
+	if seq, ok := p.(*ast.Sequential); ok {
 		p = seq.Procs[0]
 	}
-	if f, ok := p.(*ast.FilterProc); ok {
+	if f, ok := p.(*ast.Filter); ok {
 		return f
 	}
 	return nil

--- a/pkg/unpack/reflector.go
+++ b/pkg/unpack/reflector.go
@@ -115,7 +115,12 @@ func (r Reflector) lookup(object map[string]interface{}) (reflect.Value, error) 
 	// If we hit a key but it didn't have any matching rule (even to skip),
 	// then we raise an error.
 	if hits > 0 {
-		return zero, fmt.Errorf("unpack: JSON object found with candidate key(s) having no template match")
+		b, err := json.Marshal(object)
+		objtext := string(b)
+		if err != nil {
+			objtext = err.Error()
+		}
+		return zero, fmt.Errorf("unpack: JSON object found with candidate key(s) having no template match\n%s", objtext)
 	}
 	return zero, nil
 }

--- a/ppl/lake/index/rule.go
+++ b/ppl/lake/index/rule.go
@@ -127,19 +127,19 @@ var countAst = ast.NewAggAssignment("count", nil, nil)
 // the type passed in as argument.
 func (r Rule) typeProc() (ast.Proc, error) {
 	return &ast.Sequential{
-		Op: "Sequential",
+		Kind: "Sequential",
 		Procs: []ast.Proc{
 			&ast.TypeSplitter{
 				Key:      keyName,
 				TypeName: r.Type,
 			},
 			&ast.Summarize{
-				Op:   "Summarize",
+				Kind: "Summarize",
 				Keys: []ast.Assignment{keyAst},
 				Aggs: []ast.Assignment{countAst},
 			},
 			&ast.Sort{
-				Op:   "Sort",
+				Kind: "Sort",
 				Args: []ast.Expr{ast.NewDotExpr(keyName)},
 			},
 		},
@@ -148,19 +148,19 @@ func (r Rule) typeProc() (ast.Proc, error) {
 
 func (r Rule) fieldProc() (ast.Proc, error) {
 	return &ast.Sequential{
-		Op: "Sequential",
+		Kind: "Sequential",
 		Procs: []ast.Proc{
 			&ast.FieldCutter{
 				Field: field.Dotted(r.Field),
 				Out:   keyName,
 			},
 			&ast.Summarize{
-				Op:   "Summarize",
+				Kind: "Summarize",
 				Keys: []ast.Assignment{keyAst},
 				Aggs: []ast.Assignment{countAst},
 			},
 			&ast.Sort{
-				Op:   "Sort",
+				Kind: "Sort",
 				Args: []ast.Expr{ast.NewDotExpr(keyName)},
 			},
 		},

--- a/ppl/lake/index/rule.go
+++ b/ppl/lake/index/rule.go
@@ -121,38 +121,48 @@ var keyAst = ast.Assignment{
 	LHS: ast.NewDotExpr(keyName),
 	RHS: ast.NewDotExpr(keyName),
 }
-var countAst = ast.NewReducerAssignment("count", nil, nil)
+var countAst = ast.NewAggAssignment("count", nil, nil)
 
 // NewFieldRule creates an indexing rule that will index all fields of
 // the type passed in as argument.
 func (r Rule) typeProc() (ast.Proc, error) {
-	return &ast.SequentialProc{
+	return &ast.Sequential{
+		Op: "Sequential",
 		Procs: []ast.Proc{
 			&ast.TypeSplitter{
 				Key:      keyName,
 				TypeName: r.Type,
 			},
-			&ast.GroupByProc{
-				Keys:     []ast.Assignment{keyAst},
-				Reducers: []ast.Assignment{countAst},
+			&ast.Summarize{
+				Op:   "Summarize",
+				Keys: []ast.Assignment{keyAst},
+				Aggs: []ast.Assignment{countAst},
 			},
-			&ast.SortProc{Fields: []ast.Expression{ast.NewDotExpr(keyName)}},
+			&ast.Sort{
+				Op:   "Sort",
+				Args: []ast.Expr{ast.NewDotExpr(keyName)},
+			},
 		},
 	}, nil
 }
 
 func (r Rule) fieldProc() (ast.Proc, error) {
-	return &ast.SequentialProc{
+	return &ast.Sequential{
+		Op: "Sequential",
 		Procs: []ast.Proc{
 			&ast.FieldCutter{
 				Field: field.Dotted(r.Field),
 				Out:   keyName,
 			},
-			&ast.GroupByProc{
-				Keys:     []ast.Assignment{keyAst},
-				Reducers: []ast.Assignment{countAst},
+			&ast.Summarize{
+				Op:   "Summarize",
+				Keys: []ast.Assignment{keyAst},
+				Aggs: []ast.Assignment{countAst},
 			},
-			&ast.SortProc{Fields: []ast.Expression{ast.NewDotExpr(keyName)}},
+			&ast.Sort{
+				Op:   "Sort",
+				Args: []ast.Expr{ast.NewDotExpr(keyName)},
+			},
 		},
 	}, nil
 }

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -47,7 +47,7 @@ func TestASTPost(t *testing.T) {
 	_, conn := newCore(t)
 	resp, err := conn.Do(context.Background(), http.MethodPost, "/ast", &api.ASTRequest{ZQL: "*"})
 	require.NoError(t, err)
-	require.Equal(t, string(resp.Body()), "{\"op\":\"Sequential\",\"procs\":[{\"op\":\"Filter\",\"expr\":{\"op\":\"Literal\",\"type\":\"bool\",\"value\":\"true\"}}]}\n")
+	require.Equal(t, string(resp.Body()), "{\"kind\":\"Sequential\",\"procs\":[{\"kind\":\"Filter\",\"expr\":{\"kind\":\"Literal\",\"type\":\"bool\",\"value\":\"true\"}}]}\n")
 }
 
 func TestSearch(t *testing.T) {

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -47,7 +47,7 @@ func TestASTPost(t *testing.T) {
 	_, conn := newCore(t)
 	resp, err := conn.Do(context.Background(), http.MethodPost, "/ast", &api.ASTRequest{ZQL: "*"})
 	require.NoError(t, err)
-	require.Equal(t, string(resp.Body()), "{\"op\":\"SequentialProc\",\"procs\":[{\"op\":\"FilterProc\",\"filter\":{\"op\":\"Literal\",\"type\":\"bool\",\"value\":\"true\"}}]}\n")
+	require.Equal(t, string(resp.Body()), "{\"op\":\"Sequential\",\"procs\":[{\"op\":\"Filter\",\"expr\":{\"op\":\"Literal\",\"type\":\"bool\",\"value\":\"true\"}}]}\n")
 }
 
 func TestSearch(t *testing.T) {

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -277,16 +277,16 @@ func setSortDir(p ast.Proc, dir int) {
 	// is saying that the group-by keys are sorted and we should be
 	// using compiler.NewWithSortedInput and passing in the group-by key
 	// for the sortKey.
-	p.(*ast.SequentialProc).Procs[0].(*ast.GroupByProc).InputSortDir = dir
+	p.(*ast.Sequential).Procs[0].(*ast.Summarize).InputSortDir = dir
 }
 
-func compileGroupBy(code string) (*ast.GroupByProc, error) {
+func compileGroupBy(code string) (*ast.Summarize, error) {
 	parsed, err := compiler.ParseProc(code)
 	if err != nil {
 		return nil, err
 	}
-	sp := parsed.(*ast.SequentialProc)
-	return sp.Procs[0].(*ast.GroupByProc), nil
+	sp := parsed.(*ast.Sequential)
+	return sp.Procs[0].(*ast.Summarize), nil
 }
 
 func TestGroupbyUnit(t *testing.T) {

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -52,9 +52,9 @@ func CompileTestProc(code string, pctx *proc.Context, parent proc.Interface) (pr
 	if err != nil {
 		return nil, err
 	}
-	sp, ok := parsed.(*ast.SequentialProc)
+	sp, ok := parsed.(*ast.Sequential)
 	if !ok {
-		return nil, errors.New("expected SequentialProc")
+		return nil, errors.New("expected Sequential proc")
 	}
 	if len(sp.Procs) != 2 {
 		return nil, errors.New("expected 2 procs")

--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -41,7 +41,7 @@ func (c *canon) assignments(assignments []ast.Assignment) {
 	}
 }
 
-func (c *canon) exprs(exprs []ast.Expression) {
+func (c *canon) exprs(exprs []ast.Expr) {
 	for k, e := range exprs {
 		if k > 0 {
 			c.write(", ")
@@ -50,12 +50,12 @@ func (c *canon) exprs(exprs []ast.Expression) {
 	}
 }
 
-func (c *canon) expr(e ast.Expression, paren bool) {
+func (c *canon) expr(e ast.Expr, paren bool) {
 	switch e := e.(type) {
 	case nil:
 		c.write("null")
-	case *ast.Reducer:
-		c.write("%s(", e.Operator)
+	case *ast.Agg:
+		c.write("%s(", e.Name)
 		if e.Expr != nil {
 			c.expr(e.Expr, false)
 		}
@@ -66,41 +66,41 @@ func (c *canon) expr(e ast.Expression, paren bool) {
 		}
 	case *ast.Literal:
 		c.literal(*e)
-	case *ast.Identifier:
+	case *ast.Id:
 		// If the identifier refers to a named variable in scope (like "$"),
 		// then return a Var expression referring to the pointer to the value.
 		// Note that constants may be accessed this way too by entering their
 		// names into the global (outermost) scope in the Scope entity.
 		c.write(e.Name)
-	case *ast.RootRecord:
+	case *ast.Root:
 		c.write(".")
-	case *ast.UnaryExpression:
+	case *ast.UnaryExpr:
 		c.space()
-		c.write(e.Operator)
+		c.write(e.Kind)
 		c.expr(e.Operand, true)
-	case *ast.SelectExpression:
+	case *ast.SelectExpr:
 		c.write("TBD:select")
-	case *ast.BinaryExpression:
+	case *ast.BinaryExpr:
 		c.binary(e)
-	case *ast.ConditionalExpression:
+	case *ast.Conditional:
 		c.write("(")
-		c.expr(e.Condition, true)
+		c.expr(e.Cond, true)
 		c.write(") ? ")
 		c.expr(e.Then, false)
 		c.write(" : ")
 		c.expr(e.Else, false)
-	case *ast.FunctionCall:
-		c.write("%s(", e.Function)
+	case *ast.Call:
+		c.write("%s(", e.Name)
 		c.exprs(e.Args)
 		c.write(")")
-	case *ast.CastExpression:
+	case *ast.Cast:
 		c.expr(e.Expr, false)
 		c.open(":%s", e.Type)
 	case *ast.Search:
 		c.write("match(")
 		c.literal(e.Value)
 		c.write(")")
-	case *ast.FieldPath:
+	case *ast.Path:
 		c.fieldpath(e.Name)
 	case *ast.Ref:
 		c.write("%s", e.Name)
@@ -111,8 +111,8 @@ func (c *canon) expr(e ast.Expression, paren bool) {
 	}
 }
 
-func (c *canon) binary(e *ast.BinaryExpression) {
-	switch e.Operator {
+func (c *canon) binary(e *ast.BinaryExpr) {
+	switch e.Kind {
 	case ".":
 		if !isRoot(e.LHS) {
 			c.expr(e.LHS, false)
@@ -130,25 +130,25 @@ func (c *canon) binary(e *ast.BinaryExpression) {
 		c.write("]")
 	case "in", "and":
 		c.expr(e.LHS, false)
-		c.write(" %s ", e.Operator)
+		c.write(" %s ", e.Kind)
 		c.expr(e.RHS, false)
 	case "or":
 		c.expr(e.LHS, true)
-		c.write(" %s ", e.Operator)
+		c.write(" %s ", e.Kind)
 		c.expr(e.RHS, true)
 	default:
 		// do need parens calc
 		c.expr(e.LHS, true)
-		c.write("%s", e.Operator)
+		c.write("%s", e.Kind)
 		c.expr(e.RHS, true)
 	}
 }
 
-func isRoot(e ast.Expression) bool {
-	if _, ok := e.(*ast.RootRecord); ok {
+func isRoot(e ast.Expr) bool {
+	if _, ok := e.(*ast.Root); ok {
 		return true
 	}
-	if f, ok := e.(*ast.FieldPath); ok {
+	if f, ok := e.(*ast.Path); ok {
 		if f.Name != nil && len(f.Name) == 0 {
 			return true
 		}
@@ -173,11 +173,11 @@ func (c *canon) next() {
 
 func (c *canon) proc(p ast.Proc) {
 	switch p := p.(type) {
-	case *ast.SequentialProc:
+	case *ast.Sequential:
 		for _, p := range p.Procs {
 			c.proc(p)
 		}
-	case *ast.ParallelProc:
+	case *ast.Parallel:
 		c.next()
 		c.open("split (")
 		for _, p := range p.Procs {
@@ -192,14 +192,14 @@ func (c *canon) proc(p ast.Proc) {
 		c.ret()
 		c.flush()
 		c.write(")")
-		if p.MergeOrderField != nil {
+		if p.MergeBy != nil {
 			c.write(" merge-by ")
-			c.fieldpath(p.MergeOrderField)
+			c.fieldpath(p.MergeBy)
 		}
-		if p.MergeOrderReverse {
+		if p.MergeReverse {
 			c.write(" rev")
 		}
-	case *ast.ConstProc:
+	case *ast.Const:
 		c.write("const %s=", p.Name)
 		c.expr(p.Expr, false)
 		c.ret()
@@ -209,16 +209,16 @@ func (c *canon) proc(p ast.Proc) {
 		c.typ(p.Type)
 		c.ret()
 		c.flush()
-	case *ast.GroupByProc:
+	case *ast.Summarize:
 		c.next()
 		c.open("summarize")
 		if secs := p.Duration.Seconds; secs != 0 {
 			c.write(" every %s", time.Duration(1_000_000_000*secs))
 		}
-		if p.ConsumePart {
+		if p.PartialsIn {
 			c.write(" partials-in")
 		}
-		if p.EmitPart {
+		if p.PartialsOut {
 			c.write(" partials-out")
 		}
 		if p.InputSortDir != 0 {
@@ -226,7 +226,7 @@ func (c *canon) proc(p ast.Proc) {
 		}
 		c.ret()
 		c.open()
-		c.assignments(p.Reducers)
+		c.assignments(p.Aggs)
 		if len(p.Keys) != 0 {
 			c.write(" by ")
 			c.assignments(p.Keys)
@@ -236,19 +236,19 @@ func (c *canon) proc(p ast.Proc) {
 		}
 		c.close()
 		c.close()
-	case *ast.CutProc:
+	case *ast.Cut:
 		c.next()
 		c.write("cut ")
-		c.assignments(p.Fields)
-	case *ast.PickProc:
+		c.assignments(p.Args)
+	case *ast.Pick:
 		c.next()
 		c.open("pick ")
-		c.assignments(p.Fields)
-	case *ast.DropProc:
+		c.assignments(p.Args)
+	case *ast.Drop:
 		c.next()
 		c.write("drop ")
-		c.exprs(p.Fields)
-	case *ast.SortProc:
+		c.exprs(p.Args)
+	case *ast.Sort:
 		c.next()
 		c.write("sort")
 		if p.SortDir < 0 {
@@ -257,55 +257,55 @@ func (c *canon) proc(p ast.Proc) {
 		if p.NullsFirst {
 			c.write(" -nulls first")
 		}
-		if len(p.Fields) > 0 {
+		if len(p.Args) > 0 {
 			c.space()
-			c.exprs(p.Fields)
+			c.exprs(p.Args)
 		}
-	case *ast.HeadProc:
+	case *ast.Head:
 		c.next()
 		c.write("head %d", p.Count)
-	case *ast.TailProc:
+	case *ast.Tail:
 		c.next()
 		c.write("tail %d", p.Count)
-	case *ast.UniqProc:
+	case *ast.Uniq:
 		c.next()
 		c.write("uniq")
 		if p.Cflag {
 			c.write(" -c")
 		}
-	case *ast.PassProc:
+	case *ast.Pass:
 		c.next()
 		c.write("pass")
-	case *ast.FilterProc:
+	case *ast.Filter:
 		c.next()
 		c.open("filter ")
-		if isTrue(p.Filter) {
+		if isTrue(p.Expr) {
 			c.write("*")
 		} else {
-			c.expr(p.Filter, false)
+			c.expr(p.Expr, false)
 		}
 		c.close()
-	case *ast.TopProc:
+	case *ast.Top:
 		c.next()
 		c.write("top limit=%d flush=%t ", p.Limit, p.Flush)
-		c.exprs(p.Fields)
-	case *ast.PutProc:
+		c.exprs(p.Args)
+	case *ast.Put:
 		c.next()
 		c.write("put ")
-		c.assignments(p.Clauses)
-	case *ast.RenameProc:
+		c.assignments(p.Args)
+	case *ast.Rename:
 		c.next()
 		c.write("rename ")
-		c.assignments(p.Fields)
-	case *ast.FuseProc:
+		c.assignments(p.Args)
+	case *ast.Fuse:
 		c.next()
 		c.write("fuse")
-	case *ast.FunctionCall:
+	case *ast.Call:
 		c.next()
-		c.write("%s(", p.Function)
+		c.write("%s(", p.Name)
 		c.exprs(p.Args)
 		c.write(")")
-	case *ast.JoinProc:
+	case *ast.Join:
 		c.next()
 		c.open("join on ")
 		c.expr(p.LeftKey, false)
@@ -313,7 +313,7 @@ func (c *canon) proc(p ast.Proc) {
 		c.expr(p.RightKey, false)
 		c.ret()
 		c.open("join-cut ")
-		c.assignments(p.Clauses)
+		c.assignments(p.Args)
 		c.close()
 		c.close()
 	//case *ast.SqlExpression:
@@ -326,7 +326,7 @@ func (c *canon) proc(p ast.Proc) {
 	}
 }
 
-func isTrue(e ast.Expression) bool {
+func isTrue(e ast.Expr) bool {
 	if lit, ok := e.(*ast.Literal); ok {
 		return lit.Type == "bool" && lit.Value == "true"
 	}

--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -76,7 +76,7 @@ func (c *canon) expr(e ast.Expr, paren bool) {
 		c.write(".")
 	case *ast.UnaryExpr:
 		c.space()
-		c.write(e.Kind)
+		c.write(e.Op)
 		c.expr(e.Operand, true)
 	case *ast.SelectExpr:
 		c.write("TBD:select")
@@ -112,7 +112,7 @@ func (c *canon) expr(e ast.Expr, paren bool) {
 }
 
 func (c *canon) binary(e *ast.BinaryExpr) {
-	switch e.Kind {
+	switch e.Op {
 	case ".":
 		if !isRoot(e.LHS) {
 			c.expr(e.LHS, false)
@@ -130,16 +130,16 @@ func (c *canon) binary(e *ast.BinaryExpr) {
 		c.write("]")
 	case "in", "and":
 		c.expr(e.LHS, false)
-		c.write(" %s ", e.Kind)
+		c.write(" %s ", e.Op)
 		c.expr(e.RHS, false)
 	case "or":
 		c.expr(e.LHS, true)
-		c.write(" %s ", e.Kind)
+		c.write(" %s ", e.Op)
 		c.expr(e.RHS, true)
 	default:
 		// do need parens calc
 		c.expr(e.LHS, true)
-		c.write("%s", e.Kind)
+		c.write("%s", e.Op)
 		c.expr(e.RHS, true)
 	}
 }

--- a/zng/literal.go
+++ b/zng/literal.go
@@ -14,7 +14,7 @@ func ParseLiteral(literal ast.Literal) (interface{}, error) {
 	// specifically arrays of bytes that do not correspond to
 	// UTF-8 encoded strings).
 	if literal.Type == "string" {
-		literal = ast.Literal{Op: "Literal", Type: "bstring", Value: literal.Value}
+		literal = ast.Literal{Kind: "Literal", Type: "bstring", Value: literal.Value}
 	}
 	v, err := Parse(literal)
 	if err != nil {

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -29,10 +29,10 @@ func makeBinaryExprChain(first, rest interface{}) interface{} {
 	for _, p := range rest.([]interface{}) {
 		part := p.([]interface{})
 		ret = map[string]interface{}{
-			"op":       "BinaryExpr",
-			"operator": part[0],
-			"lhs":      ret,
-			"rhs":      part[1],
+			"op":   "BinaryExpr",
+			"kind": part[0],
+			"lhs":  ret,
+			"rhs":  part[1],
 		}
 	}
 	return ret

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -16,7 +16,7 @@ func makeChain(first interface{}, restIn interface{}, op string) interface{} {
 	result := first
 	for _, term := range rest {
 		result = map[string]interface{}{
-			"op":    op,
+			"kind":  op,
 			"left":  result,
 			"right": term,
 		}
@@ -29,8 +29,8 @@ func makeBinaryExprChain(first, rest interface{}) interface{} {
 	for _, p := range rest.([]interface{}) {
 		part := p.([]interface{})
 		ret = map[string]interface{}{
-			"op":   "BinaryExpr",
-			"kind": part[0],
+			"kind": "BinaryExpr",
+			"op":   part[0],
 			"lhs":  ret,
 			"rhs":  part[1],
 		}

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -25,7 +25,7 @@ function makeArgMap(args) {
 function makeBinaryExprChain(first, rest) {
   let ret = first
   for (let part of rest) {
-    ret = { op: "BinaryExpr", operator: part[0], lhs: ret, rhs: part[1] };
+    ret = { op: "BinaryExpr", kind: part[0], lhs: ret, rhs: part[1] };
   }
   return ret
 }

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -25,7 +25,7 @@ function makeArgMap(args) {
 function makeBinaryExprChain(first, rest) {
   let ret = first
   for (let part of rest) {
-    ret = { op: "BinaryExpr", kind: part[0], lhs: ret, rhs: part[1] };
+    ret = { kind: "BinaryExpr", op: part[0], lhs: ret, rhs: part[1] };
   }
   return ret
 }

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -292,7 +292,7 @@ function peg$parse(input, options) {
             for(let  p of rest) {
               procs.push( p);
             }
-            return {"op": "Sequential", "procs": procs}
+            return {"kind": "Sequential", "procs": procs}
           },
       peg$c2 = function(v) { return v },
       peg$c3 = "const",
@@ -302,18 +302,18 @@ function peg$parse(input, options) {
       peg$c7 = ";",
       peg$c8 = peg$literalExpectation(";", false),
       peg$c9 = function(id, expr) {
-            return {"op":"Const","name":id, "expr":expr}
+            return {"kind":"Const","name":id, "expr":expr}
           },
       peg$c10 = "type",
       peg$c11 = peg$literalExpectation("type", false),
       peg$c12 = function(id, typ) {
-            return {"op":"TypeProc","name":id, "type":typ}
+            return {"kind":"TypeProc","name":id, "type":typ}
           },
       peg$c13 = function(first, rest) {
-            return {"op": "Sequential", "procs": [first, ... rest]}
+            return {"kind": "Sequential", "procs": [first, ... rest]}
           },
       peg$c14 = function(op) {
-            return {"op": "Sequential", "procs": [op]}
+            return {"kind": "Sequential", "procs": [op]}
           },
       peg$c15 = "|",
       peg$c16 = peg$literalExpectation("|", false),
@@ -331,7 +331,7 @@ function peg$parse(input, options) {
             return {"expr": e, "proc": proc}
           },
       peg$c24 = function(proc) {
-            return {"expr": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
+            return {"expr": {"kind": "Literal", "type": "bool", "value": "true"}, "proc": proc}
           },
       peg$c25 = "case",
       peg$c26 = peg$literalExpectation("case", true),
@@ -344,17 +344,17 @@ function peg$parse(input, options) {
       peg$c33 = ")",
       peg$c34 = peg$literalExpectation(")", false),
       peg$c35 = function(procArray) {
-            return {"op": "Parallel", "procs": procArray}
+            return {"kind": "Parallel", "procs": procArray}
           },
       peg$c36 = "switch",
       peg$c37 = peg$literalExpectation("switch", false),
       peg$c38 = function(caseArray) {
-            return {"op": "Switch", "cases": caseArray}
+            return {"kind": "Switch", "cases": caseArray}
           },
       peg$c39 = function(f) { return f },
       peg$c40 = function(a) { return a },
       peg$c41 = function(expr) {
-            return {"op": "Filter", "expr": expr}
+            return {"kind": "Filter", "expr": expr}
           },
       peg$c42 = ":",
       peg$c43 = peg$literalExpectation(":", false),
@@ -373,27 +373,27 @@ function peg$parse(input, options) {
       peg$c52 = "!",
       peg$c53 = peg$literalExpectation("!", false),
       peg$c54 = function(e) {
-            return {"op": "UnaryExpr", "kind": "!", "operand": e}
+            return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
       peg$c55 = function(expr) { return expr },
       peg$c56 = "*",
       peg$c57 = peg$literalExpectation("*", false),
       peg$c58 = function(compareOp, v) {
-            return {"op": "Call", "name": "or",
+            return {"kind": "Call", "name": "or",
               
             "args": [
                 
-            {"op": "SelectExpr",
+            {"kind": "SelectExpr",
                     
-            "selectors": [{"op": "Root"}],
+            "selectors": [{"kind": "Root"}],
                     
             "methods": [
                       
-            {"op": "Call", "name": "map",
+            {"kind": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "kind": "=",
+            "args": [{"kind": "BinaryExpr", "op": "=",
                                             
-            "lhs": {"op": "Id", "name": "$"},
+            "lhs": {"kind": "Id", "name": "$"},
                                             
             "rhs": v}]}]}]}
           
@@ -406,24 +406,24 @@ function peg$parse(input, options) {
 
           },
       peg$c59 = function(f, comp, v) {
-            return {"op": "BinaryExpr", "kind":comp, "lhs":f, "rhs":v}
+            return {"kind": "BinaryExpr", "op":comp, "lhs":f, "rhs":v}
           },
       peg$c60 = function(v) {
-            return {"op": "Call", "name": "or",
+            return {"kind": "Call", "name": "or",
               
             "args": [
                 
-            {"op": "SelectExpr",
+            {"kind": "SelectExpr",
                     
-            "selectors": [{"op": "Root"}],
+            "selectors": [{"kind": "Root"}],
                     
             "methods": [
                       
-            {"op": "Call", "name": "map",
+            {"kind": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "kind": "in",
+            "args": [{"kind": "BinaryExpr", "op": "in",
                                             
-            "rhs": {"op": "Id", "name": "$"},
+            "rhs": {"kind": "Id", "name": "$"},
                                             
             "lhs": v}]}]}]}
           
@@ -436,17 +436,17 @@ function peg$parse(input, options) {
 
           },
       peg$c61 = function(v) {
-            return {"op": "Search", "text": text(), "value": v}
+            return {"kind": "Search", "text": text(), "value": v}
           },
       peg$c62 = function() {
-            return {"op": "Literal", "type": "bool", "value": "true"}
+            return {"kind": "Literal", "type": "bool", "value": "true"}
           },
       peg$c63 = function(v) {
-            return {"op": "Literal", "type": "string", "value": v}
+            return {"kind": "Literal", "type": "string", "value": v}
           },
       peg$c64 = function(v) {
             let str = v;
-            let literal = {"op": "Literal", "type": "string", "value": v};
+            let literal = {"kind": "Literal", "type": "string", "value": v};
             if (reglob$1.IsGlobby(str)) {
               literal["type"] = "regexp";
               literal["value"] = reglob$1.Reglob(str);
@@ -477,13 +477,13 @@ function peg$parse(input, options) {
               return makeBinaryExprChain(first, rest)
           },
       peg$c84 = function(e, typ) {
-            return {"op": "Cast", "expr": e, "type": typ}
+            return {"kind": "Cast", "expr": e, "type": typ}
           },
       peg$c85 = function(every, keys, limit) {
-            return {"op": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
+            return {"kind": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
       peg$c86 = function(every, aggs, keys, limit) {
-            let p = {"op": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit};
+            let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
@@ -503,18 +503,18 @@ function peg$parse(input, options) {
       peg$c98 = peg$literalExpectation("-limit", false),
       peg$c99 = function(limit) { return limit },
       peg$c100 = function() { return 0 },
-      peg$c101 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c101 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
       peg$c102 = function(first, expr) { return expr },
       peg$c103 = function(lval, agg) {
-            return {"op": "Assignment", "lhs": lval, "rhs": agg}
+            return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
       peg$c104 = function(agg) {
-            return {"op": "Assignment", "lhs": null, "rhs": agg}
+            return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
       peg$c105 = ".",
       peg$c106 = peg$literalExpectation(".", false),
       peg$c107 = function(op, expr, where) {
-            let r = {"op": "Agg", "name": op, "expr": null, "where":where};
+            let r = {"kind": "Agg", "name": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
@@ -534,7 +534,7 @@ function peg$parse(input, options) {
       peg$c113 = function(args, l) { return l },
       peg$c114 = function(args, list) {
             let argm = args;
-            let proc = {"op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false};
+            let proc = {"kind": "Sort", "args": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
               proc["sortdir"] = -1;
             }
@@ -563,7 +563,7 @@ function peg$parse(input, options) {
       peg$c130 = peg$literalExpectation("-flush", false),
       peg$c131 = function(limit, flush, f) { return f },
       peg$c132 = function(limit, flush, fields) {
-            let proc = {"op": "Top", "limit": 0, "args": null, "flush": false};
+            let proc = {"kind": "Top", "limit": 0, "args": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
             }
@@ -578,26 +578,26 @@ function peg$parse(input, options) {
       peg$c133 = "cut",
       peg$c134 = peg$literalExpectation("cut", true),
       peg$c135 = function(args) {
-            return {"op": "Cut", "args": args}
+            return {"kind": "Cut", "args": args}
           },
       peg$c136 = "pick",
       peg$c137 = peg$literalExpectation("pick", true),
       peg$c138 = function(args) {
-            return {"op": "Pick", "args": args}
+            return {"kind": "Pick", "args": args}
           },
       peg$c139 = "drop",
       peg$c140 = peg$literalExpectation("drop", true),
       peg$c141 = function(args) {
-            return {"op": "Drop", "args": args}
+            return {"kind": "Drop", "args": args}
           },
       peg$c142 = "head",
       peg$c143 = peg$literalExpectation("head", true),
-      peg$c144 = function(count) { return {"op": "Head", "count": count} },
-      peg$c145 = function() { return {"op": "Head", "count": 1} },
+      peg$c144 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c145 = function() { return {"kind": "Head", "count": 1} },
       peg$c146 = "tail",
       peg$c147 = peg$literalExpectation("tail", true),
-      peg$c148 = function(count) { return {"op": "Tail", "count": count} },
-      peg$c149 = function() { return {"op": "Tail", "count": 1} },
+      peg$c148 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c149 = function() { return {"kind": "Tail", "count": 1} },
       peg$c150 = "filter",
       peg$c151 = peg$literalExpectation("filter", true),
       peg$c152 = function(op) {
@@ -608,43 +608,43 @@ function peg$parse(input, options) {
       peg$c155 = "-c",
       peg$c156 = peg$literalExpectation("-c", false),
       peg$c157 = function() {
-            return {"op": "Uniq", "cflag": true}
+            return {"kind": "Uniq", "cflag": true}
           },
       peg$c158 = function() {
-            return {"op": "Uniq", "cflag": false}
+            return {"kind": "Uniq", "cflag": false}
           },
       peg$c159 = "put",
       peg$c160 = peg$literalExpectation("put", true),
       peg$c161 = function(args) {
-            return {"op": "Put", "args": args}
+            return {"kind": "Put", "args": args}
           },
       peg$c162 = "rename",
       peg$c163 = peg$literalExpectation("rename", true),
       peg$c164 = function(first, cl) { return cl },
       peg$c165 = function(first, rest) {
-            return {"op": "Rename", "args": [first, ... rest]}
+            return {"kind": "Rename", "args": [first, ... rest]}
           },
       peg$c166 = "fuse",
       peg$c167 = peg$literalExpectation("fuse", true),
       peg$c168 = function() {
-            return {"op": "Fuse"}
+            return {"kind": "Fuse"}
           },
       peg$c169 = "shape",
       peg$c170 = peg$literalExpectation("shape", true),
       peg$c171 = function() {
-            return {"op": "Shape"}
+            return {"kind": "Shape"}
           },
       peg$c172 = "join",
       peg$c173 = peg$literalExpectation("join", true),
-      peg$c174 = function(kind, leftKey, rightKey, columns) {
-            let proc = {"op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": null};
+      peg$c174 = function(style, leftKey, rightKey, columns) {
+            let proc = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null};
             if (columns) {
               proc["args"] = columns[1];
             }
             return proc
           },
-      peg$c175 = function(kind, key, columns) {
-            let proc = {"op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": null};
+      peg$c175 = function(style, key, columns) {
+            let proc = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null};
             if (columns) {
               proc["args"] = columns[1];
             }
@@ -662,23 +662,23 @@ function peg$parse(input, options) {
       peg$c185 = "taste",
       peg$c186 = peg$literalExpectation("taste", true),
       peg$c187 = function(e) {
-            return {"op": "Sequential", "procs": [
+            return {"kind": "Sequential", "procs": [
               
-            {"op": "Summarize",
+            {"kind": "Summarize",
                 
-            "keys": [{"op": "Assignment",
+            "keys": [{"kind": "Assignment",
                          
-            "lhs": {"op": "Id", "name": "shape"},
+            "lhs": {"kind": "Id", "name": "shape"},
                          
-            "rhs": {"op": "Call", "name": "typeof",
+            "rhs": {"kind": "Call", "name": "typeof",
                                     
             "args": [e]}}],
                 
-            "aggs": [{"op": "Assignment",
+            "aggs": [{"kind": "Assignment",
                                     
-            "lhs": {"op": "Id", "name": "taste"},
+            "lhs": {"kind": "Id", "name": "taste"},
                                     
-            "rhs": {"op": "Agg",
+            "rhs": {"kind": "Agg",
                                                
             "name": "any",
                                                
@@ -688,17 +688,17 @@ function peg$parse(input, options) {
                 
             "duration": null, "limit": 0},
               
-            {"op": "Cut",
+            {"kind": "Cut",
                   
-            "args": [{"op": "Assignment",
+            "args": [{"kind": "Assignment",
                                       
             "lhs": null,
                                       
-            "rhs": {"op": "Id", "name": "taste"}}]}]}
+            "rhs": {"kind": "Id", "name": "taste"}}]}]}
           
           },
       peg$c188 = function(lval) { return lval},
-      peg$c189 = function() { return {"op":"Root"} },
+      peg$c189 = function() { return {"kind":"Root"} },
       peg$c190 = function(first, rest) {
             let result = [first];
 
@@ -708,11 +708,11 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c191 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c191 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
       peg$c192 = "?",
       peg$c193 = peg$literalExpectation("?", false),
       peg$c194 = function(condition, thenClause, elseClause) {
-            return {"op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
+            return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
       peg$c195 = function(first, comp, expr) { return [comp, expr] },
       peg$c196 = "+",
@@ -722,7 +722,7 @@ function peg$parse(input, options) {
       peg$c200 = "/",
       peg$c201 = peg$literalExpectation("/", false),
       peg$c202 = function(e) {
-              return {"op": "UnaryExpr", "kind": "!", "operand": e}
+              return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
       peg$c203 = "not",
       peg$c204 = peg$literalExpectation("not", false),
@@ -731,21 +731,21 @@ function peg$parse(input, options) {
       peg$c207 = "select",
       peg$c208 = peg$literalExpectation("select", false),
       peg$c209 = function(args, methods) {
-            return {"op":"SelectExpr", "selectors":args, "methods": methods}
+            return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
       peg$c210 = function(methods) { return methods },
       peg$c211 = function(fn, args) {
-            return {"op": "Call", "name": fn, "args": args}
+            return {"kind": "Call", "name": fn, "args": args}
           },
       peg$c212 = function(first, e) { return e },
       peg$c213 = function() { return [] },
       peg$c214 = function() {
-            return {"op":"Root"}
+            return {"kind":"Root"}
           },
       peg$c215 = function(field) {
-            return {"op": "BinaryExpr", "kind":".",
+            return {"kind": "BinaryExpr", "op":".",
                            
-            "lhs":{"op":"Root"},
+            "lhs":{"kind":"Root"},
                            
             "rhs":field}
           
@@ -756,28 +756,28 @@ function peg$parse(input, options) {
       peg$c218 = "]",
       peg$c219 = peg$literalExpectation("]", false),
       peg$c220 = function(expr) {
-            return {"op": "BinaryExpr", "kind":"[",
+            return {"kind": "BinaryExpr", "op":"[",
                            
-            "lhs":{"op":"Root"},
+            "lhs":{"kind":"Root"},
                            
             "rhs":expr}
           
 
           },
       peg$c221 = function(from, to) {
-            return ["[", {"op": "BinaryExpr", "kind":":",
+            return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
       peg$c222 = function(to) {
-            return ["[", {"op": "BinaryExpr", "kind":":",
+            return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
       peg$c223 = function(from) {
-            return ["[", {"op": "BinaryExpr", "kind":":",
+            return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
@@ -785,46 +785,46 @@ function peg$parse(input, options) {
       peg$c224 = function(expr) { return ["[", expr] },
       peg$c225 = function(id) { return [".", id] },
       peg$c226 = function(v) {
-            return {"op": "Literal", "type": "regexp", "value": v}
+            return {"kind": "Literal", "type": "regexp", "value": v}
           },
       peg$c227 = function(v) {
-            return {"op": "Literal", "type": "net", "value": v}
+            return {"kind": "Literal", "type": "net", "value": v}
           },
       peg$c228 = function(v) {
-            return {"op": "Literal", "type": "ip", "value": v}
+            return {"kind": "Literal", "type": "ip", "value": v}
           },
       peg$c229 = function(v) {
-            return {"op": "Literal", "type": "float64", "value": v}
+            return {"kind": "Literal", "type": "float64", "value": v}
           },
       peg$c230 = function(v) {
-            return {"op": "Literal", "type": "int64", "value": v}
+            return {"kind": "Literal", "type": "int64", "value": v}
           },
       peg$c231 = "true",
       peg$c232 = peg$literalExpectation("true", false),
-      peg$c233 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c233 = function() { return {"kind": "Literal", "type": "bool", "value": "true"} },
       peg$c234 = "false",
       peg$c235 = peg$literalExpectation("false", false),
-      peg$c236 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c236 = function() { return {"kind": "Literal", "type": "bool", "value": "false"} },
       peg$c237 = "null",
       peg$c238 = peg$literalExpectation("null", false),
-      peg$c239 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c239 = function() { return {"kind": "Literal", "type": "null", "value": ""} },
       peg$c240 = function(typ) {
-            return {"op": "TypeValue", "value": typ}
+            return {"kind": "TypeValue", "value": typ}
           },
       peg$c241 = function(typ) { return typ},
       peg$c242 = function(typ) { return typ },
       peg$c243 = function() {
-            return {"op": "TypeNull"}
+            return {"kind": "TypeNull"}
           },
       peg$c244 = function(name, typ) {
-            return {"op": "TypeDef", "name": name, "type": typ}
+            return {"kind": "TypeDef", "name": name, "type": typ}
         },
       peg$c245 = function(name) {
-            return {"op": "TypeName", "name": name}
+            return {"kind": "TypeName", "name": name}
           },
       peg$c246 = function(u) { return u },
       peg$c247 = function(types) {
-            return {"op": "TypeUnion", "types": types}
+            return {"kind": "TypeUnion", "types": types}
           },
       peg$c248 = function(first, rest) {
           return [first, ... rest]
@@ -834,24 +834,24 @@ function peg$parse(input, options) {
       peg$c251 = "}",
       peg$c252 = peg$literalExpectation("}", false),
       peg$c253 = function(fields) {
-            return {"op":"TypeRecord", "fields":fields}
+            return {"kind":"TypeRecord", "fields":fields}
           },
       peg$c254 = function(typ) {
-            return {"op":"TypeArray", "type":typ}
+            return {"kind":"TypeArray", "type":typ}
           },
       peg$c255 = "|[",
       peg$c256 = peg$literalExpectation("|[", false),
       peg$c257 = "]|",
       peg$c258 = peg$literalExpectation("]|", false),
       peg$c259 = function(typ) {
-            return {"op":"TypeSet", "type":typ}
+            return {"kind":"TypeSet", "type":typ}
           },
       peg$c260 = "|{",
       peg$c261 = peg$literalExpectation("|{", false),
       peg$c262 = "}|",
       peg$c263 = peg$literalExpectation("}|", false),
       peg$c264 = function(keyType, valType) {
-            return {"op":"TypeMap", "key_type":keyType, "val_type": valType}
+            return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
       peg$c265 = "uint8",
       peg$c266 = peg$literalExpectation("uint8", false),
@@ -876,7 +876,7 @@ function peg$parse(input, options) {
       peg$c285 = "string",
       peg$c286 = peg$literalExpectation("string", false),
       peg$c287 = function() {
-                return {"op": "TypePrimitive", "name": text()}
+                return {"kind": "TypePrimitive", "name": text()}
               },
       peg$c288 = "duration",
       peg$c289 = peg$literalExpectation("duration", false),
@@ -912,7 +912,7 @@ function peg$parse(input, options) {
       peg$c317 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
       peg$c318 = /^[0-9]/,
       peg$c319 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c320 = function(id) { return {"op": "Id", "name": id} },
+      peg$c320 = function(id) { return {"kind": "Id", "name": id} },
       peg$c321 = function() {  return text() },
       peg$c322 = "$",
       peg$c323 = peg$literalExpectation("$", false),
@@ -4929,7 +4929,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    s1 = peg$parseJoinKind();
+    s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
       if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
         s2 = input.substr(peg$currPos, 4);
@@ -5017,7 +5017,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseJoinKind();
+      s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
         if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
           s2 = input.substr(peg$currPos, 4);
@@ -5078,7 +5078,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseJoinKind() {
+  function peg$parseJoinStyle() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
@@ -11251,7 +11251,7 @@ function peg$parse(input, options) {
   function makeBinaryExprChain(first, rest) {
     let ret = first;
     for (let part of rest) {
-      ret = { op: "BinaryExpr", kind: part[0], lhs: ret, rhs: part[1] };
+      ret = { kind: "BinaryExpr", op: part[0], lhs: ret, rhs: part[1] };
     }
     return ret
   }

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -292,7 +292,7 @@ function peg$parse(input, options) {
             for(let  p of rest) {
               procs.push( p);
             }
-            return {"op": "SequentialProc", "procs": procs}
+            return {"op": "Sequential", "procs": procs}
           },
       peg$c2 = function(v) { return v },
       peg$c3 = "const",
@@ -302,7 +302,7 @@ function peg$parse(input, options) {
       peg$c7 = ";",
       peg$c8 = peg$literalExpectation(";", false),
       peg$c9 = function(id, expr) {
-            return {"op":"ConstProc","name":id, "expr":expr}
+            return {"op":"Const","name":id, "expr":expr}
           },
       peg$c10 = "type",
       peg$c11 = peg$literalExpectation("type", false),
@@ -310,10 +310,10 @@ function peg$parse(input, options) {
             return {"op":"TypeProc","name":id, "type":typ}
           },
       peg$c13 = function(first, rest) {
-            return {"op": "SequentialProc", "procs": [first, ... rest]}
+            return {"op": "Sequential", "procs": [first, ... rest]}
           },
       peg$c14 = function(op) {
-            return {"op": "SequentialProc", "procs": [op]}
+            return {"op": "Sequential", "procs": [op]}
           },
       peg$c15 = "|",
       peg$c16 = peg$literalExpectation("|", false),
@@ -327,11 +327,11 @@ function peg$parse(input, options) {
       peg$c20 = "=>",
       peg$c21 = peg$literalExpectation("=>", false),
       peg$c22 = function(ch) { return ch },
-      peg$c23 = function(filter, proc) {
-            return {"filter": filter, "proc": proc}
+      peg$c23 = function(e, proc) {
+            return {"expr": e, "proc": proc}
           },
       peg$c24 = function(proc) {
-            return {"filter": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
+            return {"expr": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
           },
       peg$c25 = "case",
       peg$c26 = peg$literalExpectation("case", true),
@@ -344,17 +344,17 @@ function peg$parse(input, options) {
       peg$c33 = ")",
       peg$c34 = peg$literalExpectation(")", false),
       peg$c35 = function(procArray) {
-            return {"op": "ParallelProc", "procs": procArray}
+            return {"op": "Parallel", "procs": procArray}
           },
       peg$c36 = "switch",
       peg$c37 = peg$literalExpectation("switch", false),
       peg$c38 = function(caseArray) {
-            return {"op": "SwitchProc", "cases": caseArray}
+            return {"op": "Switch", "cases": caseArray}
           },
       peg$c39 = function(f) { return f },
       peg$c40 = function(a) { return a },
       peg$c41 = function(expr) {
-            return {"op": "FilterProc", "filter": expr}
+            return {"op": "Filter", "expr": expr}
           },
       peg$c42 = ":",
       peg$c43 = peg$literalExpectation(":", false),
@@ -373,27 +373,27 @@ function peg$parse(input, options) {
       peg$c52 = "!",
       peg$c53 = peg$literalExpectation("!", false),
       peg$c54 = function(e) {
-            return {"op": "UnaryExpr", "operator": "!", "operand": e}
+            return {"op": "UnaryExpr", "kind": "!", "operand": e}
           },
       peg$c55 = function(expr) { return expr },
       peg$c56 = "*",
       peg$c57 = peg$literalExpectation("*", false),
       peg$c58 = function(compareOp, v) {
-            return {"op": "FunctionCall", "function": "or",
+            return {"op": "Call", "name": "or",
               
             "args": [
                 
             {"op": "SelectExpr",
                     
-            "selectors": [{"op": "RootRecord"}],
+            "selectors": [{"op": "Root"}],
                     
             "methods": [
                       
-            {"op": "FunctionCall", "function": "map",
+            {"op": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "operator": "=",
+            "args": [{"op": "BinaryExpr", "kind": "=",
                                             
-            "lhs": {"op": "Identifier", "name": "$"},
+            "lhs": {"op": "Id", "name": "$"},
                                             
             "rhs": v}]}]}]}
           
@@ -406,24 +406,24 @@ function peg$parse(input, options) {
 
           },
       peg$c59 = function(f, comp, v) {
-            return {"op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v}
+            return {"op": "BinaryExpr", "kind":comp, "lhs":f, "rhs":v}
           },
       peg$c60 = function(v) {
-            return {"op": "FunctionCall", "function": "or",
+            return {"op": "Call", "name": "or",
               
             "args": [
                 
             {"op": "SelectExpr",
                     
-            "selectors": [{"op": "RootRecord"}],
+            "selectors": [{"op": "Root"}],
                     
             "methods": [
                       
-            {"op": "FunctionCall", "function": "map",
+            {"op": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "operator": "in",
+            "args": [{"op": "BinaryExpr", "kind": "in",
                                             
-            "rhs": {"op": "Identifier", "name": "$"},
+            "rhs": {"op": "Id", "name": "$"},
                                             
             "lhs": v}]}]}]}
           
@@ -477,13 +477,13 @@ function peg$parse(input, options) {
               return makeBinaryExprChain(first, rest)
           },
       peg$c84 = function(e, typ) {
-            return {"op": "CastExpr", "expr": e, "type": typ}
+            return {"op": "Cast", "expr": e, "type": typ}
           },
       peg$c85 = function(every, keys, limit) {
-            return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
+            return {"op": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
-      peg$c86 = function(every, reducers, keys, limit) {
-            let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit};
+      peg$c86 = function(every, aggs, keys, limit) {
+            let p = {"op": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
@@ -505,16 +505,16 @@ function peg$parse(input, options) {
       peg$c100 = function() { return 0 },
       peg$c101 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
       peg$c102 = function(first, expr) { return expr },
-      peg$c103 = function(lval, reducer) {
-            return {"op": "Assignment", "lhs": lval, "rhs": reducer}
+      peg$c103 = function(lval, agg) {
+            return {"op": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c104 = function(reducer) {
-            return {"op": "Assignment", "lhs": null, "rhs": reducer}
+      peg$c104 = function(agg) {
+            return {"op": "Assignment", "lhs": null, "rhs": agg}
           },
       peg$c105 = ".",
       peg$c106 = peg$literalExpectation(".", false),
       peg$c107 = function(op, expr, where) {
-            let r = {"op": "Reducer", "operator": op, "expr": null, "where":where};
+            let r = {"op": "Agg", "name": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
@@ -534,7 +534,7 @@ function peg$parse(input, options) {
       peg$c113 = function(args, l) { return l },
       peg$c114 = function(args, list) {
             let argm = args;
-            let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
+            let proc = {"op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
               proc["sortdir"] = -1;
             }
@@ -563,12 +563,12 @@ function peg$parse(input, options) {
       peg$c130 = peg$literalExpectation("-flush", false),
       peg$c131 = function(limit, flush, f) { return f },
       peg$c132 = function(limit, flush, fields) {
-            let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false};
+            let proc = {"op": "Top", "limit": 0, "args": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
             }
             if (fields) {
-              proc["fields"] = fields;
+              proc["args"] = fields;
             }
             if (flush) {
               proc["flush"] = true;
@@ -577,27 +577,27 @@ function peg$parse(input, options) {
           },
       peg$c133 = "cut",
       peg$c134 = peg$literalExpectation("cut", true),
-      peg$c135 = function(columns) {
-            return {"op": "CutProc", "fields": columns}
+      peg$c135 = function(args) {
+            return {"op": "Cut", "args": args}
           },
       peg$c136 = "pick",
       peg$c137 = peg$literalExpectation("pick", true),
-      peg$c138 = function(columns) {
-            return {"op": "PickProc", "fields": columns}
+      peg$c138 = function(args) {
+            return {"op": "Pick", "args": args}
           },
       peg$c139 = "drop",
       peg$c140 = peg$literalExpectation("drop", true),
-      peg$c141 = function(columns) {
-            return {"op": "DropProc", "fields": columns}
+      peg$c141 = function(args) {
+            return {"op": "Drop", "args": args}
           },
       peg$c142 = "head",
       peg$c143 = peg$literalExpectation("head", true),
-      peg$c144 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c145 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c144 = function(count) { return {"op": "Head", "count": count} },
+      peg$c145 = function() { return {"op": "Head", "count": 1} },
       peg$c146 = "tail",
       peg$c147 = peg$literalExpectation("tail", true),
-      peg$c148 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c149 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c148 = function(count) { return {"op": "Tail", "count": count} },
+      peg$c149 = function() { return {"op": "Tail", "count": 1} },
       peg$c150 = "filter",
       peg$c151 = peg$literalExpectation("filter", true),
       peg$c152 = function(op) {
@@ -608,45 +608,45 @@ function peg$parse(input, options) {
       peg$c155 = "-c",
       peg$c156 = peg$literalExpectation("-c", false),
       peg$c157 = function() {
-            return {"op": "UniqProc", "cflag": true}
+            return {"op": "Uniq", "cflag": true}
           },
       peg$c158 = function() {
-            return {"op": "UniqProc", "cflag": false}
+            return {"op": "Uniq", "cflag": false}
           },
       peg$c159 = "put",
       peg$c160 = peg$literalExpectation("put", true),
-      peg$c161 = function(columns) {
-            return {"op": "PutProc", "clauses": columns}
+      peg$c161 = function(args) {
+            return {"op": "Put", "args": args}
           },
       peg$c162 = "rename",
       peg$c163 = peg$literalExpectation("rename", true),
       peg$c164 = function(first, cl) { return cl },
       peg$c165 = function(first, rest) {
-            return {"op": "RenameProc", "fields": [first, ... rest]}
+            return {"op": "Rename", "args": [first, ... rest]}
           },
       peg$c166 = "fuse",
       peg$c167 = peg$literalExpectation("fuse", true),
       peg$c168 = function() {
-            return {"op": "FuseProc"}
+            return {"op": "Fuse"}
           },
       peg$c169 = "shape",
       peg$c170 = peg$literalExpectation("shape", true),
       peg$c171 = function() {
-            return {"op": "ShapeProc"}
+            return {"op": "Shape"}
           },
       peg$c172 = "join",
       peg$c173 = peg$literalExpectation("join", true),
       peg$c174 = function(kind, leftKey, rightKey, columns) {
-            let proc = {"op": "JoinProc", "kind": kind, "left_key": leftKey, "right_key": rightKey, "clauses": null};
+            let proc = {"op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": null};
             if (columns) {
-              proc["clauses"] = columns[1];
+              proc["args"] = columns[1];
             }
             return proc
           },
       peg$c175 = function(kind, key, columns) {
-            let proc = {"op": "JoinProc", "kind": kind, "left_key": key, "right_key": key, "clauses": null};
+            let proc = {"op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": null};
             if (columns) {
-              proc["clauses"] = columns[1];
+              proc["args"] = columns[1];
             }
             return proc
           },
@@ -662,25 +662,25 @@ function peg$parse(input, options) {
       peg$c185 = "taste",
       peg$c186 = peg$literalExpectation("taste", true),
       peg$c187 = function(e) {
-            return {"op": "SequentialProc", "procs": [
+            return {"op": "Sequential", "procs": [
               
-            {"op": "GroupByProc",
+            {"op": "Summarize",
                 
             "keys": [{"op": "Assignment",
                          
-            "lhs": {"op": "Identifier", "name": "shape"},
+            "lhs": {"op": "Id", "name": "shape"},
                          
-            "rhs": {"op": "FunctionCall", "function": "typeof",
+            "rhs": {"op": "Call", "name": "typeof",
                                     
             "args": [e]}}],
                 
-            "reducers": [{"op": "Assignment",
+            "aggs": [{"op": "Assignment",
                                     
-            "lhs": {"op": "Identifier", "name": "taste"},
+            "lhs": {"op": "Id", "name": "taste"},
                                     
-            "rhs": {"op": "Reducer",
+            "rhs": {"op": "Agg",
                                                
-            "operator": "any",
+            "name": "any",
                                                
             "expr": e,
                                                
@@ -688,17 +688,17 @@ function peg$parse(input, options) {
                 
             "duration": null, "limit": 0},
               
-            {"op": "CutProc",
+            {"op": "Cut",
                   
-            "fields": [{"op": "Assignment",
+            "args": [{"op": "Assignment",
                                       
             "lhs": null,
                                       
-            "rhs": {"op": "Identifier", "name": "taste"}}]}]}
+            "rhs": {"op": "Id", "name": "taste"}}]}]}
           
           },
       peg$c188 = function(lval) { return lval},
-      peg$c189 = function() { return {"op":"RootRecord"} },
+      peg$c189 = function() { return {"op":"Root"} },
       peg$c190 = function(first, rest) {
             let result = [first];
 
@@ -712,7 +712,7 @@ function peg$parse(input, options) {
       peg$c192 = "?",
       peg$c193 = peg$literalExpectation("?", false),
       peg$c194 = function(condition, thenClause, elseClause) {
-            return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
+            return {"op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
       peg$c195 = function(first, comp, expr) { return [comp, expr] },
       peg$c196 = "+",
@@ -722,7 +722,7 @@ function peg$parse(input, options) {
       peg$c200 = "/",
       peg$c201 = peg$literalExpectation("/", false),
       peg$c202 = function(e) {
-              return {"op": "UnaryExpr", "operator": "!", "operand": e}
+              return {"op": "UnaryExpr", "kind": "!", "operand": e}
           },
       peg$c203 = "not",
       peg$c204 = peg$literalExpectation("not", false),
@@ -735,17 +735,17 @@ function peg$parse(input, options) {
           },
       peg$c210 = function(methods) { return methods },
       peg$c211 = function(fn, args) {
-            return {"op": "FunctionCall", "function": fn, "args": args}
+            return {"op": "Call", "name": fn, "args": args}
           },
       peg$c212 = function(first, e) { return e },
       peg$c213 = function() { return [] },
       peg$c214 = function() {
-            return {"op":"RootRecord"}
+            return {"op":"Root"}
           },
       peg$c215 = function(field) {
-            return {"op": "BinaryExpr", "operator":".",
+            return {"op": "BinaryExpr", "kind":".",
                            
-            "lhs":{"op":"RootRecord"},
+            "lhs":{"op":"Root"},
                            
             "rhs":field}
           
@@ -756,28 +756,28 @@ function peg$parse(input, options) {
       peg$c218 = "]",
       peg$c219 = peg$literalExpectation("]", false),
       peg$c220 = function(expr) {
-            return {"op": "BinaryExpr", "operator":"[",
+            return {"op": "BinaryExpr", "kind":"[",
                            
-            "lhs":{"op":"RootRecord"},
+            "lhs":{"op":"Root"},
                            
             "rhs":expr}
           
 
           },
       peg$c221 = function(from, to) {
-            return ["[", {"op": "BinaryExpr", "operator":":",
+            return ["[", {"op": "BinaryExpr", "kind":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
       peg$c222 = function(to) {
-            return ["[", {"op": "BinaryExpr", "operator":":",
+            return ["[", {"op": "BinaryExpr", "kind":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
       peg$c223 = function(from) {
-            return ["[", {"op": "BinaryExpr", "operator":":",
+            return ["[", {"op": "BinaryExpr", "kind":":",
                                   
             "lhs":from, "rhs": null}]
           
@@ -809,7 +809,7 @@ function peg$parse(input, options) {
       peg$c238 = peg$literalExpectation("null", false),
       peg$c239 = function() { return {"op": "Literal", "type": "null", "value": ""} },
       peg$c240 = function(typ) {
-            return {"op": "TypeExpr", "type": typ}
+            return {"op": "TypeValue", "value": typ}
           },
       peg$c241 = function(typ) { return typ},
       peg$c242 = function(typ) { return typ },
@@ -912,7 +912,7 @@ function peg$parse(input, options) {
       peg$c317 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
       peg$c318 = /^[0-9]/,
       peg$c319 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c320 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c320 = function(id) { return {"op": "Id", "name": id} },
       peg$c321 = function() {  return text() },
       peg$c322 = "$",
       peg$c323 = peg$literalExpectation("$", false),
@@ -3397,7 +3397,7 @@ function peg$parse(input, options) {
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEveryDur();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseReducers();
+          s3 = peg$parseAggAssignments();
           if (s3 !== peg$FAILED) {
             s4 = peg$currPos;
             s5 = peg$parse_();
@@ -3737,7 +3737,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducerAssignment() {
+  function peg$parseAggAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -3755,7 +3755,7 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseReducer();
+            s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
               s1 = peg$c103(s1, s5);
@@ -3782,7 +3782,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseReducer();
+      s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c104(s1);
@@ -3793,7 +3793,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducer() {
+  function peg$parseAgg() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
 
     s0 = peg$currPos;
@@ -3808,7 +3808,7 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseReducerName();
+      s2 = peg$parseAggName();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -3920,7 +3920,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducerName() {
+  function peg$parseAggName() {
     var s0;
 
     s0 = peg$parseIdentifierName();
@@ -3975,11 +3975,11 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducers() {
+  function peg$parseAggAssignments() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$parseReducerAssignment();
+    s1 = peg$parseAggAssignment();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
@@ -3995,7 +3995,7 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
-            s7 = peg$parseReducerAssignment();
+            s7 = peg$parseAggAssignment();
             if (s7 !== peg$FAILED) {
               s4 = [s4, s5, s6, s7];
               s3 = s4;
@@ -4030,7 +4030,7 @@ function peg$parse(input, options) {
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
-              s7 = peg$parseReducerAssignment();
+              s7 = peg$parseAggAssignment();
               if (s7 !== peg$FAILED) {
                 s4 = [s4, s5, s6, s7];
                 s3 = s4;
@@ -11251,7 +11251,7 @@ function peg$parse(input, options) {
   function makeBinaryExprChain(first, rest) {
     let ret = first;
     for (let part of rest) {
-      ret = { op: "BinaryExpr", operator: part[0], lhs: ret, rhs: part[1] };
+      ret = { op: "BinaryExpr", kind: part[0], lhs: ret, rhs: part[1] };
     }
     return ret
   }

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -104,7 +104,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 22, col: 5, offset: 743},
+						pos:  position{line: 22, col: 5, offset: 739},
 						name: "Sequential",
 					},
 				},
@@ -112,22 +112,22 @@ var g = &grammar{
 		},
 		{
 			name: "Const",
-			pos:  position{line: 24, col: 1, offset: 755},
+			pos:  position{line: 24, col: 1, offset: 751},
 			expr: &actionExpr{
-				pos: position{line: 24, col: 9, offset: 763},
+				pos: position{line: 24, col: 9, offset: 759},
 				run: (*parser).callonConst1,
 				expr: &seqExpr{
-					pos: position{line: 24, col: 9, offset: 763},
+					pos: position{line: 24, col: 9, offset: 759},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 24, col: 9, offset: 763},
+							pos:  position{line: 24, col: 9, offset: 759},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 24, col: 12, offset: 766},
+							pos:   position{line: 24, col: 12, offset: 762},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 24, col: 14, offset: 768},
+								pos:  position{line: 24, col: 14, offset: 764},
 								name: "AnyConst",
 							},
 						},
@@ -137,73 +137,73 @@ var g = &grammar{
 		},
 		{
 			name: "AnyConst",
-			pos:  position{line: 26, col: 1, offset: 796},
+			pos:  position{line: 26, col: 1, offset: 792},
 			expr: &choiceExpr{
-				pos: position{line: 27, col: 5, offset: 809},
+				pos: position{line: 27, col: 5, offset: 805},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 27, col: 5, offset: 809},
+						pos: position{line: 27, col: 5, offset: 805},
 						run: (*parser).callonAnyConst2,
 						expr: &seqExpr{
-							pos: position{line: 27, col: 5, offset: 809},
+							pos: position{line: 27, col: 5, offset: 805},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 27, col: 5, offset: 809},
+									pos:        position{line: 27, col: 5, offset: 805},
 									val:        "const",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 13, offset: 817},
+									pos:  position{line: 27, col: 13, offset: 813},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 27, col: 15, offset: 819},
+									pos:   position{line: 27, col: 15, offset: 815},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 27, col: 18, offset: 822},
+										pos:  position{line: 27, col: 18, offset: 818},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 33, offset: 837},
+									pos:  position{line: 27, col: 33, offset: 833},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 27, col: 36, offset: 840},
+									pos:        position{line: 27, col: 36, offset: 836},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 40, offset: 844},
+									pos:  position{line: 27, col: 40, offset: 840},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 27, col: 43, offset: 847},
+									pos:   position{line: 27, col: 43, offset: 843},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 27, col: 48, offset: 852},
+										pos:  position{line: 27, col: 48, offset: 848},
 										name: "Expr",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 27, col: 55, offset: 859},
+									pos: position{line: 27, col: 55, offset: 855},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 27, col: 55, offset: 859},
+											pos: position{line: 27, col: 55, offset: 855},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 55, offset: 859},
+													pos:  position{line: 27, col: 55, offset: 855},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 27, col: 58, offset: 862},
+													pos:        position{line: 27, col: 58, offset: 858},
 													val:        ";",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 27, col: 64, offset: 868},
+											pos:  position{line: 27, col: 64, offset: 864},
 											name: "EOL",
 										},
 									},
@@ -212,68 +212,68 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 30, col: 5, offset: 968},
+						pos: position{line: 30, col: 5, offset: 960},
 						run: (*parser).callonAnyConst18,
 						expr: &seqExpr{
-							pos: position{line: 30, col: 5, offset: 968},
+							pos: position{line: 30, col: 5, offset: 960},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 30, col: 5, offset: 968},
+									pos:        position{line: 30, col: 5, offset: 960},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 12, offset: 975},
+									pos:  position{line: 30, col: 12, offset: 967},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 30, col: 14, offset: 977},
+									pos:   position{line: 30, col: 14, offset: 969},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 30, col: 17, offset: 980},
+										pos:  position{line: 30, col: 17, offset: 972},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 32, offset: 995},
+									pos:  position{line: 30, col: 32, offset: 987},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 30, col: 35, offset: 998},
+									pos:        position{line: 30, col: 35, offset: 990},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 39, offset: 1002},
+									pos:  position{line: 30, col: 39, offset: 994},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 30, col: 42, offset: 1005},
+									pos:   position{line: 30, col: 42, offset: 997},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 30, col: 46, offset: 1009},
+										pos:  position{line: 30, col: 46, offset: 1001},
 										name: "Type",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 30, col: 53, offset: 1016},
+									pos: position{line: 30, col: 53, offset: 1008},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 30, col: 53, offset: 1016},
+											pos: position{line: 30, col: 53, offset: 1008},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 30, col: 53, offset: 1016},
+													pos:  position{line: 30, col: 53, offset: 1008},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 30, col: 56, offset: 1019},
+													pos:        position{line: 30, col: 56, offset: 1011},
 													val:        ";",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 30, col: 62, offset: 1025},
+											pos:  position{line: 30, col: 62, offset: 1017},
 											name: "EOL",
 										},
 									},
@@ -286,31 +286,31 @@ var g = &grammar{
 		},
 		{
 			name: "Sequential",
-			pos:  position{line: 34, col: 1, offset: 1120},
+			pos:  position{line: 34, col: 1, offset: 1112},
 			expr: &choiceExpr{
-				pos: position{line: 35, col: 5, offset: 1135},
+				pos: position{line: 35, col: 5, offset: 1127},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 35, col: 5, offset: 1135},
+						pos: position{line: 35, col: 5, offset: 1127},
 						run: (*parser).callonSequential2,
 						expr: &seqExpr{
-							pos: position{line: 35, col: 5, offset: 1135},
+							pos: position{line: 35, col: 5, offset: 1127},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 35, col: 5, offset: 1135},
+									pos:   position{line: 35, col: 5, offset: 1127},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 35, col: 11, offset: 1141},
+										pos:  position{line: 35, col: 11, offset: 1133},
 										name: "Operation",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 35, col: 21, offset: 1151},
+									pos:   position{line: 35, col: 21, offset: 1143},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 35, col: 26, offset: 1156},
+										pos: position{line: 35, col: 26, offset: 1148},
 										expr: &ruleRefExpr{
-											pos:  position{line: 35, col: 26, offset: 1156},
+											pos:  position{line: 35, col: 26, offset: 1148},
 											name: "SequentialTail",
 										},
 									},
@@ -319,13 +319,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 38, col: 5, offset: 1316},
+						pos: position{line: 38, col: 5, offset: 1304},
 						run: (*parser).callonSequential9,
 						expr: &labeledExpr{
-							pos:   position{line: 38, col: 5, offset: 1316},
+							pos:   position{line: 38, col: 5, offset: 1304},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 38, col: 8, offset: 1319},
+								pos:  position{line: 38, col: 8, offset: 1307},
 								name: "Operation",
 							},
 						},
@@ -335,31 +335,31 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialTail",
-			pos:  position{line: 42, col: 1, offset: 1431},
+			pos:  position{line: 42, col: 1, offset: 1415},
 			expr: &actionExpr{
-				pos: position{line: 42, col: 18, offset: 1448},
+				pos: position{line: 42, col: 18, offset: 1432},
 				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 42, col: 18, offset: 1448},
+					pos: position{line: 42, col: 18, offset: 1432},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 18, offset: 1448},
+							pos:  position{line: 42, col: 18, offset: 1432},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 42, col: 21, offset: 1451},
+							pos:        position{line: 42, col: 21, offset: 1435},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 25, offset: 1455},
+							pos:  position{line: 42, col: 25, offset: 1439},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 42, col: 28, offset: 1458},
+							pos:   position{line: 42, col: 28, offset: 1442},
 							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 42, col: 30, offset: 1460},
+								pos:  position{line: 42, col: 30, offset: 1444},
 								name: "Operation",
 							},
 						},
@@ -369,31 +369,31 @@ var g = &grammar{
 		},
 		{
 			name: "Parallel",
-			pos:  position{line: 44, col: 1, offset: 1489},
+			pos:  position{line: 44, col: 1, offset: 1473},
 			expr: &choiceExpr{
-				pos: position{line: 45, col: 5, offset: 1502},
+				pos: position{line: 45, col: 5, offset: 1486},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 45, col: 5, offset: 1502},
+						pos: position{line: 45, col: 5, offset: 1486},
 						run: (*parser).callonParallel2,
 						expr: &seqExpr{
-							pos: position{line: 45, col: 5, offset: 1502},
+							pos: position{line: 45, col: 5, offset: 1486},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 45, col: 5, offset: 1502},
+									pos:   position{line: 45, col: 5, offset: 1486},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 45, col: 11, offset: 1508},
+										pos:  position{line: 45, col: 11, offset: 1492},
 										name: "Sequential",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 45, col: 22, offset: 1519},
+									pos:   position{line: 45, col: 22, offset: 1503},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 45, col: 27, offset: 1524},
+										pos: position{line: 45, col: 27, offset: 1508},
 										expr: &ruleRefExpr{
-											pos:  position{line: 45, col: 27, offset: 1524},
+											pos:  position{line: 45, col: 27, offset: 1508},
 											name: "ParallelTail",
 										},
 									},
@@ -402,13 +402,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 48, col: 5, offset: 1625},
+						pos: position{line: 48, col: 5, offset: 1609},
 						run: (*parser).callonParallel9,
 						expr: &labeledExpr{
-							pos:   position{line: 48, col: 5, offset: 1625},
+							pos:   position{line: 48, col: 5, offset: 1609},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 48, col: 11, offset: 1631},
+								pos:  position{line: 48, col: 11, offset: 1615},
 								name: "Sequential",
 							},
 						},
@@ -418,31 +418,31 @@ var g = &grammar{
 		},
 		{
 			name: "ParallelTail",
-			pos:  position{line: 52, col: 1, offset: 1690},
+			pos:  position{line: 52, col: 1, offset: 1674},
 			expr: &actionExpr{
-				pos: position{line: 53, col: 5, offset: 1707},
+				pos: position{line: 53, col: 5, offset: 1691},
 				run: (*parser).callonParallelTail1,
 				expr: &seqExpr{
-					pos: position{line: 53, col: 5, offset: 1707},
+					pos: position{line: 53, col: 5, offset: 1691},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 53, col: 5, offset: 1707},
+							pos:  position{line: 53, col: 5, offset: 1691},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 53, col: 8, offset: 1710},
+							pos:        position{line: 53, col: 8, offset: 1694},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 53, col: 13, offset: 1715},
+							pos:  position{line: 53, col: 13, offset: 1699},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 53, col: 16, offset: 1718},
+							pos:   position{line: 53, col: 16, offset: 1702},
 							label: "ch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 53, col: 19, offset: 1721},
+								pos:  position{line: 53, col: 19, offset: 1705},
 								name: "Sequential",
 							},
 						},
@@ -452,54 +452,54 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchBranch",
-			pos:  position{line: 55, col: 1, offset: 1752},
+			pos:  position{line: 55, col: 1, offset: 1736},
 			expr: &choiceExpr{
-				pos: position{line: 56, col: 5, offset: 1769},
+				pos: position{line: 56, col: 5, offset: 1753},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 56, col: 5, offset: 1769},
+						pos: position{line: 56, col: 5, offset: 1753},
 						run: (*parser).callonSwitchBranch2,
 						expr: &seqExpr{
-							pos: position{line: 56, col: 5, offset: 1769},
+							pos: position{line: 56, col: 5, offset: 1753},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 5, offset: 1769},
+									pos:  position{line: 56, col: 5, offset: 1753},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 8, offset: 1772},
+									pos:  position{line: 56, col: 8, offset: 1756},
 									name: "CaseToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 18, offset: 1782},
+									pos:  position{line: 56, col: 18, offset: 1766},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 20, offset: 1784},
-									label: "filter",
+									pos:   position{line: 56, col: 20, offset: 1768},
+									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 27, offset: 1791},
+										pos:  position{line: 56, col: 22, offset: 1770},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 41, offset: 1805},
+									pos:  position{line: 56, col: 36, offset: 1784},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 56, col: 44, offset: 1808},
+									pos:        position{line: 56, col: 39, offset: 1787},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 49, offset: 1813},
+									pos:  position{line: 56, col: 44, offset: 1792},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 52, offset: 1816},
+									pos:   position{line: 56, col: 47, offset: 1795},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 57, offset: 1821},
+										pos:  position{line: 56, col: 52, offset: 1800},
 										name: "Sequential",
 									},
 								},
@@ -507,37 +507,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 59, col: 5, offset: 1917},
+						pos: position{line: 59, col: 5, offset: 1889},
 						run: (*parser).callonSwitchBranch14,
 						expr: &seqExpr{
-							pos: position{line: 59, col: 5, offset: 1917},
+							pos: position{line: 59, col: 5, offset: 1889},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 5, offset: 1917},
+									pos:  position{line: 59, col: 5, offset: 1889},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 8, offset: 1920},
+									pos:  position{line: 59, col: 8, offset: 1892},
 									name: "DefaultToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 21, offset: 1933},
+									pos:  position{line: 59, col: 21, offset: 1905},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 59, col: 24, offset: 1936},
+									pos:        position{line: 59, col: 24, offset: 1908},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 29, offset: 1941},
+									pos:  position{line: 59, col: 29, offset: 1913},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 59, col: 32, offset: 1944},
+									pos:   position{line: 59, col: 32, offset: 1916},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 59, col: 37, offset: 1949},
+										pos:  position{line: 59, col: 37, offset: 1921},
 										name: "Sequential",
 									},
 								},
@@ -549,31 +549,31 @@ var g = &grammar{
 		},
 		{
 			name: "Switch",
-			pos:  position{line: 63, col: 1, offset: 2108},
+			pos:  position{line: 63, col: 1, offset: 2078},
 			expr: &choiceExpr{
-				pos: position{line: 64, col: 5, offset: 2119},
+				pos: position{line: 64, col: 5, offset: 2089},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 64, col: 5, offset: 2119},
+						pos: position{line: 64, col: 5, offset: 2089},
 						run: (*parser).callonSwitch2,
 						expr: &seqExpr{
-							pos: position{line: 64, col: 5, offset: 2119},
+							pos: position{line: 64, col: 5, offset: 2089},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 64, col: 5, offset: 2119},
+									pos:   position{line: 64, col: 5, offset: 2089},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 64, col: 11, offset: 2125},
+										pos:  position{line: 64, col: 11, offset: 2095},
 										name: "SwitchBranch",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 64, col: 24, offset: 2138},
+									pos:   position{line: 64, col: 24, offset: 2108},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 64, col: 29, offset: 2143},
+										pos: position{line: 64, col: 29, offset: 2113},
 										expr: &ruleRefExpr{
-											pos:  position{line: 64, col: 29, offset: 2143},
+											pos:  position{line: 64, col: 29, offset: 2113},
 											name: "SwitchBranch",
 										},
 									},
@@ -582,13 +582,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 67, col: 5, offset: 2244},
+						pos: position{line: 67, col: 5, offset: 2214},
 						run: (*parser).callonSwitch9,
 						expr: &labeledExpr{
-							pos:   position{line: 67, col: 5, offset: 2244},
+							pos:   position{line: 67, col: 5, offset: 2214},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 67, col: 11, offset: 2250},
+								pos:  position{line: 67, col: 11, offset: 2220},
 								name: "SwitchBranch",
 							},
 						},
@@ -598,75 +598,75 @@ var g = &grammar{
 		},
 		{
 			name: "CaseToken",
-			pos:  position{line: 71, col: 1, offset: 2311},
+			pos:  position{line: 71, col: 1, offset: 2281},
 			expr: &litMatcher{
-				pos:        position{line: 71, col: 13, offset: 2323},
+				pos:        position{line: 71, col: 13, offset: 2293},
 				val:        "case",
 				ignoreCase: true,
 			},
 		},
 		{
 			name: "DefaultToken",
-			pos:  position{line: 72, col: 1, offset: 2331},
+			pos:  position{line: 72, col: 1, offset: 2301},
 			expr: &litMatcher{
-				pos:        position{line: 72, col: 16, offset: 2346},
+				pos:        position{line: 72, col: 16, offset: 2316},
 				val:        "default",
 				ignoreCase: true,
 			},
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 74, col: 1, offset: 2358},
+			pos:  position{line: 74, col: 1, offset: 2328},
 			expr: &choiceExpr{
-				pos: position{line: 75, col: 5, offset: 2372},
+				pos: position{line: 75, col: 5, offset: 2342},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 75, col: 5, offset: 2372},
+						pos: position{line: 75, col: 5, offset: 2342},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 75, col: 5, offset: 2372},
+							pos: position{line: 75, col: 5, offset: 2342},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 75, col: 5, offset: 2372},
+									pos:        position{line: 75, col: 5, offset: 2342},
 									val:        "split",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 13, offset: 2380},
+									pos:  position{line: 75, col: 13, offset: 2350},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 16, offset: 2383},
+									pos:        position{line: 75, col: 16, offset: 2353},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 20, offset: 2387},
+									pos:  position{line: 75, col: 20, offset: 2357},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 23, offset: 2390},
+									pos:        position{line: 75, col: 23, offset: 2360},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 28, offset: 2395},
+									pos:  position{line: 75, col: 28, offset: 2365},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 75, col: 31, offset: 2398},
+									pos:   position{line: 75, col: 31, offset: 2368},
 									label: "procArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 75, col: 41, offset: 2408},
+										pos:  position{line: 75, col: 41, offset: 2378},
 										name: "Parallel",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 50, offset: 2417},
+									pos:  position{line: 75, col: 50, offset: 2387},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 53, offset: 2420},
+									pos:        position{line: 75, col: 53, offset: 2390},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -674,43 +674,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 78, col: 5, offset: 2519},
+						pos: position{line: 78, col: 5, offset: 2485},
 						run: (*parser).callonOperation14,
 						expr: &seqExpr{
-							pos: position{line: 78, col: 5, offset: 2519},
+							pos: position{line: 78, col: 5, offset: 2485},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 78, col: 5, offset: 2519},
+									pos:        position{line: 78, col: 5, offset: 2485},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 14, offset: 2528},
+									pos:  position{line: 78, col: 14, offset: 2494},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 78, col: 17, offset: 2531},
+									pos:        position{line: 78, col: 17, offset: 2497},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 21, offset: 2535},
+									pos:  position{line: 78, col: 21, offset: 2501},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 78, col: 24, offset: 2538},
+									pos:   position{line: 78, col: 24, offset: 2504},
 									label: "caseArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 78, col: 34, offset: 2548},
+										pos:  position{line: 78, col: 34, offset: 2514},
 										name: "Switch",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 41, offset: 2555},
+									pos:  position{line: 78, col: 41, offset: 2521},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 78, col: 44, offset: 2558},
+									pos:        position{line: 78, col: 44, offset: 2524},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -718,27 +718,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 81, col: 5, offset: 2655},
+						pos:  position{line: 81, col: 5, offset: 2617},
 						name: "Operator",
 					},
 					&actionExpr{
-						pos: position{line: 82, col: 5, offset: 2668},
+						pos: position{line: 82, col: 5, offset: 2630},
 						run: (*parser).callonOperation25,
 						expr: &seqExpr{
-							pos: position{line: 82, col: 5, offset: 2668},
+							pos: position{line: 82, col: 5, offset: 2630},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 82, col: 5, offset: 2668},
+									pos:   position{line: 82, col: 5, offset: 2630},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 7, offset: 2670},
+										pos:  position{line: 82, col: 7, offset: 2632},
 										name: "Function",
 									},
 								},
 								&andExpr{
-									pos: position{line: 82, col: 16, offset: 2679},
+									pos: position{line: 82, col: 16, offset: 2641},
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 17, offset: 2680},
+										pos:  position{line: 82, col: 17, offset: 2642},
 										name: "EndOfOp",
 									},
 								},
@@ -746,23 +746,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 83, col: 5, offset: 2710},
+						pos: position{line: 83, col: 5, offset: 2672},
 						run: (*parser).callonOperation31,
 						expr: &seqExpr{
-							pos: position{line: 83, col: 5, offset: 2710},
+							pos: position{line: 83, col: 5, offset: 2672},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 83, col: 5, offset: 2710},
+									pos:   position{line: 83, col: 5, offset: 2672},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 7, offset: 2712},
+										pos:  position{line: 83, col: 7, offset: 2674},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 83, col: 19, offset: 2724},
+									pos: position{line: 83, col: 19, offset: 2686},
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 20, offset: 2725},
+										pos:  position{line: 83, col: 20, offset: 2687},
 										name: "EndOfOp",
 									},
 								},
@@ -770,23 +770,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 84, col: 5, offset: 2756},
+						pos: position{line: 84, col: 5, offset: 2718},
 						run: (*parser).callonOperation37,
 						expr: &seqExpr{
-							pos: position{line: 84, col: 5, offset: 2756},
+							pos: position{line: 84, col: 5, offset: 2718},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 84, col: 5, offset: 2756},
+									pos:   position{line: 84, col: 5, offset: 2718},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 10, offset: 2761},
+										pos:  position{line: 84, col: 10, offset: 2723},
 										name: "SearchBoolean",
 									},
 								},
 								&notExpr{
-									pos: position{line: 84, col: 24, offset: 2775},
+									pos: position{line: 84, col: 24, offset: 2737},
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 25, offset: 2776},
+										pos:  position{line: 84, col: 25, offset: 2738},
 										name: "AggGuard",
 									},
 								},
@@ -798,34 +798,34 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 88, col: 1, offset: 2871},
+			pos:  position{line: 88, col: 1, offset: 2827},
 			expr: &seqExpr{
-				pos: position{line: 88, col: 11, offset: 2881},
+				pos: position{line: 88, col: 11, offset: 2837},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 88, col: 11, offset: 2881},
+						pos:  position{line: 88, col: 11, offset: 2837},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 88, col: 15, offset: 2885},
+						pos: position{line: 88, col: 15, offset: 2841},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 88, col: 15, offset: 2885},
+								pos:        position{line: 88, col: 15, offset: 2841},
 								val:        "|",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 88, col: 21, offset: 2891},
+								pos:        position{line: 88, col: 21, offset: 2847},
 								val:        "=>",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 88, col: 28, offset: 2898},
+								pos:        position{line: 88, col: 28, offset: 2854},
 								val:        ")",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 88, col: 34, offset: 2904},
+								pos:  position{line: 88, col: 34, offset: 2860},
 								name: "EOF",
 							},
 						},
@@ -835,49 +835,49 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 90, col: 1, offset: 2910},
+			pos:  position{line: 90, col: 1, offset: 2866},
 			expr: &seqExpr{
-				pos: position{line: 90, col: 13, offset: 2922},
+				pos: position{line: 90, col: 13, offset: 2878},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 90, col: 13, offset: 2922},
+						pos:  position{line: 90, col: 13, offset: 2878},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 90, col: 17, offset: 2926},
+						pos: position{line: 90, col: 17, offset: 2882},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 90, col: 18, offset: 2927},
+								pos: position{line: 90, col: 18, offset: 2883},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 90, col: 18, offset: 2927},
+										pos: position{line: 90, col: 18, offset: 2883},
 										expr: &litMatcher{
-											pos:        position{line: 90, col: 19, offset: 2928},
+											pos:        position{line: 90, col: 19, offset: 2884},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 90, col: 24, offset: 2933},
+										pos:  position{line: 90, col: 24, offset: 2889},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 90, col: 38, offset: 2947},
+								pos:  position{line: 90, col: 38, offset: 2903},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 90, col: 57, offset: 2966},
+								pos:  position{line: 90, col: 57, offset: 2922},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 90, col: 82, offset: 2991},
+								pos:        position{line: 90, col: 82, offset: 2947},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 90, col: 88, offset: 2997},
+								pos:        position{line: 90, col: 88, offset: 2953},
 								val:        "(",
 								ignoreCase: false,
 							},
@@ -888,46 +888,46 @@ var g = &grammar{
 		},
 		{
 			name: "AggGuard",
-			pos:  position{line: 92, col: 1, offset: 3003},
+			pos:  position{line: 92, col: 1, offset: 2959},
 			expr: &choiceExpr{
-				pos: position{line: 92, col: 12, offset: 3014},
+				pos: position{line: 92, col: 12, offset: 2970},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 92, col: 13, offset: 3015},
+						pos: position{line: 92, col: 13, offset: 2971},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 13, offset: 3015},
+								pos:  position{line: 92, col: 13, offset: 2971},
 								name: "_",
 							},
 							&choiceExpr{
-								pos: position{line: 92, col: 16, offset: 3018},
+								pos: position{line: 92, col: 16, offset: 2974},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 92, col: 16, offset: 3018},
+										pos:  position{line: 92, col: 16, offset: 2974},
 										name: "ByToken",
 									},
 									&litMatcher{
-										pos:        position{line: 92, col: 26, offset: 3028},
+										pos:        position{line: 92, col: 26, offset: 2984},
 										val:        "-with",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 35, offset: 3037},
+								pos:  position{line: 92, col: 35, offset: 2993},
 								name: "EOT",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 92, col: 43, offset: 3045},
+						pos: position{line: 92, col: 43, offset: 3001},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 43, offset: 3045},
+								pos:  position{line: 92, col: 43, offset: 3001},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 92, col: 46, offset: 3048},
+								pos:        position{line: 92, col: 46, offset: 3004},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -938,28 +938,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 94, col: 1, offset: 3054},
+			pos:  position{line: 94, col: 1, offset: 3010},
 			expr: &actionExpr{
-				pos: position{line: 95, col: 5, offset: 3072},
+				pos: position{line: 95, col: 5, offset: 3028},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 95, col: 5, offset: 3072},
+					pos: position{line: 95, col: 5, offset: 3028},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 95, col: 5, offset: 3072},
+							pos:   position{line: 95, col: 5, offset: 3028},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 95, col: 11, offset: 3078},
+								pos:  position{line: 95, col: 11, offset: 3034},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 95, col: 21, offset: 3088},
+							pos:   position{line: 95, col: 21, offset: 3044},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 95, col: 26, offset: 3093},
+								pos: position{line: 95, col: 26, offset: 3049},
 								expr: &ruleRefExpr{
-									pos:  position{line: 95, col: 26, offset: 3093},
+									pos:  position{line: 95, col: 26, offset: 3049},
 									name: "SearchOrTerm",
 								},
 							},
@@ -970,30 +970,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 99, col: 1, offset: 3167},
+			pos:  position{line: 99, col: 1, offset: 3123},
 			expr: &actionExpr{
-				pos: position{line: 99, col: 16, offset: 3182},
+				pos: position{line: 99, col: 16, offset: 3138},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 99, col: 16, offset: 3182},
+					pos: position{line: 99, col: 16, offset: 3138},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 16, offset: 3182},
+							pos:  position{line: 99, col: 16, offset: 3138},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 18, offset: 3184},
+							pos:  position{line: 99, col: 18, offset: 3140},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 26, offset: 3192},
+							pos:  position{line: 99, col: 26, offset: 3148},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 99, col: 28, offset: 3194},
+							pos:   position{line: 99, col: 28, offset: 3150},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 99, col: 30, offset: 3196},
+								pos:  position{line: 99, col: 30, offset: 3152},
 								name: "SearchAnd",
 							},
 						},
@@ -1003,61 +1003,61 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 101, col: 1, offset: 3246},
+			pos:  position{line: 101, col: 1, offset: 3202},
 			expr: &actionExpr{
-				pos: position{line: 102, col: 5, offset: 3260},
+				pos: position{line: 102, col: 5, offset: 3216},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 102, col: 5, offset: 3260},
+					pos: position{line: 102, col: 5, offset: 3216},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 102, col: 5, offset: 3260},
+							pos:   position{line: 102, col: 5, offset: 3216},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 102, col: 11, offset: 3266},
+								pos:  position{line: 102, col: 11, offset: 3222},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 103, col: 5, offset: 3283},
+							pos:   position{line: 103, col: 5, offset: 3239},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 103, col: 10, offset: 3288},
+								pos: position{line: 103, col: 10, offset: 3244},
 								expr: &actionExpr{
-									pos: position{line: 103, col: 11, offset: 3289},
+									pos: position{line: 103, col: 11, offset: 3245},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 103, col: 11, offset: 3289},
+										pos: position{line: 103, col: 11, offset: 3245},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 103, col: 11, offset: 3289},
+												pos:  position{line: 103, col: 11, offset: 3245},
 												name: "__",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 103, col: 14, offset: 3292},
+												pos: position{line: 103, col: 14, offset: 3248},
 												expr: &seqExpr{
-													pos: position{line: 103, col: 15, offset: 3293},
+													pos: position{line: 103, col: 15, offset: 3249},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 103, col: 15, offset: 3293},
+															pos:  position{line: 103, col: 15, offset: 3249},
 															name: "AndToken",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 103, col: 24, offset: 3302},
+															pos:  position{line: 103, col: 24, offset: 3258},
 															name: "_",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 103, col: 28, offset: 3306},
+												pos:  position{line: 103, col: 28, offset: 3262},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 103, col: 31, offset: 3309},
+												pos:   position{line: 103, col: 31, offset: 3265},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 103, col: 36, offset: 3314},
+													pos:  position{line: 103, col: 36, offset: 3270},
 													name: "SearchFactor",
 												},
 											},
@@ -1072,42 +1072,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 107, col: 1, offset: 3430},
+			pos:  position{line: 107, col: 1, offset: 3386},
 			expr: &choiceExpr{
-				pos: position{line: 108, col: 5, offset: 3447},
+				pos: position{line: 108, col: 5, offset: 3403},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 108, col: 5, offset: 3447},
+						pos: position{line: 108, col: 5, offset: 3403},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 108, col: 5, offset: 3447},
+							pos: position{line: 108, col: 5, offset: 3403},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 108, col: 6, offset: 3448},
+									pos: position{line: 108, col: 6, offset: 3404},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 108, col: 6, offset: 3448},
+											pos: position{line: 108, col: 6, offset: 3404},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 6, offset: 3448},
+													pos:  position{line: 108, col: 6, offset: 3404},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 15, offset: 3457},
+													pos:  position{line: 108, col: 15, offset: 3413},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 108, col: 19, offset: 3461},
+											pos: position{line: 108, col: 19, offset: 3417},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 108, col: 19, offset: 3461},
+													pos:        position{line: 108, col: 19, offset: 3417},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 23, offset: 3465},
+													pos:  position{line: 108, col: 23, offset: 3421},
 													name: "__",
 												},
 											},
@@ -1115,10 +1115,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 108, col: 27, offset: 3469},
+									pos:   position{line: 108, col: 27, offset: 3425},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 108, col: 29, offset: 3471},
+										pos:  position{line: 108, col: 29, offset: 3427},
 										name: "SearchFactor",
 									},
 								},
@@ -1126,42 +1126,42 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 111, col: 5, offset: 3587},
+						pos:  position{line: 111, col: 5, offset: 3539},
 						name: "ShortCut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 112, col: 5, offset: 3600},
+						pos:  position{line: 112, col: 5, offset: 3552},
 						name: "SearchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 113, col: 5, offset: 3615},
+						pos: position{line: 113, col: 5, offset: 3567},
 						run: (*parser).callonSearchFactor15,
 						expr: &seqExpr{
-							pos: position{line: 113, col: 5, offset: 3615},
+							pos: position{line: 113, col: 5, offset: 3567},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 113, col: 5, offset: 3615},
+									pos:        position{line: 113, col: 5, offset: 3567},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 113, col: 9, offset: 3619},
+									pos:  position{line: 113, col: 9, offset: 3571},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 113, col: 12, offset: 3622},
+									pos:   position{line: 113, col: 12, offset: 3574},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 17, offset: 3627},
+										pos:  position{line: 113, col: 17, offset: 3579},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 113, col: 31, offset: 3641},
+									pos:  position{line: 113, col: 31, offset: 3593},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 113, col: 34, offset: 3644},
+									pos:        position{line: 113, col: 34, offset: 3596},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1173,42 +1173,42 @@ var g = &grammar{
 		},
 		{
 			name: "ShortCut",
-			pos:  position{line: 115, col: 1, offset: 3670},
+			pos:  position{line: 115, col: 1, offset: 3622},
 			expr: &choiceExpr{
-				pos: position{line: 116, col: 5, offset: 3683},
+				pos: position{line: 116, col: 5, offset: 3635},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 116, col: 5, offset: 3683},
+						pos: position{line: 116, col: 5, offset: 3635},
 						run: (*parser).callonShortCut2,
 						expr: &seqExpr{
-							pos: position{line: 116, col: 5, offset: 3683},
+							pos: position{line: 116, col: 5, offset: 3635},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 116, col: 5, offset: 3683},
+									pos:        position{line: 116, col: 5, offset: 3635},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 116, col: 9, offset: 3687},
+									pos:  position{line: 116, col: 9, offset: 3639},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 12, offset: 3690},
+									pos:   position{line: 116, col: 12, offset: 3642},
 									label: "compareOp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 22, offset: 3700},
+										pos:  position{line: 116, col: 22, offset: 3652},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 116, col: 36, offset: 3714},
+									pos:  position{line: 116, col: 36, offset: 3666},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 39, offset: 3717},
+									pos:   position{line: 116, col: 39, offset: 3669},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 41, offset: 3719},
+										pos:  position{line: 116, col: 41, offset: 3671},
 										name: "SearchValue",
 									},
 								},
@@ -1216,47 +1216,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 143, col: 5, offset: 4440},
+						pos: position{line: 143, col: 5, offset: 4350},
 						run: (*parser).callonShortCut11,
 						expr: &seqExpr{
-							pos: position{line: 143, col: 5, offset: 4440},
+							pos: position{line: 143, col: 5, offset: 4350},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 143, col: 5, offset: 4440},
+									pos:   position{line: 143, col: 5, offset: 4350},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 7, offset: 4442},
+										pos:  position{line: 143, col: 7, offset: 4352},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 12, offset: 4447},
+									pos:  position{line: 143, col: 12, offset: 4357},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 15, offset: 4450},
+									pos:   position{line: 143, col: 15, offset: 4360},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 20, offset: 4455},
+										pos:  position{line: 143, col: 20, offset: 4365},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 34, offset: 4469},
+									pos:  position{line: 143, col: 34, offset: 4379},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 37, offset: 4472},
+									pos:   position{line: 143, col: 37, offset: 4382},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 39, offset: 4474},
+										pos:  position{line: 143, col: 39, offset: 4384},
 										name: "GlobbySearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 143, col: 57, offset: 4492},
+									pos: position{line: 143, col: 57, offset: 4402},
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 58, offset: 4493},
+										pos:  position{line: 143, col: 58, offset: 4403},
 										name: "ExprGuard",
 									},
 								},
@@ -1264,33 +1264,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 146, col: 5, offset: 4611},
+						pos: position{line: 146, col: 5, offset: 4517},
 						run: (*parser).callonShortCut23,
 						expr: &seqExpr{
-							pos: position{line: 146, col: 5, offset: 4611},
+							pos: position{line: 146, col: 5, offset: 4517},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 146, col: 5, offset: 4611},
+									pos:   position{line: 146, col: 5, offset: 4517},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 7, offset: 4613},
+										pos:  position{line: 146, col: 7, offset: 4519},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 19, offset: 4625},
+									pos:  position{line: 146, col: 19, offset: 4531},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 21, offset: 4627},
+									pos:  position{line: 146, col: 21, offset: 4533},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 29, offset: 4635},
+									pos:  position{line: 146, col: 29, offset: 4541},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 146, col: 31, offset: 4637},
+									pos:        position{line: 146, col: 31, offset: 4543},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1298,39 +1298,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 173, col: 5, offset: 5351},
+						pos: position{line: 173, col: 5, offset: 5215},
 						run: (*parser).callonShortCut31,
 						expr: &seqExpr{
-							pos: position{line: 173, col: 5, offset: 5351},
+							pos: position{line: 173, col: 5, offset: 5215},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 173, col: 5, offset: 5351},
+									pos: position{line: 173, col: 5, offset: 5215},
 									expr: &seqExpr{
-										pos: position{line: 173, col: 7, offset: 5353},
+										pos: position{line: 173, col: 7, offset: 5217},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 173, col: 7, offset: 5353},
+												pos:  position{line: 173, col: 7, offset: 5217},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 173, col: 19, offset: 5365},
+												pos:  position{line: 173, col: 19, offset: 5229},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 173, col: 24, offset: 5370},
+									pos:   position{line: 173, col: 24, offset: 5234},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 173, col: 26, offset: 5372},
+										pos:  position{line: 173, col: 26, offset: 5236},
 										name: "GlobbySearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 173, col: 44, offset: 5390},
+									pos: position{line: 173, col: 44, offset: 5254},
 									expr: &ruleRefExpr{
-										pos:  position{line: 173, col: 45, offset: 5391},
+										pos:  position{line: 173, col: 45, offset: 5255},
 										name: "ExprGuard",
 									},
 								},
@@ -1338,20 +1338,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 5506},
+						pos: position{line: 176, col: 5, offset: 5370},
 						run: (*parser).callonShortCut41,
 						expr: &seqExpr{
-							pos: position{line: 176, col: 5, offset: 5506},
+							pos: position{line: 176, col: 5, offset: 5370},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 176, col: 5, offset: 5506},
+									pos:        position{line: 176, col: 5, offset: 5370},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 176, col: 9, offset: 5510},
+									pos: position{line: 176, col: 9, offset: 5374},
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 10, offset: 5511},
+										pos:  position{line: 176, col: 10, offset: 5375},
 										name: "ExprGuard",
 									},
 								},
@@ -1363,22 +1363,22 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 180, col: 1, offset: 5621},
+			pos:  position{line: 180, col: 1, offset: 5485},
 			expr: &choiceExpr{
-				pos: position{line: 181, col: 5, offset: 5637},
+				pos: position{line: 181, col: 5, offset: 5501},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 181, col: 5, offset: 5637},
+						pos:  position{line: 181, col: 5, offset: 5501},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 182, col: 5, offset: 5649},
+						pos: position{line: 182, col: 5, offset: 5513},
 						run: (*parser).callonSearchValue3,
 						expr: &labeledExpr{
-							pos:   position{line: 182, col: 5, offset: 5649},
+							pos:   position{line: 182, col: 5, offset: 5513},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 182, col: 7, offset: 5651},
+								pos:  position{line: 182, col: 7, offset: 5515},
 								name: "KeyWord",
 							},
 						},
@@ -1388,22 +1388,22 @@ var g = &grammar{
 		},
 		{
 			name: "GlobbySearchValue",
-			pos:  position{line: 186, col: 1, offset: 5756},
+			pos:  position{line: 186, col: 1, offset: 5620},
 			expr: &choiceExpr{
-				pos: position{line: 187, col: 5, offset: 5778},
+				pos: position{line: 187, col: 5, offset: 5642},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 187, col: 5, offset: 5778},
+						pos:  position{line: 187, col: 5, offset: 5642},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 188, col: 5, offset: 5790},
+						pos: position{line: 188, col: 5, offset: 5654},
 						run: (*parser).callonGlobbySearchValue3,
 						expr: &labeledExpr{
-							pos:   position{line: 188, col: 5, offset: 5790},
+							pos:   position{line: 188, col: 5, offset: 5654},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 7, offset: 5792},
+								pos:  position{line: 188, col: 7, offset: 5656},
 								name: "SearchGlob",
 							},
 						},
@@ -1413,31 +1413,31 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGlob",
-			pos:  position{line: 198, col: 1, offset: 6078},
+			pos:  position{line: 198, col: 1, offset: 5942},
 			expr: &actionExpr{
-				pos: position{line: 199, col: 5, offset: 6093},
+				pos: position{line: 199, col: 5, offset: 5957},
 				run: (*parser).callonSearchGlob1,
 				expr: &seqExpr{
-					pos: position{line: 199, col: 5, offset: 6093},
+					pos: position{line: 199, col: 5, offset: 5957},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 199, col: 5, offset: 6093},
+							pos:   position{line: 199, col: 5, offset: 5957},
 							label: "head",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 199, col: 10, offset: 6098},
+								pos: position{line: 199, col: 10, offset: 5962},
 								expr: &ruleRefExpr{
-									pos:  position{line: 199, col: 10, offset: 6098},
+									pos:  position{line: 199, col: 10, offset: 5962},
 									name: "GlobPart",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 199, col: 20, offset: 6108},
+							pos:   position{line: 199, col: 20, offset: 5972},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 199, col: 25, offset: 6113},
+								pos: position{line: 199, col: 25, offset: 5977},
 								expr: &litMatcher{
-									pos:        position{line: 199, col: 26, offset: 6114},
+									pos:        position{line: 199, col: 26, offset: 5978},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1449,29 +1449,29 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPart",
-			pos:  position{line: 203, col: 1, offset: 6181},
+			pos:  position{line: 203, col: 1, offset: 6045},
 			expr: &choiceExpr{
-				pos: position{line: 204, col: 5, offset: 6194},
+				pos: position{line: 204, col: 5, offset: 6058},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 204, col: 5, offset: 6194},
+						pos: position{line: 204, col: 5, offset: 6058},
 						run: (*parser).callonGlobPart2,
 						expr: &seqExpr{
-							pos: position{line: 204, col: 5, offset: 6194},
+							pos: position{line: 204, col: 5, offset: 6058},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 204, col: 5, offset: 6194},
+									pos:   position{line: 204, col: 5, offset: 6058},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 204, col: 7, offset: 6196},
+										pos:  position{line: 204, col: 7, offset: 6060},
 										name: "Stars",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 204, col: 13, offset: 6202},
+									pos:   position{line: 204, col: 13, offset: 6066},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 204, col: 15, offset: 6204},
+										pos:  position{line: 204, col: 15, offset: 6068},
 										name: "KeyWord",
 									},
 								},
@@ -1479,7 +1479,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 5, offset: 6254},
+						pos:  position{line: 205, col: 5, offset: 6118},
 						name: "KeyWord",
 					},
 				},
@@ -1487,14 +1487,14 @@ var g = &grammar{
 		},
 		{
 			name: "Stars",
-			pos:  position{line: 207, col: 1, offset: 6263},
+			pos:  position{line: 207, col: 1, offset: 6127},
 			expr: &actionExpr{
-				pos: position{line: 207, col: 9, offset: 6271},
+				pos: position{line: 207, col: 9, offset: 6135},
 				run: (*parser).callonStars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 207, col: 9, offset: 6271},
+					pos: position{line: 207, col: 9, offset: 6135},
 					expr: &litMatcher{
-						pos:        position{line: 207, col: 9, offset: 6271},
+						pos:        position{line: 207, col: 9, offset: 6135},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -1503,40 +1503,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGuard",
-			pos:  position{line: 209, col: 1, offset: 6308},
+			pos:  position{line: 209, col: 1, offset: 6172},
 			expr: &choiceExpr{
-				pos: position{line: 210, col: 5, offset: 6324},
+				pos: position{line: 210, col: 5, offset: 6188},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 210, col: 5, offset: 6324},
+						pos:  position{line: 210, col: 5, offset: 6188},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 211, col: 5, offset: 6337},
+						pos:  position{line: 211, col: 5, offset: 6201},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 212, col: 5, offset: 6349},
+						pos:  position{line: 212, col: 5, offset: 6213},
 						name: "NotToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 213, col: 5, offset: 6362},
+						pos:  position{line: 213, col: 5, offset: 6226},
 						name: "InToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 214, col: 5, offset: 6374},
+						pos:  position{line: 214, col: 5, offset: 6238},
 						name: "ByToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 215, col: 5, offset: 6386},
+						pos:  position{line: 215, col: 5, offset: 6250},
 						name: "CaseToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 216, col: 5, offset: 6400},
+						pos:  position{line: 216, col: 5, offset: 6264},
 						name: "DefaultToken",
 					},
 					&litMatcher{
-						pos:        position{line: 217, col: 5, offset: 6417},
+						pos:        position{line: 217, col: 5, offset: 6281},
 						val:        "type(",
 						ignoreCase: false,
 					},
@@ -1545,53 +1545,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 221, col: 1, offset: 6474},
+			pos:  position{line: 221, col: 1, offset: 6338},
 			expr: &ruleRefExpr{
-				pos:  position{line: 221, col: 14, offset: 6487},
+				pos:  position{line: 221, col: 14, offset: 6351},
 				name: "SearchExprRelative",
 			},
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 223, col: 1, offset: 6507},
+			pos:  position{line: 223, col: 1, offset: 6371},
 			expr: &actionExpr{
-				pos: position{line: 223, col: 14, offset: 6520},
+				pos: position{line: 223, col: 14, offset: 6384},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 223, col: 15, offset: 6521},
+					pos: position{line: 223, col: 15, offset: 6385},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 223, col: 15, offset: 6521},
+							pos:        position{line: 223, col: 15, offset: 6385},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 21, offset: 6527},
+							pos:        position{line: 223, col: 21, offset: 6391},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 28, offset: 6534},
+							pos:        position{line: 223, col: 28, offset: 6398},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 35, offset: 6541},
+							pos:        position{line: 223, col: 35, offset: 6405},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 42, offset: 6548},
+							pos:        position{line: 223, col: 42, offset: 6412},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 48, offset: 6554},
+							pos:        position{line: 223, col: 48, offset: 6418},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 55, offset: 6561},
+							pos:        position{line: 223, col: 55, offset: 6425},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1601,53 +1601,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprRelative",
-			pos:  position{line: 225, col: 1, offset: 6598},
+			pos:  position{line: 225, col: 1, offset: 6462},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 6621},
+				pos: position{line: 226, col: 5, offset: 6485},
 				run: (*parser).callonSearchExprRelative1,
 				expr: &seqExpr{
-					pos: position{line: 226, col: 5, offset: 6621},
+					pos: position{line: 226, col: 5, offset: 6485},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 6621},
+							pos:   position{line: 226, col: 5, offset: 6485},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 226, col: 11, offset: 6627},
+								pos:  position{line: 226, col: 11, offset: 6491},
 								name: "SearchExprAdd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 227, col: 5, offset: 6645},
+							pos:   position{line: 227, col: 5, offset: 6509},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 227, col: 10, offset: 6650},
+								pos: position{line: 227, col: 10, offset: 6514},
 								expr: &actionExpr{
-									pos: position{line: 227, col: 11, offset: 6651},
+									pos: position{line: 227, col: 11, offset: 6515},
 									run: (*parser).callonSearchExprRelative7,
 									expr: &seqExpr{
-										pos: position{line: 227, col: 11, offset: 6651},
+										pos: position{line: 227, col: 11, offset: 6515},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 227, col: 11, offset: 6651},
+												pos:  position{line: 227, col: 11, offset: 6515},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 227, col: 14, offset: 6654},
+												pos:   position{line: 227, col: 14, offset: 6518},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 227, col: 17, offset: 6657},
+													pos:  position{line: 227, col: 17, offset: 6521},
 													name: "Comparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 227, col: 28, offset: 6668},
+												pos:  position{line: 227, col: 28, offset: 6532},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 227, col: 31, offset: 6671},
+												pos:   position{line: 227, col: 31, offset: 6535},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 227, col: 36, offset: 6676},
+													pos:  position{line: 227, col: 36, offset: 6540},
 													name: "SearchExprAdd",
 												},
 											},
@@ -1662,53 +1662,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprAdd",
-			pos:  position{line: 231, col: 1, offset: 6793},
+			pos:  position{line: 231, col: 1, offset: 6657},
 			expr: &actionExpr{
-				pos: position{line: 232, col: 5, offset: 6811},
+				pos: position{line: 232, col: 5, offset: 6675},
 				run: (*parser).callonSearchExprAdd1,
 				expr: &seqExpr{
-					pos: position{line: 232, col: 5, offset: 6811},
+					pos: position{line: 232, col: 5, offset: 6675},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 232, col: 5, offset: 6811},
+							pos:   position{line: 232, col: 5, offset: 6675},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 11, offset: 6817},
+								pos:  position{line: 232, col: 11, offset: 6681},
 								name: "SearchExprMul",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 5, offset: 6835},
+							pos:   position{line: 233, col: 5, offset: 6699},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 233, col: 10, offset: 6840},
+								pos: position{line: 233, col: 10, offset: 6704},
 								expr: &actionExpr{
-									pos: position{line: 233, col: 11, offset: 6841},
+									pos: position{line: 233, col: 11, offset: 6705},
 									run: (*parser).callonSearchExprAdd7,
 									expr: &seqExpr{
-										pos: position{line: 233, col: 11, offset: 6841},
+										pos: position{line: 233, col: 11, offset: 6705},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 233, col: 11, offset: 6841},
+												pos:  position{line: 233, col: 11, offset: 6705},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 233, col: 14, offset: 6844},
+												pos:   position{line: 233, col: 14, offset: 6708},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 233, col: 17, offset: 6847},
+													pos:  position{line: 233, col: 17, offset: 6711},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 233, col: 34, offset: 6864},
+												pos:  position{line: 233, col: 34, offset: 6728},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 233, col: 37, offset: 6867},
+												pos:   position{line: 233, col: 37, offset: 6731},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 233, col: 42, offset: 6872},
+													pos:  position{line: 233, col: 42, offset: 6736},
 													name: "SearchExprMul",
 												},
 											},
@@ -1723,53 +1723,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprMul",
-			pos:  position{line: 237, col: 1, offset: 6989},
+			pos:  position{line: 237, col: 1, offset: 6853},
 			expr: &actionExpr{
-				pos: position{line: 238, col: 5, offset: 7007},
+				pos: position{line: 238, col: 5, offset: 6871},
 				run: (*parser).callonSearchExprMul1,
 				expr: &seqExpr{
-					pos: position{line: 238, col: 5, offset: 7007},
+					pos: position{line: 238, col: 5, offset: 6871},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 238, col: 5, offset: 7007},
+							pos:   position{line: 238, col: 5, offset: 6871},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 238, col: 11, offset: 7013},
+								pos:  position{line: 238, col: 11, offset: 6877},
 								name: "SearchExprCast",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 5, offset: 7032},
+							pos:   position{line: 239, col: 5, offset: 6896},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 239, col: 10, offset: 7037},
+								pos: position{line: 239, col: 10, offset: 6901},
 								expr: &actionExpr{
-									pos: position{line: 239, col: 11, offset: 7038},
+									pos: position{line: 239, col: 11, offset: 6902},
 									run: (*parser).callonSearchExprMul7,
 									expr: &seqExpr{
-										pos: position{line: 239, col: 11, offset: 7038},
+										pos: position{line: 239, col: 11, offset: 6902},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 239, col: 11, offset: 7038},
+												pos:  position{line: 239, col: 11, offset: 6902},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 239, col: 14, offset: 7041},
+												pos:   position{line: 239, col: 14, offset: 6905},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 239, col: 17, offset: 7044},
+													pos:  position{line: 239, col: 17, offset: 6908},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 239, col: 40, offset: 7067},
+												pos:  position{line: 239, col: 40, offset: 6931},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 239, col: 43, offset: 7070},
+												pos:   position{line: 239, col: 43, offset: 6934},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 239, col: 48, offset: 7075},
+													pos:  position{line: 239, col: 48, offset: 6939},
 													name: "SearchExprCast",
 												},
 											},
@@ -1784,42 +1784,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprCast",
-			pos:  position{line: 243, col: 1, offset: 7193},
+			pos:  position{line: 243, col: 1, offset: 7057},
 			expr: &choiceExpr{
-				pos: position{line: 244, col: 5, offset: 7212},
+				pos: position{line: 244, col: 5, offset: 7076},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 244, col: 5, offset: 7212},
+						pos: position{line: 244, col: 5, offset: 7076},
 						run: (*parser).callonSearchExprCast2,
 						expr: &seqExpr{
-							pos: position{line: 244, col: 5, offset: 7212},
+							pos: position{line: 244, col: 5, offset: 7076},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 244, col: 5, offset: 7212},
+									pos:   position{line: 244, col: 5, offset: 7076},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 244, col: 7, offset: 7214},
+										pos:  position{line: 244, col: 7, offset: 7078},
 										name: "SearchExprFunc",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 244, col: 22, offset: 7229},
+									pos:  position{line: 244, col: 22, offset: 7093},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 244, col: 25, offset: 7232},
+									pos:        position{line: 244, col: 25, offset: 7096},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 244, col: 29, offset: 7236},
+									pos:  position{line: 244, col: 29, offset: 7100},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 244, col: 32, offset: 7239},
+									pos:   position{line: 244, col: 32, offset: 7103},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 244, col: 36, offset: 7243},
+										pos:  position{line: 244, col: 36, offset: 7107},
 										name: "CastType",
 									},
 								},
@@ -1827,7 +1827,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 5, offset: 7347},
+						pos:  position{line: 247, col: 5, offset: 7207},
 						name: "SearchExprFunc",
 					},
 				},
@@ -1835,39 +1835,39 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprFunc",
-			pos:  position{line: 249, col: 1, offset: 7363},
+			pos:  position{line: 249, col: 1, offset: 7223},
 			expr: &choiceExpr{
-				pos: position{line: 250, col: 5, offset: 7382},
+				pos: position{line: 250, col: 5, offset: 7242},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 250, col: 5, offset: 7382},
+						pos:  position{line: 250, col: 5, offset: 7242},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 7396},
+						pos:  position{line: 251, col: 5, offset: 7256},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 252, col: 5, offset: 7412},
+						pos: position{line: 252, col: 5, offset: 7272},
 						run: (*parser).callonSearchExprFunc4,
 						expr: &seqExpr{
-							pos: position{line: 252, col: 5, offset: 7412},
+							pos: position{line: 252, col: 5, offset: 7272},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 252, col: 5, offset: 7412},
+									pos:   position{line: 252, col: 5, offset: 7272},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 252, col: 11, offset: 7418},
+										pos:  position{line: 252, col: 11, offset: 7278},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 252, col: 20, offset: 7427},
+									pos:   position{line: 252, col: 20, offset: 7287},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 252, col: 25, offset: 7432},
+										pos: position{line: 252, col: 25, offset: 7292},
 										expr: &ruleRefExpr{
-											pos:  position{line: 252, col: 26, offset: 7433},
+											pos:  position{line: 252, col: 26, offset: 7293},
 											name: "Deref",
 										},
 									},
@@ -1876,11 +1876,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 7505},
+						pos:  position{line: 255, col: 5, offset: 7365},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 7517},
+						pos:  position{line: 256, col: 5, offset: 7377},
 						name: "DerefExpr",
 					},
 				},
@@ -1888,41 +1888,41 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 260, col: 1, offset: 7554},
+			pos:  position{line: 260, col: 1, offset: 7414},
 			expr: &choiceExpr{
-				pos: position{line: 261, col: 5, offset: 7570},
+				pos: position{line: 261, col: 5, offset: 7430},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 7570},
+						pos: position{line: 261, col: 5, offset: 7430},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 261, col: 5, offset: 7570},
+							pos: position{line: 261, col: 5, offset: 7430},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 261, col: 5, offset: 7570},
+									pos:  position{line: 261, col: 5, offset: 7430},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 15, offset: 7580},
+									pos:   position{line: 261, col: 15, offset: 7440},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 21, offset: 7586},
+										pos:  position{line: 261, col: 21, offset: 7446},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 30, offset: 7595},
+									pos:   position{line: 261, col: 30, offset: 7455},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 35, offset: 7600},
+										pos:  position{line: 261, col: 35, offset: 7460},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 47, offset: 7612},
+									pos:   position{line: 261, col: 47, offset: 7472},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 53, offset: 7618},
+										pos:  position{line: 261, col: 53, offset: 7478},
 										name: "LimitArg",
 									},
 								},
@@ -1930,45 +1930,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 7767},
+						pos: position{line: 264, col: 5, offset: 7621},
 						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 264, col: 5, offset: 7767},
+							pos: position{line: 264, col: 5, offset: 7621},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 264, col: 5, offset: 7767},
+									pos:  position{line: 264, col: 5, offset: 7621},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 15, offset: 7777},
+									pos:   position{line: 264, col: 15, offset: 7631},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 264, col: 21, offset: 7783},
+										pos:  position{line: 264, col: 21, offset: 7637},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 30, offset: 7792},
-									label: "reducers",
+									pos:   position{line: 264, col: 30, offset: 7646},
+									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 264, col: 39, offset: 7801},
-										name: "Reducers",
+										pos:  position{line: 264, col: 35, offset: 7651},
+										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 48, offset: 7810},
+									pos:   position{line: 264, col: 50, offset: 7666},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 264, col: 53, offset: 7815},
+										pos: position{line: 264, col: 55, offset: 7671},
 										expr: &seqExpr{
-											pos: position{line: 264, col: 54, offset: 7816},
+											pos: position{line: 264, col: 56, offset: 7672},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 264, col: 54, offset: 7816},
+													pos:  position{line: 264, col: 56, offset: 7672},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 264, col: 56, offset: 7818},
+													pos:  position{line: 264, col: 58, offset: 7674},
 													name: "GroupByKeys",
 												},
 											},
@@ -1976,10 +1976,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 70, offset: 7832},
+									pos:   position{line: 264, col: 72, offset: 7688},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 264, col: 76, offset: 7838},
+										pos:  position{line: 264, col: 78, offset: 7694},
 										name: "LimitArg",
 									},
 								},
@@ -1991,26 +1991,26 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 272, col: 1, offset: 8079},
+			pos:  position{line: 272, col: 1, offset: 7925},
 			expr: &choiceExpr{
-				pos: position{line: 272, col: 13, offset: 8091},
+				pos: position{line: 272, col: 13, offset: 7937},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 272, col: 13, offset: 8091},
+						pos: position{line: 272, col: 13, offset: 7937},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 272, col: 13, offset: 8091},
+								pos:        position{line: 272, col: 13, offset: 7937},
 								val:        "summarize",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 272, col: 25, offset: 8103},
+								pos:  position{line: 272, col: 25, offset: 7949},
 								name: "_",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 272, col: 29, offset: 8107},
+						pos:        position{line: 272, col: 29, offset: 7953},
 						val:        "",
 						ignoreCase: false,
 					},
@@ -2019,45 +2019,45 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 274, col: 1, offset: 8111},
+			pos:  position{line: 274, col: 1, offset: 7957},
 			expr: &choiceExpr{
-				pos: position{line: 275, col: 5, offset: 8124},
+				pos: position{line: 275, col: 5, offset: 7970},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 275, col: 5, offset: 8124},
+						pos: position{line: 275, col: 5, offset: 7970},
 						run: (*parser).callonEveryDur2,
 						expr: &seqExpr{
-							pos: position{line: 275, col: 5, offset: 8124},
+							pos: position{line: 275, col: 5, offset: 7970},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 275, col: 5, offset: 8124},
+									pos:        position{line: 275, col: 5, offset: 7970},
 									val:        "every",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 275, col: 14, offset: 8133},
+									pos:  position{line: 275, col: 14, offset: 7979},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 275, col: 16, offset: 8135},
+									pos:   position{line: 275, col: 16, offset: 7981},
 									label: "dur",
 									expr: &ruleRefExpr{
-										pos:  position{line: 275, col: 20, offset: 8139},
+										pos:  position{line: 275, col: 20, offset: 7985},
 										name: "Duration",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 275, col: 29, offset: 8148},
+									pos:  position{line: 275, col: 29, offset: 7994},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 276, col: 5, offset: 8174},
+						pos: position{line: 276, col: 5, offset: 8020},
 						run: (*parser).callonEveryDur9,
 						expr: &litMatcher{
-							pos:        position{line: 276, col: 5, offset: 8174},
+							pos:        position{line: 276, col: 5, offset: 8020},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2067,26 +2067,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 278, col: 1, offset: 8199},
+			pos:  position{line: 278, col: 1, offset: 8045},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 5, offset: 8215},
+				pos: position{line: 279, col: 5, offset: 8061},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 5, offset: 8215},
+					pos: position{line: 279, col: 5, offset: 8061},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 279, col: 5, offset: 8215},
+							pos:  position{line: 279, col: 5, offset: 8061},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 279, col: 13, offset: 8223},
+							pos:  position{line: 279, col: 13, offset: 8069},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 15, offset: 8225},
+							pos:   position{line: 279, col: 15, offset: 8071},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 23, offset: 8233},
+								pos:  position{line: 279, col: 23, offset: 8079},
 								name: "FlexAssignments",
 							},
 						},
@@ -2096,43 +2096,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 281, col: 1, offset: 8274},
+			pos:  position{line: 281, col: 1, offset: 8120},
 			expr: &choiceExpr{
-				pos: position{line: 282, col: 5, offset: 8287},
+				pos: position{line: 282, col: 5, offset: 8133},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 282, col: 5, offset: 8287},
+						pos: position{line: 282, col: 5, offset: 8133},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 282, col: 5, offset: 8287},
+							pos: position{line: 282, col: 5, offset: 8133},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 282, col: 5, offset: 8287},
+									pos:  position{line: 282, col: 5, offset: 8133},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 282, col: 7, offset: 8289},
+									pos:        position{line: 282, col: 7, offset: 8135},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 282, col: 14, offset: 8296},
+									pos:  position{line: 282, col: 14, offset: 8142},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 282, col: 16, offset: 8298},
+									pos:        position{line: 282, col: 16, offset: 8144},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 282, col: 25, offset: 8307},
+									pos:  position{line: 282, col: 25, offset: 8153},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 282, col: 27, offset: 8309},
+									pos:   position{line: 282, col: 27, offset: 8155},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 282, col: 33, offset: 8315},
+										pos:  position{line: 282, col: 33, offset: 8161},
 										name: "UInt",
 									},
 								},
@@ -2140,10 +2140,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 8346},
+						pos: position{line: 283, col: 5, offset: 8192},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 283, col: 5, offset: 8346},
+							pos:        position{line: 283, col: 5, offset: 8192},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2153,22 +2153,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 288, col: 1, offset: 8606},
+			pos:  position{line: 288, col: 1, offset: 8452},
 			expr: &choiceExpr{
-				pos: position{line: 289, col: 5, offset: 8625},
+				pos: position{line: 289, col: 5, offset: 8471},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 289, col: 5, offset: 8625},
+						pos:  position{line: 289, col: 5, offset: 8471},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 290, col: 5, offset: 8640},
+						pos: position{line: 290, col: 5, offset: 8486},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 290, col: 5, offset: 8640},
+							pos:   position{line: 290, col: 5, offset: 8486},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 10, offset: 8645},
+								pos:  position{line: 290, col: 10, offset: 8491},
 								name: "Expr",
 							},
 						},
@@ -2178,50 +2178,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 292, col: 1, offset: 8735},
+			pos:  position{line: 292, col: 1, offset: 8581},
 			expr: &actionExpr{
-				pos: position{line: 293, col: 5, offset: 8755},
+				pos: position{line: 293, col: 5, offset: 8601},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 293, col: 5, offset: 8755},
+					pos: position{line: 293, col: 5, offset: 8601},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 293, col: 5, offset: 8755},
+							pos:   position{line: 293, col: 5, offset: 8601},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 11, offset: 8761},
+								pos:  position{line: 293, col: 11, offset: 8607},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 26, offset: 8776},
+							pos:   position{line: 293, col: 26, offset: 8622},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 293, col: 31, offset: 8781},
+								pos: position{line: 293, col: 31, offset: 8627},
 								expr: &actionExpr{
-									pos: position{line: 293, col: 32, offset: 8782},
+									pos: position{line: 293, col: 32, offset: 8628},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 293, col: 32, offset: 8782},
+										pos: position{line: 293, col: 32, offset: 8628},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 293, col: 32, offset: 8782},
+												pos:  position{line: 293, col: 32, offset: 8628},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 293, col: 35, offset: 8785},
+												pos:        position{line: 293, col: 35, offset: 8631},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 293, col: 39, offset: 8789},
+												pos:  position{line: 293, col: 39, offset: 8635},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 293, col: 42, offset: 8792},
+												pos:   position{line: 293, col: 42, offset: 8638},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 293, col: 47, offset: 8797},
+													pos:  position{line: 293, col: 47, offset: 8643},
 													name: "FlexAssignment",
 												},
 											},
@@ -2235,58 +2235,58 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ReducerAssignment",
-			pos:  position{line: 297, col: 1, offset: 8919},
+			name: "AggAssignment",
+			pos:  position{line: 297, col: 1, offset: 8765},
 			expr: &choiceExpr{
-				pos: position{line: 298, col: 5, offset: 8941},
+				pos: position{line: 298, col: 5, offset: 8783},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 298, col: 5, offset: 8941},
-						run: (*parser).callonReducerAssignment2,
+						pos: position{line: 298, col: 5, offset: 8783},
+						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 298, col: 5, offset: 8941},
+							pos: position{line: 298, col: 5, offset: 8783},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 298, col: 5, offset: 8941},
+									pos:   position{line: 298, col: 5, offset: 8783},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 298, col: 10, offset: 8946},
+										pos:  position{line: 298, col: 10, offset: 8788},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 298, col: 15, offset: 8951},
+									pos:  position{line: 298, col: 15, offset: 8793},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 298, col: 18, offset: 8954},
+									pos:        position{line: 298, col: 18, offset: 8796},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 298, col: 22, offset: 8958},
+									pos:  position{line: 298, col: 22, offset: 8800},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 298, col: 25, offset: 8961},
-									label: "reducer",
+									pos:   position{line: 298, col: 25, offset: 8803},
+									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 298, col: 33, offset: 8969},
-										name: "Reducer",
+										pos:  position{line: 298, col: 29, offset: 8807},
+										name: "Agg",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 301, col: 5, offset: 9079},
-						run: (*parser).callonReducerAssignment11,
+						pos: position{line: 301, col: 5, offset: 8909},
+						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 301, col: 5, offset: 9079},
-							label: "reducer",
+							pos:   position{line: 301, col: 5, offset: 8909},
+							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 301, col: 13, offset: 9087},
-								name: "Reducer",
+								pos:  position{line: 301, col: 9, offset: 8913},
+								name: "Agg",
 							},
 						},
 					},
@@ -2294,73 +2294,73 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Reducer",
-			pos:  position{line: 305, col: 1, offset: 9193},
+			name: "Agg",
+			pos:  position{line: 305, col: 1, offset: 9011},
 			expr: &actionExpr{
-				pos: position{line: 306, col: 5, offset: 9205},
-				run: (*parser).callonReducer1,
+				pos: position{line: 306, col: 5, offset: 9019},
+				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 306, col: 5, offset: 9205},
+					pos: position{line: 306, col: 5, offset: 9019},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 306, col: 5, offset: 9205},
+							pos: position{line: 306, col: 5, offset: 9019},
 							expr: &ruleRefExpr{
-								pos:  position{line: 306, col: 6, offset: 9206},
+								pos:  position{line: 306, col: 6, offset: 9020},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 16, offset: 9216},
+							pos:   position{line: 306, col: 16, offset: 9030},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 306, col: 19, offset: 9219},
-								name: "ReducerName",
+								pos:  position{line: 306, col: 19, offset: 9033},
+								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 31, offset: 9231},
+							pos:  position{line: 306, col: 27, offset: 9041},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 306, col: 34, offset: 9234},
+							pos:        position{line: 306, col: 30, offset: 9044},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 38, offset: 9238},
+							pos:  position{line: 306, col: 34, offset: 9048},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 41, offset: 9241},
+							pos:   position{line: 306, col: 37, offset: 9051},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 306, col: 46, offset: 9246},
+								pos: position{line: 306, col: 42, offset: 9056},
 								expr: &ruleRefExpr{
-									pos:  position{line: 306, col: 46, offset: 9246},
+									pos:  position{line: 306, col: 42, offset: 9056},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 53, offset: 9253},
+							pos:  position{line: 306, col: 49, offset: 9063},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 306, col: 56, offset: 9256},
+							pos:        position{line: 306, col: 52, offset: 9066},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 306, col: 60, offset: 9260},
+							pos: position{line: 306, col: 56, offset: 9070},
 							expr: &seqExpr{
-								pos: position{line: 306, col: 62, offset: 9262},
+								pos: position{line: 306, col: 58, offset: 9072},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 306, col: 62, offset: 9262},
+										pos:  position{line: 306, col: 58, offset: 9072},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 306, col: 65, offset: 9265},
+										pos:        position{line: 306, col: 61, offset: 9075},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2368,12 +2368,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 70, offset: 9270},
+							pos:   position{line: 306, col: 66, offset: 9080},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 306, col: 76, offset: 9276},
+								pos: position{line: 306, col: 72, offset: 9086},
 								expr: &ruleRefExpr{
-									pos:  position{line: 306, col: 76, offset: 9276},
+									pos:  position{line: 306, col: 72, offset: 9086},
 									name: "WhereClause",
 								},
 							},
@@ -2383,21 +2383,21 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ReducerName",
-			pos:  position{line: 314, col: 1, offset: 9472},
+			name: "AggName",
+			pos:  position{line: 314, col: 1, offset: 9274},
 			expr: &choiceExpr{
-				pos: position{line: 315, col: 5, offset: 9488},
+				pos: position{line: 315, col: 5, offset: 9286},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 315, col: 5, offset: 9488},
+						pos:  position{line: 315, col: 5, offset: 9286},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 316, col: 5, offset: 9507},
+						pos:  position{line: 316, col: 5, offset: 9305},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 9520},
+						pos:  position{line: 317, col: 5, offset: 9318},
 						name: "OrToken",
 					},
 				},
@@ -2405,31 +2405,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 319, col: 1, offset: 9529},
+			pos:  position{line: 319, col: 1, offset: 9327},
 			expr: &actionExpr{
-				pos: position{line: 319, col: 15, offset: 9543},
+				pos: position{line: 319, col: 15, offset: 9341},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 319, col: 15, offset: 9543},
+					pos: position{line: 319, col: 15, offset: 9341},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 319, col: 15, offset: 9543},
+							pos:  position{line: 319, col: 15, offset: 9341},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 319, col: 17, offset: 9545},
+							pos:        position{line: 319, col: 17, offset: 9343},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 319, col: 25, offset: 9553},
+							pos:  position{line: 319, col: 25, offset: 9351},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 319, col: 27, offset: 9555},
+							pos:   position{line: 319, col: 27, offset: 9353},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 319, col: 32, offset: 9560},
+								pos:  position{line: 319, col: 32, offset: 9358},
 								name: "SearchBoolean",
 							},
 						},
@@ -2438,46 +2438,46 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Reducers",
-			pos:  position{line: 321, col: 1, offset: 9596},
+			name: "AggAssignments",
+			pos:  position{line: 321, col: 1, offset: 9394},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 5, offset: 9609},
-				run: (*parser).callonReducers1,
+				pos: position{line: 322, col: 5, offset: 9413},
+				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 5, offset: 9609},
+					pos: position{line: 322, col: 5, offset: 9413},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 322, col: 5, offset: 9609},
+							pos:   position{line: 322, col: 5, offset: 9413},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 322, col: 11, offset: 9615},
-								name: "ReducerAssignment",
+								pos:  position{line: 322, col: 11, offset: 9419},
+								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 29, offset: 9633},
+							pos:   position{line: 322, col: 25, offset: 9433},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 322, col: 34, offset: 9638},
+								pos: position{line: 322, col: 30, offset: 9438},
 								expr: &seqExpr{
-									pos: position{line: 322, col: 35, offset: 9639},
+									pos: position{line: 322, col: 31, offset: 9439},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 35, offset: 9639},
+											pos:  position{line: 322, col: 31, offset: 9439},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 322, col: 38, offset: 9642},
+											pos:        position{line: 322, col: 34, offset: 9442},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 42, offset: 9646},
+											pos:  position{line: 322, col: 38, offset: 9446},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 45, offset: 9649},
-											name: "ReducerAssignment",
+											pos:  position{line: 322, col: 41, offset: 9449},
+											name: "AggAssignment",
 										},
 									},
 								},
@@ -2489,68 +2489,68 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 330, col: 1, offset: 9854},
+			pos:  position{line: 330, col: 1, offset: 9650},
 			expr: &choiceExpr{
-				pos: position{line: 331, col: 5, offset: 9867},
+				pos: position{line: 331, col: 5, offset: 9663},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 9867},
+						pos:  position{line: 331, col: 5, offset: 9663},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 332, col: 5, offset: 9880},
+						pos:  position{line: 332, col: 5, offset: 9676},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 9892},
+						pos:  position{line: 333, col: 5, offset: 9688},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 9904},
+						pos:  position{line: 334, col: 5, offset: 9700},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 9917},
+						pos:  position{line: 335, col: 5, offset: 9713},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 9930},
+						pos:  position{line: 336, col: 5, offset: 9726},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 9943},
+						pos:  position{line: 337, col: 5, offset: 9739},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 9956},
+						pos:  position{line: 338, col: 5, offset: 9752},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 9971},
+						pos:  position{line: 339, col: 5, offset: 9767},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 9984},
+						pos:  position{line: 340, col: 5, offset: 9780},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 341, col: 5, offset: 9996},
+						pos:  position{line: 341, col: 5, offset: 9792},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 342, col: 5, offset: 10011},
+						pos:  position{line: 342, col: 5, offset: 9807},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 343, col: 5, offset: 10024},
+						pos:  position{line: 343, col: 5, offset: 9820},
 						name: "ShapeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 344, col: 5, offset: 10038},
+						pos:  position{line: 344, col: 5, offset: 9834},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 345, col: 5, offset: 10051},
+						pos:  position{line: 345, col: 5, offset: 9847},
 						name: "TasteProc",
 					},
 				},
@@ -2558,46 +2558,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 347, col: 1, offset: 10062},
+			pos:  position{line: 347, col: 1, offset: 9858},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 10075},
+				pos: position{line: 348, col: 5, offset: 9871},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 5, offset: 10075},
+					pos: position{line: 348, col: 5, offset: 9871},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 5, offset: 10075},
+							pos:        position{line: 348, col: 5, offset: 9871},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 13, offset: 10083},
+							pos:   position{line: 348, col: 13, offset: 9879},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 18, offset: 10088},
+								pos:  position{line: 348, col: 18, offset: 9884},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 27, offset: 10097},
+							pos:   position{line: 348, col: 27, offset: 9893},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 348, col: 32, offset: 10102},
+								pos: position{line: 348, col: 32, offset: 9898},
 								expr: &actionExpr{
-									pos: position{line: 348, col: 33, offset: 10103},
+									pos: position{line: 348, col: 33, offset: 9899},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 348, col: 33, offset: 10103},
+										pos: position{line: 348, col: 33, offset: 9899},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 348, col: 33, offset: 10103},
+												pos:  position{line: 348, col: 33, offset: 9899},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 348, col: 35, offset: 10105},
+												pos:   position{line: 348, col: 35, offset: 9901},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 348, col: 37, offset: 10107},
+													pos:  position{line: 348, col: 37, offset: 9903},
 													name: "Exprs",
 												},
 											},
@@ -2612,30 +2612,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 362, col: 1, offset: 10526},
+			pos:  position{line: 362, col: 1, offset: 10316},
 			expr: &actionExpr{
-				pos: position{line: 362, col: 12, offset: 10537},
+				pos: position{line: 362, col: 12, offset: 10327},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 362, col: 12, offset: 10537},
+					pos:   position{line: 362, col: 12, offset: 10327},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 362, col: 17, offset: 10542},
+						pos: position{line: 362, col: 17, offset: 10332},
 						expr: &actionExpr{
-							pos: position{line: 362, col: 18, offset: 10543},
+							pos: position{line: 362, col: 18, offset: 10333},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 362, col: 18, offset: 10543},
+								pos: position{line: 362, col: 18, offset: 10333},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 362, col: 18, offset: 10543},
+										pos:  position{line: 362, col: 18, offset: 10333},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 362, col: 20, offset: 10545},
+										pos:   position{line: 362, col: 20, offset: 10335},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 362, col: 22, offset: 10547},
+											pos:  position{line: 362, col: 22, offset: 10337},
 											name: "SortArg",
 										},
 									},
@@ -2648,50 +2648,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 364, col: 1, offset: 10603},
+			pos:  position{line: 364, col: 1, offset: 10393},
 			expr: &choiceExpr{
-				pos: position{line: 365, col: 5, offset: 10615},
+				pos: position{line: 365, col: 5, offset: 10405},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 365, col: 5, offset: 10615},
+						pos: position{line: 365, col: 5, offset: 10405},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 365, col: 5, offset: 10615},
+							pos:        position{line: 365, col: 5, offset: 10405},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 366, col: 5, offset: 10690},
+						pos: position{line: 366, col: 5, offset: 10480},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 366, col: 5, offset: 10690},
+							pos: position{line: 366, col: 5, offset: 10480},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 366, col: 5, offset: 10690},
+									pos:        position{line: 366, col: 5, offset: 10480},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 366, col: 14, offset: 10699},
+									pos:  position{line: 366, col: 14, offset: 10489},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 366, col: 16, offset: 10701},
+									pos:   position{line: 366, col: 16, offset: 10491},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 366, col: 23, offset: 10708},
+										pos: position{line: 366, col: 23, offset: 10498},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 366, col: 24, offset: 10709},
+											pos: position{line: 366, col: 24, offset: 10499},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 366, col: 24, offset: 10709},
+													pos:        position{line: 366, col: 24, offset: 10499},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 366, col: 34, offset: 10719},
+													pos:        position{line: 366, col: 34, offset: 10509},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2707,38 +2707,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 368, col: 1, offset: 10833},
+			pos:  position{line: 368, col: 1, offset: 10623},
 			expr: &actionExpr{
-				pos: position{line: 369, col: 5, offset: 10845},
+				pos: position{line: 369, col: 5, offset: 10635},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 369, col: 5, offset: 10845},
+					pos: position{line: 369, col: 5, offset: 10635},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 369, col: 5, offset: 10845},
+							pos:        position{line: 369, col: 5, offset: 10635},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 12, offset: 10852},
+							pos:   position{line: 369, col: 12, offset: 10642},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 18, offset: 10858},
+								pos: position{line: 369, col: 18, offset: 10648},
 								expr: &actionExpr{
-									pos: position{line: 369, col: 19, offset: 10859},
+									pos: position{line: 369, col: 19, offset: 10649},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 369, col: 19, offset: 10859},
+										pos: position{line: 369, col: 19, offset: 10649},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 369, col: 19, offset: 10859},
+												pos:  position{line: 369, col: 19, offset: 10649},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 369, col: 21, offset: 10861},
+												pos:   position{line: 369, col: 21, offset: 10651},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 369, col: 23, offset: 10863},
+													pos:  position{line: 369, col: 23, offset: 10653},
 													name: "UInt",
 												},
 											},
@@ -2748,19 +2748,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 47, offset: 10887},
+							pos:   position{line: 369, col: 47, offset: 10677},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 53, offset: 10893},
+								pos: position{line: 369, col: 53, offset: 10683},
 								expr: &seqExpr{
-									pos: position{line: 369, col: 54, offset: 10894},
+									pos: position{line: 369, col: 54, offset: 10684},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 369, col: 54, offset: 10894},
+											pos:  position{line: 369, col: 54, offset: 10684},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 369, col: 56, offset: 10896},
+											pos:        position{line: 369, col: 56, offset: 10686},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2769,25 +2769,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 67, offset: 10907},
+							pos:   position{line: 369, col: 67, offset: 10697},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 74, offset: 10914},
+								pos: position{line: 369, col: 74, offset: 10704},
 								expr: &actionExpr{
-									pos: position{line: 369, col: 75, offset: 10915},
+									pos: position{line: 369, col: 75, offset: 10705},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 369, col: 75, offset: 10915},
+										pos: position{line: 369, col: 75, offset: 10705},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 369, col: 75, offset: 10915},
+												pos:  position{line: 369, col: 75, offset: 10705},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 369, col: 77, offset: 10917},
+												pos:   position{line: 369, col: 77, offset: 10707},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 369, col: 79, offset: 10919},
+													pos:  position{line: 369, col: 79, offset: 10709},
 													name: "FieldExprs",
 												},
 											},
@@ -2802,27 +2802,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 383, col: 1, offset: 11270},
+			pos:  position{line: 383, col: 1, offset: 11052},
 			expr: &actionExpr{
-				pos: position{line: 384, col: 5, offset: 11282},
+				pos: position{line: 384, col: 5, offset: 11064},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 384, col: 5, offset: 11282},
+					pos: position{line: 384, col: 5, offset: 11064},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 384, col: 5, offset: 11282},
+							pos:        position{line: 384, col: 5, offset: 11064},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 384, col: 12, offset: 11289},
+							pos:  position{line: 384, col: 12, offset: 11071},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 384, col: 14, offset: 11291},
-							label: "columns",
+							pos:   position{line: 384, col: 14, offset: 11073},
+							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 384, col: 22, offset: 11299},
+								pos:  position{line: 384, col: 19, offset: 11078},
 								name: "FlexAssignments",
 							},
 						},
@@ -2832,27 +2832,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 388, col: 1, offset: 11401},
+			pos:  position{line: 388, col: 1, offset: 11171},
 			expr: &actionExpr{
-				pos: position{line: 389, col: 5, offset: 11414},
+				pos: position{line: 389, col: 5, offset: 11184},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 389, col: 5, offset: 11414},
+					pos: position{line: 389, col: 5, offset: 11184},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 389, col: 5, offset: 11414},
+							pos:        position{line: 389, col: 5, offset: 11184},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 389, col: 13, offset: 11422},
+							pos:  position{line: 389, col: 13, offset: 11192},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 389, col: 15, offset: 11424},
-							label: "columns",
+							pos:   position{line: 389, col: 15, offset: 11194},
+							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 389, col: 23, offset: 11432},
+								pos:  position{line: 389, col: 20, offset: 11199},
 								name: "FlexAssignments",
 							},
 						},
@@ -2862,27 +2862,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 393, col: 1, offset: 11535},
+			pos:  position{line: 393, col: 1, offset: 11293},
 			expr: &actionExpr{
-				pos: position{line: 394, col: 5, offset: 11548},
+				pos: position{line: 394, col: 5, offset: 11306},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 394, col: 5, offset: 11548},
+					pos: position{line: 394, col: 5, offset: 11306},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 394, col: 5, offset: 11548},
+							pos:        position{line: 394, col: 5, offset: 11306},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 13, offset: 11556},
+							pos:  position{line: 394, col: 13, offset: 11314},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 15, offset: 11558},
-							label: "columns",
+							pos:   position{line: 394, col: 15, offset: 11316},
+							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 23, offset: 11566},
+								pos:  position{line: 394, col: 20, offset: 11321},
 								name: "FieldExprs",
 							},
 						},
@@ -2892,30 +2892,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 398, col: 1, offset: 11664},
+			pos:  position{line: 398, col: 1, offset: 11410},
 			expr: &choiceExpr{
-				pos: position{line: 399, col: 5, offset: 11677},
+				pos: position{line: 399, col: 5, offset: 11423},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 399, col: 5, offset: 11677},
+						pos: position{line: 399, col: 5, offset: 11423},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 399, col: 5, offset: 11677},
+							pos: position{line: 399, col: 5, offset: 11423},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 399, col: 5, offset: 11677},
+									pos:        position{line: 399, col: 5, offset: 11423},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 399, col: 13, offset: 11685},
+									pos:  position{line: 399, col: 13, offset: 11431},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 399, col: 15, offset: 11687},
+									pos:   position{line: 399, col: 15, offset: 11433},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 399, col: 21, offset: 11693},
+										pos:  position{line: 399, col: 21, offset: 11439},
 										name: "UInt",
 									},
 								},
@@ -2923,10 +2923,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 400, col: 5, offset: 11775},
+						pos: position{line: 400, col: 5, offset: 11517},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 400, col: 5, offset: 11775},
+							pos:        position{line: 400, col: 5, offset: 11517},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2936,30 +2936,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 402, col: 1, offset: 11853},
+			pos:  position{line: 402, col: 1, offset: 11591},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 5, offset: 11866},
+				pos: position{line: 403, col: 5, offset: 11604},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 403, col: 5, offset: 11866},
+						pos: position{line: 403, col: 5, offset: 11604},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 403, col: 5, offset: 11866},
+							pos: position{line: 403, col: 5, offset: 11604},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 403, col: 5, offset: 11866},
+									pos:        position{line: 403, col: 5, offset: 11604},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 403, col: 13, offset: 11874},
+									pos:  position{line: 403, col: 13, offset: 11612},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 403, col: 15, offset: 11876},
+									pos:   position{line: 403, col: 15, offset: 11614},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 403, col: 21, offset: 11882},
+										pos:  position{line: 403, col: 21, offset: 11620},
 										name: "UInt",
 									},
 								},
@@ -2967,10 +2967,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 404, col: 5, offset: 11964},
+						pos: position{line: 404, col: 5, offset: 11698},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 404, col: 5, offset: 11964},
+							pos:        position{line: 404, col: 5, offset: 11698},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2980,27 +2980,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 406, col: 1, offset: 12042},
+			pos:  position{line: 406, col: 1, offset: 11772},
 			expr: &actionExpr{
-				pos: position{line: 407, col: 5, offset: 12057},
+				pos: position{line: 407, col: 5, offset: 11787},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 407, col: 5, offset: 12057},
+					pos: position{line: 407, col: 5, offset: 11787},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 407, col: 5, offset: 12057},
+							pos:        position{line: 407, col: 5, offset: 11787},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 407, col: 15, offset: 12067},
+							pos:  position{line: 407, col: 15, offset: 11797},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 407, col: 17, offset: 12069},
+							pos:   position{line: 407, col: 17, offset: 11799},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 407, col: 20, offset: 12072},
+								pos:  position{line: 407, col: 20, offset: 11802},
 								name: "Filter",
 							},
 						},
@@ -3010,15 +3010,15 @@ var g = &grammar{
 		},
 		{
 			name: "Filter",
-			pos:  position{line: 411, col: 1, offset: 12109},
+			pos:  position{line: 411, col: 1, offset: 11839},
 			expr: &actionExpr{
-				pos: position{line: 412, col: 5, offset: 12120},
+				pos: position{line: 412, col: 5, offset: 11850},
 				run: (*parser).callonFilter1,
 				expr: &labeledExpr{
-					pos:   position{line: 412, col: 5, offset: 12120},
+					pos:   position{line: 412, col: 5, offset: 11850},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 412, col: 10, offset: 12125},
+						pos:  position{line: 412, col: 10, offset: 11855},
 						name: "SearchBoolean",
 					},
 				},
@@ -3026,27 +3026,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 416, col: 1, offset: 12225},
+			pos:  position{line: 416, col: 1, offset: 11949},
 			expr: &choiceExpr{
-				pos: position{line: 417, col: 5, offset: 12238},
+				pos: position{line: 417, col: 5, offset: 11962},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 417, col: 5, offset: 12238},
+						pos: position{line: 417, col: 5, offset: 11962},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 417, col: 5, offset: 12238},
+							pos: position{line: 417, col: 5, offset: 11962},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 417, col: 5, offset: 12238},
+									pos:        position{line: 417, col: 5, offset: 11962},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 417, col: 13, offset: 12246},
+									pos:  position{line: 417, col: 13, offset: 11970},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 417, col: 15, offset: 12248},
+									pos:        position{line: 417, col: 15, offset: 11972},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -3054,10 +3054,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 420, col: 5, offset: 12339},
+						pos: position{line: 420, col: 5, offset: 12059},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 420, col: 5, offset: 12339},
+							pos:        position{line: 420, col: 5, offset: 12059},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -3067,27 +3067,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 424, col: 1, offset: 12431},
+			pos:  position{line: 424, col: 1, offset: 12147},
 			expr: &actionExpr{
-				pos: position{line: 425, col: 5, offset: 12443},
+				pos: position{line: 425, col: 5, offset: 12159},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 425, col: 5, offset: 12443},
+					pos: position{line: 425, col: 5, offset: 12159},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 425, col: 5, offset: 12443},
+							pos:        position{line: 425, col: 5, offset: 12159},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 425, col: 12, offset: 12450},
+							pos:  position{line: 425, col: 12, offset: 12166},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 425, col: 14, offset: 12452},
-							label: "columns",
+							pos:   position{line: 425, col: 14, offset: 12168},
+							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 425, col: 22, offset: 12460},
+								pos:  position{line: 425, col: 19, offset: 12173},
 								name: "FlexAssignments",
 							},
 						},
@@ -3097,59 +3097,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 429, col: 1, offset: 12563},
+			pos:  position{line: 429, col: 1, offset: 12266},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 12578},
+				pos: position{line: 430, col: 5, offset: 12281},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 12578},
+					pos: position{line: 430, col: 5, offset: 12281},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 430, col: 5, offset: 12578},
+							pos:        position{line: 430, col: 5, offset: 12281},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 430, col: 15, offset: 12588},
+							pos:  position{line: 430, col: 15, offset: 12291},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 17, offset: 12590},
+							pos:   position{line: 430, col: 17, offset: 12293},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 23, offset: 12596},
+								pos:  position{line: 430, col: 23, offset: 12299},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 34, offset: 12607},
+							pos:   position{line: 430, col: 34, offset: 12310},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 430, col: 39, offset: 12612},
+								pos: position{line: 430, col: 39, offset: 12315},
 								expr: &actionExpr{
-									pos: position{line: 430, col: 40, offset: 12613},
+									pos: position{line: 430, col: 40, offset: 12316},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 430, col: 40, offset: 12613},
+										pos: position{line: 430, col: 40, offset: 12316},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 430, col: 40, offset: 12613},
+												pos:  position{line: 430, col: 40, offset: 12316},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 430, col: 43, offset: 12616},
+												pos:        position{line: 430, col: 43, offset: 12319},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 430, col: 47, offset: 12620},
+												pos:  position{line: 430, col: 47, offset: 12323},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 430, col: 50, offset: 12623},
+												pos:   position{line: 430, col: 50, offset: 12326},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 430, col: 53, offset: 12626},
+													pos:  position{line: 430, col: 53, offset: 12329},
 													name: "Assignment",
 												},
 											},
@@ -3164,29 +3164,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 438, col: 1, offset: 13037},
+			pos:  position{line: 438, col: 1, offset: 12734},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 13050},
+				pos: position{line: 439, col: 5, offset: 12747},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 13050},
+					pos: position{line: 439, col: 5, offset: 12747},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 439, col: 5, offset: 13050},
+							pos:        position{line: 439, col: 5, offset: 12747},
 							val:        "fuse",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 439, col: 13, offset: 13058},
+							pos: position{line: 439, col: 13, offset: 12755},
 							expr: &seqExpr{
-								pos: position{line: 439, col: 15, offset: 13060},
+								pos: position{line: 439, col: 15, offset: 12757},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 439, col: 15, offset: 13060},
+										pos:  position{line: 439, col: 15, offset: 12757},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 439, col: 18, offset: 13063},
+										pos:        position{line: 439, col: 18, offset: 12760},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -3199,12 +3199,12 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeProc",
-			pos:  position{line: 443, col: 1, offset: 13136},
+			pos:  position{line: 443, col: 1, offset: 12829},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 5, offset: 13150},
+				pos: position{line: 444, col: 5, offset: 12843},
 				run: (*parser).callonShapeProc1,
 				expr: &litMatcher{
-					pos:        position{line: 444, col: 5, offset: 13150},
+					pos:        position{line: 444, col: 5, offset: 12843},
 					val:        "shape",
 					ignoreCase: true,
 				},
@@ -3212,76 +3212,76 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 448, col: 1, offset: 13228},
+			pos:  position{line: 448, col: 1, offset: 12917},
 			expr: &choiceExpr{
-				pos: position{line: 449, col: 5, offset: 13241},
+				pos: position{line: 449, col: 5, offset: 12930},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 449, col: 5, offset: 13241},
+						pos: position{line: 449, col: 5, offset: 12930},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 449, col: 5, offset: 13241},
+							pos: position{line: 449, col: 5, offset: 12930},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 449, col: 5, offset: 13241},
+									pos:   position{line: 449, col: 5, offset: 12930},
 									label: "kind",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 10, offset: 13246},
+										pos:  position{line: 449, col: 10, offset: 12935},
 										name: "JoinKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 449, col: 19, offset: 13255},
+									pos:        position{line: 449, col: 19, offset: 12944},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 27, offset: 13263},
+									pos:  position{line: 449, col: 27, offset: 12952},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 29, offset: 13265},
+									pos:   position{line: 449, col: 29, offset: 12954},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 37, offset: 13273},
+										pos:  position{line: 449, col: 37, offset: 12962},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 45, offset: 13281},
+									pos:  position{line: 449, col: 45, offset: 12970},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 449, col: 48, offset: 13284},
+									pos:        position{line: 449, col: 48, offset: 12973},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 52, offset: 13288},
+									pos:  position{line: 449, col: 52, offset: 12977},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 55, offset: 13291},
+									pos:   position{line: 449, col: 55, offset: 12980},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 64, offset: 13300},
+										pos:  position{line: 449, col: 64, offset: 12989},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 72, offset: 13308},
+									pos:   position{line: 449, col: 72, offset: 12997},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 449, col: 80, offset: 13316},
+										pos: position{line: 449, col: 80, offset: 13005},
 										expr: &seqExpr{
-											pos: position{line: 449, col: 81, offset: 13317},
+											pos: position{line: 449, col: 81, offset: 13006},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 449, col: 81, offset: 13317},
+													pos:  position{line: 449, col: 81, offset: 13006},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 449, col: 83, offset: 13319},
+													pos:  position{line: 449, col: 83, offset: 13008},
 													name: "FlexAssignments",
 												},
 											},
@@ -3292,50 +3292,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 456, col: 5, offset: 13591},
+						pos: position{line: 456, col: 5, offset: 13270},
 						run: (*parser).callonJoinProc20,
 						expr: &seqExpr{
-							pos: position{line: 456, col: 5, offset: 13591},
+							pos: position{line: 456, col: 5, offset: 13270},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 456, col: 5, offset: 13591},
+									pos:   position{line: 456, col: 5, offset: 13270},
 									label: "kind",
 									expr: &ruleRefExpr{
-										pos:  position{line: 456, col: 10, offset: 13596},
+										pos:  position{line: 456, col: 10, offset: 13275},
 										name: "JoinKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 456, col: 20, offset: 13606},
+									pos:        position{line: 456, col: 20, offset: 13285},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 456, col: 28, offset: 13614},
+									pos:  position{line: 456, col: 28, offset: 13293},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 456, col: 30, offset: 13616},
+									pos:   position{line: 456, col: 30, offset: 13295},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 456, col: 34, offset: 13620},
+										pos:  position{line: 456, col: 34, offset: 13299},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 456, col: 42, offset: 13628},
+									pos:   position{line: 456, col: 42, offset: 13307},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 456, col: 50, offset: 13636},
+										pos: position{line: 456, col: 50, offset: 13315},
 										expr: &seqExpr{
-											pos: position{line: 456, col: 51, offset: 13637},
+											pos: position{line: 456, col: 51, offset: 13316},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 456, col: 51, offset: 13637},
+													pos:  position{line: 456, col: 51, offset: 13316},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 456, col: 53, offset: 13639},
+													pos:  position{line: 456, col: 53, offset: 13318},
 													name: "FlexAssignments",
 												},
 											},
@@ -3350,69 +3350,69 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKind",
-			pos:  position{line: 464, col: 1, offset: 13899},
+			pos:  position{line: 464, col: 1, offset: 13568},
 			expr: &choiceExpr{
-				pos: position{line: 465, col: 5, offset: 13912},
+				pos: position{line: 465, col: 5, offset: 13581},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 465, col: 5, offset: 13912},
+						pos: position{line: 465, col: 5, offset: 13581},
 						run: (*parser).callonJoinKind2,
 						expr: &seqExpr{
-							pos: position{line: 465, col: 5, offset: 13912},
+							pos: position{line: 465, col: 5, offset: 13581},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 465, col: 5, offset: 13912},
+									pos:        position{line: 465, col: 5, offset: 13581},
 									val:        "inner",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 465, col: 14, offset: 13921},
+									pos:  position{line: 465, col: 14, offset: 13590},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 466, col: 5, offset: 13951},
+						pos: position{line: 466, col: 5, offset: 13620},
 						run: (*parser).callonJoinKind6,
 						expr: &seqExpr{
-							pos: position{line: 466, col: 5, offset: 13951},
+							pos: position{line: 466, col: 5, offset: 13620},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 466, col: 5, offset: 13951},
+									pos:        position{line: 466, col: 5, offset: 13620},
 									val:        "left",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 466, col: 14, offset: 13960},
+									pos:  position{line: 466, col: 14, offset: 13629},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 467, col: 5, offset: 13989},
+						pos: position{line: 467, col: 5, offset: 13658},
 						run: (*parser).callonJoinKind10,
 						expr: &seqExpr{
-							pos: position{line: 467, col: 5, offset: 13989},
+							pos: position{line: 467, col: 5, offset: 13658},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 467, col: 5, offset: 13989},
+									pos:        position{line: 467, col: 5, offset: 13658},
 									val:        "right",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 467, col: 14, offset: 13998},
+									pos:  position{line: 467, col: 14, offset: 13667},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 468, col: 5, offset: 14028},
+						pos: position{line: 468, col: 5, offset: 13697},
 						run: (*parser).callonJoinKind14,
 						expr: &litMatcher{
-							pos:        position{line: 468, col: 5, offset: 14028},
+							pos:        position{line: 468, col: 5, offset: 13697},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3422,35 +3422,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 470, col: 1, offset: 14064},
+			pos:  position{line: 470, col: 1, offset: 13733},
 			expr: &choiceExpr{
-				pos: position{line: 471, col: 5, offset: 14076},
+				pos: position{line: 471, col: 5, offset: 13745},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 471, col: 5, offset: 14076},
+						pos:  position{line: 471, col: 5, offset: 13745},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 14085},
+						pos: position{line: 472, col: 5, offset: 13754},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 472, col: 5, offset: 14085},
+							pos: position{line: 472, col: 5, offset: 13754},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 472, col: 5, offset: 14085},
+									pos:        position{line: 472, col: 5, offset: 13754},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 472, col: 9, offset: 14089},
+									pos:   position{line: 472, col: 9, offset: 13758},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 472, col: 14, offset: 14094},
+										pos:  position{line: 472, col: 14, offset: 13763},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 472, col: 19, offset: 14099},
+									pos:        position{line: 472, col: 19, offset: 13768},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3462,23 +3462,23 @@ var g = &grammar{
 		},
 		{
 			name: "TasteProc",
-			pos:  position{line: 474, col: 1, offset: 14125},
+			pos:  position{line: 474, col: 1, offset: 13794},
 			expr: &actionExpr{
-				pos: position{line: 475, col: 5, offset: 14139},
+				pos: position{line: 475, col: 5, offset: 13808},
 				run: (*parser).callonTasteProc1,
 				expr: &seqExpr{
-					pos: position{line: 475, col: 5, offset: 14139},
+					pos: position{line: 475, col: 5, offset: 13808},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 475, col: 5, offset: 14139},
+							pos:        position{line: 475, col: 5, offset: 13808},
 							val:        "taste",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 475, col: 14, offset: 14148},
+							pos:   position{line: 475, col: 14, offset: 13817},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 475, col: 16, offset: 14150},
+								pos:  position{line: 475, col: 16, offset: 13819},
 								name: "TasteExpr",
 							},
 						},
@@ -3488,25 +3488,25 @@ var g = &grammar{
 		},
 		{
 			name: "TasteExpr",
-			pos:  position{line: 512, col: 1, offset: 15480},
+			pos:  position{line: 512, col: 1, offset: 15089},
 			expr: &choiceExpr{
-				pos: position{line: 513, col: 5, offset: 15494},
+				pos: position{line: 513, col: 5, offset: 15103},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 15494},
+						pos: position{line: 513, col: 5, offset: 15103},
 						run: (*parser).callonTasteExpr2,
 						expr: &seqExpr{
-							pos: position{line: 513, col: 5, offset: 15494},
+							pos: position{line: 513, col: 5, offset: 15103},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 513, col: 5, offset: 15494},
+									pos:  position{line: 513, col: 5, offset: 15103},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 513, col: 7, offset: 15496},
+									pos:   position{line: 513, col: 7, offset: 15105},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 513, col: 12, offset: 15501},
+										pos:  position{line: 513, col: 12, offset: 15110},
 										name: "Lval",
 									},
 								},
@@ -3514,10 +3514,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 15530},
+						pos: position{line: 514, col: 5, offset: 15139},
 						run: (*parser).callonTasteExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 514, col: 5, offset: 15530},
+							pos:        position{line: 514, col: 5, offset: 15139},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3527,60 +3527,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 516, col: 1, offset: 15592},
+			pos:  position{line: 516, col: 1, offset: 15195},
 			expr: &ruleRefExpr{
-				pos:  position{line: 516, col: 8, offset: 15599},
+				pos:  position{line: 516, col: 8, offset: 15202},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 518, col: 1, offset: 15610},
+			pos:  position{line: 518, col: 1, offset: 15213},
 			expr: &ruleRefExpr{
-				pos:  position{line: 518, col: 13, offset: 15622},
+				pos:  position{line: 518, col: 13, offset: 15225},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 520, col: 1, offset: 15628},
+			pos:  position{line: 520, col: 1, offset: 15231},
 			expr: &actionExpr{
-				pos: position{line: 521, col: 5, offset: 15643},
+				pos: position{line: 521, col: 5, offset: 15246},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 521, col: 5, offset: 15643},
+					pos: position{line: 521, col: 5, offset: 15246},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 521, col: 5, offset: 15643},
+							pos:   position{line: 521, col: 5, offset: 15246},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 521, col: 11, offset: 15649},
+								pos:  position{line: 521, col: 11, offset: 15252},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 521, col: 21, offset: 15659},
+							pos:   position{line: 521, col: 21, offset: 15262},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 521, col: 26, offset: 15664},
+								pos: position{line: 521, col: 26, offset: 15267},
 								expr: &seqExpr{
-									pos: position{line: 521, col: 27, offset: 15665},
+									pos: position{line: 521, col: 27, offset: 15268},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 521, col: 27, offset: 15665},
+											pos:  position{line: 521, col: 27, offset: 15268},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 521, col: 30, offset: 15668},
+											pos:        position{line: 521, col: 30, offset: 15271},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 521, col: 34, offset: 15672},
+											pos:  position{line: 521, col: 34, offset: 15275},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 521, col: 37, offset: 15675},
+											pos:  position{line: 521, col: 37, offset: 15278},
 											name: "FieldExpr",
 										},
 									},
@@ -3593,44 +3593,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 531, col: 1, offset: 15874},
+			pos:  position{line: 531, col: 1, offset: 15477},
 			expr: &actionExpr{
-				pos: position{line: 532, col: 5, offset: 15884},
+				pos: position{line: 532, col: 5, offset: 15487},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 532, col: 5, offset: 15884},
+					pos: position{line: 532, col: 5, offset: 15487},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 532, col: 5, offset: 15884},
+							pos:   position{line: 532, col: 5, offset: 15487},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 532, col: 11, offset: 15890},
+								pos:  position{line: 532, col: 11, offset: 15493},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 532, col: 16, offset: 15895},
+							pos:   position{line: 532, col: 16, offset: 15498},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 532, col: 21, offset: 15900},
+								pos: position{line: 532, col: 21, offset: 15503},
 								expr: &seqExpr{
-									pos: position{line: 532, col: 22, offset: 15901},
+									pos: position{line: 532, col: 22, offset: 15504},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 532, col: 22, offset: 15901},
+											pos:  position{line: 532, col: 22, offset: 15504},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 532, col: 25, offset: 15904},
+											pos:        position{line: 532, col: 25, offset: 15507},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 532, col: 29, offset: 15908},
+											pos:  position{line: 532, col: 29, offset: 15511},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 532, col: 32, offset: 15911},
+											pos:  position{line: 532, col: 32, offset: 15514},
 											name: "Expr",
 										},
 									},
@@ -3643,39 +3643,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 542, col: 1, offset: 16105},
+			pos:  position{line: 542, col: 1, offset: 15708},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 5, offset: 16120},
+				pos: position{line: 543, col: 5, offset: 15723},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 5, offset: 16120},
+					pos: position{line: 543, col: 5, offset: 15723},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 543, col: 5, offset: 16120},
+							pos:   position{line: 543, col: 5, offset: 15723},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 9, offset: 16124},
+								pos:  position{line: 543, col: 9, offset: 15727},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 14, offset: 16129},
+							pos:  position{line: 543, col: 14, offset: 15732},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 543, col: 17, offset: 16132},
+							pos:        position{line: 543, col: 17, offset: 15735},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 21, offset: 16136},
+							pos:  position{line: 543, col: 21, offset: 15739},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 24, offset: 16139},
+							pos:   position{line: 543, col: 24, offset: 15742},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 28, offset: 16143},
+								pos:  position{line: 543, col: 28, offset: 15746},
 								name: "Expr",
 							},
 						},
@@ -3685,71 +3685,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 545, col: 1, offset: 16232},
+			pos:  position{line: 545, col: 1, offset: 15835},
 			expr: &ruleRefExpr{
-				pos:  position{line: 545, col: 8, offset: 16239},
+				pos:  position{line: 545, col: 8, offset: 15842},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 547, col: 1, offset: 16256},
+			pos:  position{line: 547, col: 1, offset: 15859},
 			expr: &choiceExpr{
-				pos: position{line: 548, col: 5, offset: 16276},
+				pos: position{line: 548, col: 5, offset: 15879},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 16276},
+						pos: position{line: 548, col: 5, offset: 15879},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 16276},
+							pos: position{line: 548, col: 5, offset: 15879},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 548, col: 5, offset: 16276},
+									pos:   position{line: 548, col: 5, offset: 15879},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 15, offset: 16286},
+										pos:  position{line: 548, col: 15, offset: 15889},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 29, offset: 16300},
+									pos:  position{line: 548, col: 29, offset: 15903},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 548, col: 32, offset: 16303},
+									pos:        position{line: 548, col: 32, offset: 15906},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 36, offset: 16307},
+									pos:  position{line: 548, col: 36, offset: 15910},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 548, col: 39, offset: 16310},
+									pos:   position{line: 548, col: 39, offset: 15913},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 50, offset: 16321},
+										pos:  position{line: 548, col: 50, offset: 15924},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 55, offset: 16326},
+									pos:  position{line: 548, col: 55, offset: 15929},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 548, col: 58, offset: 16329},
+									pos:        position{line: 548, col: 58, offset: 15932},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 62, offset: 16333},
+									pos:  position{line: 548, col: 62, offset: 15936},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 548, col: 65, offset: 16336},
+									pos:   position{line: 548, col: 65, offset: 15939},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 76, offset: 16347},
+										pos:  position{line: 548, col: 76, offset: 15950},
 										name: "Expr",
 									},
 								},
@@ -3757,7 +3757,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 551, col: 5, offset: 16494},
+						pos:  position{line: 551, col: 5, offset: 16088},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -3765,53 +3765,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 553, col: 1, offset: 16509},
+			pos:  position{line: 553, col: 1, offset: 16103},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 5, offset: 16527},
+				pos: position{line: 554, col: 5, offset: 16121},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 5, offset: 16527},
+					pos: position{line: 554, col: 5, offset: 16121},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 554, col: 5, offset: 16527},
+							pos:   position{line: 554, col: 5, offset: 16121},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 554, col: 11, offset: 16533},
+								pos:  position{line: 554, col: 11, offset: 16127},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 5, offset: 16552},
+							pos:   position{line: 555, col: 5, offset: 16146},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 555, col: 10, offset: 16557},
+								pos: position{line: 555, col: 10, offset: 16151},
 								expr: &actionExpr{
-									pos: position{line: 555, col: 11, offset: 16558},
+									pos: position{line: 555, col: 11, offset: 16152},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 555, col: 11, offset: 16558},
+										pos: position{line: 555, col: 11, offset: 16152},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 555, col: 11, offset: 16558},
+												pos:  position{line: 555, col: 11, offset: 16152},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 555, col: 14, offset: 16561},
+												pos:   position{line: 555, col: 14, offset: 16155},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 555, col: 17, offset: 16564},
+													pos:  position{line: 555, col: 17, offset: 16158},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 555, col: 25, offset: 16572},
+												pos:  position{line: 555, col: 25, offset: 16166},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 555, col: 28, offset: 16575},
+												pos:   position{line: 555, col: 28, offset: 16169},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 555, col: 33, offset: 16580},
+													pos:  position{line: 555, col: 33, offset: 16174},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -3826,53 +3826,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 559, col: 1, offset: 16698},
+			pos:  position{line: 559, col: 1, offset: 16292},
 			expr: &actionExpr{
-				pos: position{line: 560, col: 5, offset: 16717},
+				pos: position{line: 560, col: 5, offset: 16311},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 560, col: 5, offset: 16717},
+					pos: position{line: 560, col: 5, offset: 16311},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 560, col: 5, offset: 16717},
+							pos:   position{line: 560, col: 5, offset: 16311},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 560, col: 11, offset: 16723},
+								pos:  position{line: 560, col: 11, offset: 16317},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 561, col: 5, offset: 16747},
+							pos:   position{line: 561, col: 5, offset: 16341},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 561, col: 10, offset: 16752},
+								pos: position{line: 561, col: 10, offset: 16346},
 								expr: &actionExpr{
-									pos: position{line: 561, col: 11, offset: 16753},
+									pos: position{line: 561, col: 11, offset: 16347},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 561, col: 11, offset: 16753},
+										pos: position{line: 561, col: 11, offset: 16347},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 561, col: 11, offset: 16753},
+												pos:  position{line: 561, col: 11, offset: 16347},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 561, col: 14, offset: 16756},
+												pos:   position{line: 561, col: 14, offset: 16350},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 561, col: 17, offset: 16759},
+													pos:  position{line: 561, col: 17, offset: 16353},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 561, col: 26, offset: 16768},
+												pos:  position{line: 561, col: 26, offset: 16362},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 561, col: 29, offset: 16771},
+												pos:   position{line: 561, col: 29, offset: 16365},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 561, col: 34, offset: 16776},
+													pos:  position{line: 561, col: 34, offset: 16370},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -3887,53 +3887,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 565, col: 1, offset: 16899},
+			pos:  position{line: 565, col: 1, offset: 16493},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 5, offset: 16923},
+				pos: position{line: 566, col: 5, offset: 16517},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 5, offset: 16923},
+					pos: position{line: 566, col: 5, offset: 16517},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 566, col: 5, offset: 16923},
+							pos:   position{line: 566, col: 5, offset: 16517},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 11, offset: 16929},
+								pos:  position{line: 566, col: 11, offset: 16523},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 567, col: 5, offset: 16946},
+							pos:   position{line: 567, col: 5, offset: 16540},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 567, col: 10, offset: 16951},
+								pos: position{line: 567, col: 10, offset: 16545},
 								expr: &actionExpr{
-									pos: position{line: 567, col: 11, offset: 16952},
+									pos: position{line: 567, col: 11, offset: 16546},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 567, col: 11, offset: 16952},
+										pos: position{line: 567, col: 11, offset: 16546},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 567, col: 11, offset: 16952},
+												pos:  position{line: 567, col: 11, offset: 16546},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 567, col: 14, offset: 16955},
+												pos:   position{line: 567, col: 14, offset: 16549},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 567, col: 19, offset: 16960},
+													pos:  position{line: 567, col: 19, offset: 16554},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 567, col: 38, offset: 16979},
+												pos:  position{line: 567, col: 38, offset: 16573},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 567, col: 41, offset: 16982},
+												pos:   position{line: 567, col: 41, offset: 16576},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 567, col: 46, offset: 16987},
+													pos:  position{line: 567, col: 46, offset: 16581},
 													name: "RelativeExpr",
 												},
 											},
@@ -3948,20 +3948,20 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 571, col: 1, offset: 17105},
+			pos:  position{line: 571, col: 1, offset: 16699},
 			expr: &actionExpr{
-				pos: position{line: 572, col: 5, offset: 17126},
+				pos: position{line: 572, col: 5, offset: 16720},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 572, col: 6, offset: 17127},
+					pos: position{line: 572, col: 6, offset: 16721},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 572, col: 6, offset: 17127},
+							pos:        position{line: 572, col: 6, offset: 16721},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 572, col: 12, offset: 17133},
+							pos:        position{line: 572, col: 12, offset: 16727},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3971,19 +3971,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 574, col: 1, offset: 17171},
+			pos:  position{line: 574, col: 1, offset: 16765},
 			expr: &choiceExpr{
-				pos: position{line: 575, col: 5, offset: 17194},
+				pos: position{line: 575, col: 5, offset: 16788},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 575, col: 5, offset: 17194},
+						pos:  position{line: 575, col: 5, offset: 16788},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 576, col: 5, offset: 17215},
+						pos: position{line: 576, col: 5, offset: 16809},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 576, col: 5, offset: 17215},
+							pos:        position{line: 576, col: 5, offset: 16809},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3993,53 +3993,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 578, col: 1, offset: 17252},
+			pos:  position{line: 578, col: 1, offset: 16846},
 			expr: &actionExpr{
-				pos: position{line: 579, col: 5, offset: 17269},
+				pos: position{line: 579, col: 5, offset: 16863},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 579, col: 5, offset: 17269},
+					pos: position{line: 579, col: 5, offset: 16863},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 579, col: 5, offset: 17269},
+							pos:   position{line: 579, col: 5, offset: 16863},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 579, col: 11, offset: 17275},
+								pos:  position{line: 579, col: 11, offset: 16869},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 580, col: 5, offset: 17292},
+							pos:   position{line: 580, col: 5, offset: 16886},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 580, col: 10, offset: 17297},
+								pos: position{line: 580, col: 10, offset: 16891},
 								expr: &actionExpr{
-									pos: position{line: 580, col: 11, offset: 17298},
+									pos: position{line: 580, col: 11, offset: 16892},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 580, col: 11, offset: 17298},
+										pos: position{line: 580, col: 11, offset: 16892},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 580, col: 11, offset: 17298},
+												pos:  position{line: 580, col: 11, offset: 16892},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 580, col: 14, offset: 17301},
+												pos:   position{line: 580, col: 14, offset: 16895},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 580, col: 17, offset: 17304},
+													pos:  position{line: 580, col: 17, offset: 16898},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 580, col: 34, offset: 17321},
+												pos:  position{line: 580, col: 34, offset: 16915},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 580, col: 37, offset: 17324},
+												pos:   position{line: 580, col: 37, offset: 16918},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 580, col: 42, offset: 17329},
+													pos:  position{line: 580, col: 42, offset: 16923},
 													name: "AdditiveExpr",
 												},
 											},
@@ -4054,30 +4054,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 584, col: 1, offset: 17445},
+			pos:  position{line: 584, col: 1, offset: 17039},
 			expr: &actionExpr{
-				pos: position{line: 584, col: 20, offset: 17464},
+				pos: position{line: 584, col: 20, offset: 17058},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 584, col: 21, offset: 17465},
+					pos: position{line: 584, col: 21, offset: 17059},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 584, col: 21, offset: 17465},
+							pos:        position{line: 584, col: 21, offset: 17059},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 584, col: 28, offset: 17472},
+							pos:        position{line: 584, col: 28, offset: 17066},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 584, col: 34, offset: 17478},
+							pos:        position{line: 584, col: 34, offset: 17072},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 584, col: 41, offset: 17485},
+							pos:        position{line: 584, col: 41, offset: 17079},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -4087,53 +4087,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 586, col: 1, offset: 17522},
+			pos:  position{line: 586, col: 1, offset: 17116},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 5, offset: 17539},
+				pos: position{line: 587, col: 5, offset: 17133},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 5, offset: 17539},
+					pos: position{line: 587, col: 5, offset: 17133},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 587, col: 5, offset: 17539},
+							pos:   position{line: 587, col: 5, offset: 17133},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 11, offset: 17545},
+								pos:  position{line: 587, col: 11, offset: 17139},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 588, col: 5, offset: 17568},
+							pos:   position{line: 588, col: 5, offset: 17162},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 588, col: 10, offset: 17573},
+								pos: position{line: 588, col: 10, offset: 17167},
 								expr: &actionExpr{
-									pos: position{line: 588, col: 11, offset: 17574},
+									pos: position{line: 588, col: 11, offset: 17168},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 588, col: 11, offset: 17574},
+										pos: position{line: 588, col: 11, offset: 17168},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 588, col: 11, offset: 17574},
+												pos:  position{line: 588, col: 11, offset: 17168},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 588, col: 14, offset: 17577},
+												pos:   position{line: 588, col: 14, offset: 17171},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 588, col: 17, offset: 17580},
+													pos:  position{line: 588, col: 17, offset: 17174},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 588, col: 34, offset: 17597},
+												pos:  position{line: 588, col: 34, offset: 17191},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 588, col: 37, offset: 17600},
+												pos:   position{line: 588, col: 37, offset: 17194},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 588, col: 42, offset: 17605},
+													pos:  position{line: 588, col: 42, offset: 17199},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -4148,20 +4148,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 592, col: 1, offset: 17727},
+			pos:  position{line: 592, col: 1, offset: 17321},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 20, offset: 17746},
+				pos: position{line: 592, col: 20, offset: 17340},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 592, col: 21, offset: 17747},
+					pos: position{line: 592, col: 21, offset: 17341},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 592, col: 21, offset: 17747},
+							pos:        position{line: 592, col: 21, offset: 17341},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 27, offset: 17753},
+							pos:        position{line: 592, col: 27, offset: 17347},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -4171,53 +4171,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 594, col: 1, offset: 17790},
+			pos:  position{line: 594, col: 1, offset: 17384},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 17813},
+				pos: position{line: 595, col: 5, offset: 17407},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 17813},
+					pos: position{line: 595, col: 5, offset: 17407},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 595, col: 5, offset: 17813},
+							pos:   position{line: 595, col: 5, offset: 17407},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 11, offset: 17819},
+								pos:  position{line: 595, col: 11, offset: 17413},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 596, col: 5, offset: 17831},
+							pos:   position{line: 596, col: 5, offset: 17425},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 596, col: 10, offset: 17836},
+								pos: position{line: 596, col: 10, offset: 17430},
 								expr: &actionExpr{
-									pos: position{line: 596, col: 11, offset: 17837},
+									pos: position{line: 596, col: 11, offset: 17431},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 596, col: 11, offset: 17837},
+										pos: position{line: 596, col: 11, offset: 17431},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 596, col: 11, offset: 17837},
+												pos:  position{line: 596, col: 11, offset: 17431},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 596, col: 14, offset: 17840},
+												pos:   position{line: 596, col: 14, offset: 17434},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 596, col: 17, offset: 17843},
+													pos:  position{line: 596, col: 17, offset: 17437},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 596, col: 40, offset: 17866},
+												pos:  position{line: 596, col: 40, offset: 17460},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 596, col: 43, offset: 17869},
+												pos:   position{line: 596, col: 43, offset: 17463},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 596, col: 48, offset: 17874},
+													pos:  position{line: 596, col: 48, offset: 17468},
 													name: "NotExpr",
 												},
 											},
@@ -4232,20 +4232,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 600, col: 1, offset: 17985},
+			pos:  position{line: 600, col: 1, offset: 17579},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 26, offset: 18010},
+				pos: position{line: 600, col: 26, offset: 17604},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 600, col: 27, offset: 18011},
+					pos: position{line: 600, col: 27, offset: 17605},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 600, col: 27, offset: 18011},
+							pos:        position{line: 600, col: 27, offset: 17605},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 600, col: 33, offset: 18017},
+							pos:        position{line: 600, col: 33, offset: 17611},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4255,30 +4255,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 602, col: 1, offset: 18054},
+			pos:  position{line: 602, col: 1, offset: 17648},
 			expr: &choiceExpr{
-				pos: position{line: 603, col: 5, offset: 18066},
+				pos: position{line: 603, col: 5, offset: 17660},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 603, col: 5, offset: 18066},
+						pos: position{line: 603, col: 5, offset: 17660},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 603, col: 5, offset: 18066},
+							pos: position{line: 603, col: 5, offset: 17660},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 603, col: 5, offset: 18066},
+									pos:        position{line: 603, col: 5, offset: 17660},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 603, col: 9, offset: 18070},
+									pos:  position{line: 603, col: 9, offset: 17664},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 603, col: 12, offset: 18073},
+									pos:   position{line: 603, col: 12, offset: 17667},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 603, col: 14, offset: 18075},
+										pos:  position{line: 603, col: 14, offset: 17669},
 										name: "NotExpr",
 									},
 								},
@@ -4286,7 +4286,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 606, col: 5, offset: 18188},
+						pos:  position{line: 606, col: 5, offset: 17778},
 						name: "CastExpr",
 					},
 				},
@@ -4294,42 +4294,42 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 608, col: 1, offset: 18198},
+			pos:  position{line: 608, col: 1, offset: 17788},
 			expr: &choiceExpr{
-				pos: position{line: 609, col: 5, offset: 18211},
+				pos: position{line: 609, col: 5, offset: 17801},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 609, col: 5, offset: 18211},
+						pos: position{line: 609, col: 5, offset: 17801},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 609, col: 5, offset: 18211},
+							pos: position{line: 609, col: 5, offset: 17801},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 609, col: 5, offset: 18211},
+									pos:   position{line: 609, col: 5, offset: 17801},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 7, offset: 18213},
+										pos:  position{line: 609, col: 7, offset: 17803},
 										name: "FuncExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 609, col: 16, offset: 18222},
+									pos:  position{line: 609, col: 16, offset: 17812},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 609, col: 19, offset: 18225},
+									pos:        position{line: 609, col: 19, offset: 17815},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 609, col: 23, offset: 18229},
+									pos:  position{line: 609, col: 23, offset: 17819},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 609, col: 26, offset: 18232},
+									pos:   position{line: 609, col: 26, offset: 17822},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 30, offset: 18236},
+										pos:  position{line: 609, col: 30, offset: 17826},
 										name: "CastType",
 									},
 								},
@@ -4337,7 +4337,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 612, col: 5, offset: 18340},
+						pos:  position{line: 612, col: 5, offset: 17926},
 						name: "FuncExpr",
 					},
 				},
@@ -4345,43 +4345,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 614, col: 1, offset: 18350},
+			pos:  position{line: 614, col: 1, offset: 17936},
 			expr: &choiceExpr{
-				pos: position{line: 615, col: 5, offset: 18363},
+				pos: position{line: 615, col: 5, offset: 17949},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 615, col: 5, offset: 18363},
+						pos:  position{line: 615, col: 5, offset: 17949},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 616, col: 5, offset: 18378},
+						pos:  position{line: 616, col: 5, offset: 17964},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 617, col: 5, offset: 18392},
+						pos:  position{line: 617, col: 5, offset: 17978},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 618, col: 5, offset: 18408},
+						pos: position{line: 618, col: 5, offset: 17994},
 						run: (*parser).callonFuncExpr5,
 						expr: &seqExpr{
-							pos: position{line: 618, col: 5, offset: 18408},
+							pos: position{line: 618, col: 5, offset: 17994},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 618, col: 5, offset: 18408},
+									pos:   position{line: 618, col: 5, offset: 17994},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 618, col: 11, offset: 18414},
+										pos:  position{line: 618, col: 11, offset: 18000},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 618, col: 20, offset: 18423},
+									pos:   position{line: 618, col: 20, offset: 18009},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 618, col: 25, offset: 18428},
+										pos: position{line: 618, col: 25, offset: 18014},
 										expr: &ruleRefExpr{
-											pos:  position{line: 618, col: 26, offset: 18429},
+											pos:  position{line: 618, col: 26, offset: 18015},
 											name: "Deref",
 										},
 									},
@@ -4390,11 +4390,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 621, col: 5, offset: 18500},
+						pos:  position{line: 621, col: 5, offset: 18086},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 622, col: 5, offset: 18514},
+						pos:  position{line: 622, col: 5, offset: 18100},
 						name: "Primary",
 					},
 				},
@@ -4402,20 +4402,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 624, col: 1, offset: 18523},
+			pos:  position{line: 624, col: 1, offset: 18109},
 			expr: &seqExpr{
-				pos: position{line: 624, col: 13, offset: 18535},
+				pos: position{line: 624, col: 13, offset: 18121},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 13, offset: 18535},
+						pos:  position{line: 624, col: 13, offset: 18121},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 22, offset: 18544},
+						pos:  position{line: 624, col: 22, offset: 18130},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 624, col: 25, offset: 18547},
+						pos:        position{line: 624, col: 25, offset: 18133},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -4424,27 +4424,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 626, col: 1, offset: 18552},
+			pos:  position{line: 626, col: 1, offset: 18138},
 			expr: &choiceExpr{
-				pos: position{line: 627, col: 5, offset: 18565},
+				pos: position{line: 627, col: 5, offset: 18151},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 627, col: 5, offset: 18565},
+						pos:        position{line: 627, col: 5, offset: 18151},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 628, col: 5, offset: 18575},
+						pos:        position{line: 628, col: 5, offset: 18161},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 629, col: 5, offset: 18587},
+						pos:        position{line: 629, col: 5, offset: 18173},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 630, col: 5, offset: 18600},
+						pos:        position{line: 630, col: 5, offset: 18186},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -4453,37 +4453,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 632, col: 1, offset: 18608},
+			pos:  position{line: 632, col: 1, offset: 18194},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 18622},
+				pos: position{line: 633, col: 5, offset: 18208},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 18622},
+					pos: position{line: 633, col: 5, offset: 18208},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 633, col: 5, offset: 18622},
+							pos:        position{line: 633, col: 5, offset: 18208},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 633, col: 13, offset: 18630},
+							pos:  position{line: 633, col: 13, offset: 18216},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 633, col: 16, offset: 18633},
+							pos:        position{line: 633, col: 16, offset: 18219},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 633, col: 20, offset: 18637},
+							pos:   position{line: 633, col: 20, offset: 18223},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 25, offset: 18642},
+								pos:  position{line: 633, col: 25, offset: 18228},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 633, col: 39, offset: 18656},
+							pos:        position{line: 633, col: 39, offset: 18242},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4493,53 +4493,53 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 635, col: 1, offset: 18682},
+			pos:  position{line: 635, col: 1, offset: 18268},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 5, offset: 18697},
+				pos: position{line: 636, col: 5, offset: 18283},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 636, col: 5, offset: 18697},
+					pos: position{line: 636, col: 5, offset: 18283},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 636, col: 5, offset: 18697},
+							pos:        position{line: 636, col: 5, offset: 18283},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 14, offset: 18706},
+							pos:  position{line: 636, col: 14, offset: 18292},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 17, offset: 18709},
+							pos:        position{line: 636, col: 17, offset: 18295},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 21, offset: 18713},
+							pos:  position{line: 636, col: 21, offset: 18299},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 24, offset: 18716},
+							pos:   position{line: 636, col: 24, offset: 18302},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 29, offset: 18721},
+								pos:  position{line: 636, col: 29, offset: 18307},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 42, offset: 18734},
+							pos:  position{line: 636, col: 42, offset: 18320},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 45, offset: 18737},
+							pos:        position{line: 636, col: 45, offset: 18323},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 49, offset: 18741},
+							pos:   position{line: 636, col: 49, offset: 18327},
 							label: "methods",
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 57, offset: 18749},
+								pos:  position{line: 636, col: 57, offset: 18335},
 								name: "Methods",
 							},
 						},
@@ -4549,30 +4549,30 @@ var g = &grammar{
 		},
 		{
 			name: "Methods",
-			pos:  position{line: 644, col: 1, offset: 19145},
+			pos:  position{line: 644, col: 1, offset: 18731},
 			expr: &choiceExpr{
-				pos: position{line: 645, col: 5, offset: 19157},
+				pos: position{line: 645, col: 5, offset: 18743},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 645, col: 5, offset: 19157},
+						pos: position{line: 645, col: 5, offset: 18743},
 						run: (*parser).callonMethods2,
 						expr: &labeledExpr{
-							pos:   position{line: 645, col: 5, offset: 19157},
+							pos:   position{line: 645, col: 5, offset: 18743},
 							label: "methods",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 645, col: 13, offset: 19165},
+								pos: position{line: 645, col: 13, offset: 18751},
 								expr: &ruleRefExpr{
-									pos:  position{line: 645, col: 13, offset: 19165},
+									pos:  position{line: 645, col: 13, offset: 18751},
 									name: "Method",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 646, col: 5, offset: 19201},
+						pos: position{line: 646, col: 5, offset: 18787},
 						run: (*parser).callonMethods6,
 						expr: &litMatcher{
-							pos:        position{line: 646, col: 5, offset: 19201},
+							pos:        position{line: 646, col: 5, offset: 18787},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4582,31 +4582,31 @@ var g = &grammar{
 		},
 		{
 			name: "Method",
-			pos:  position{line: 648, col: 1, offset: 19225},
+			pos:  position{line: 648, col: 1, offset: 18811},
 			expr: &actionExpr{
-				pos: position{line: 649, col: 5, offset: 19236},
+				pos: position{line: 649, col: 5, offset: 18822},
 				run: (*parser).callonMethod1,
 				expr: &seqExpr{
-					pos: position{line: 649, col: 5, offset: 19236},
+					pos: position{line: 649, col: 5, offset: 18822},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 5, offset: 19236},
+							pos:  position{line: 649, col: 5, offset: 18822},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 649, col: 8, offset: 19239},
+							pos:        position{line: 649, col: 8, offset: 18825},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 12, offset: 19243},
+							pos:  position{line: 649, col: 12, offset: 18829},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 15, offset: 19246},
+							pos:   position{line: 649, col: 15, offset: 18832},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 17, offset: 19248},
+								pos:  position{line: 649, col: 17, offset: 18834},
 								name: "Function",
 							},
 						},
@@ -4616,55 +4616,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 651, col: 1, offset: 19276},
+			pos:  position{line: 651, col: 1, offset: 18862},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 19289},
+				pos: position{line: 652, col: 5, offset: 18875},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 19289},
+					pos: position{line: 652, col: 5, offset: 18875},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 652, col: 5, offset: 19289},
+							pos: position{line: 652, col: 5, offset: 18875},
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 6, offset: 19290},
+								pos:  position{line: 652, col: 6, offset: 18876},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 16, offset: 19300},
+							pos:   position{line: 652, col: 16, offset: 18886},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 19, offset: 19303},
+								pos:  position{line: 652, col: 19, offset: 18889},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 34, offset: 19318},
+							pos:  position{line: 652, col: 34, offset: 18904},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 652, col: 37, offset: 19321},
+							pos:        position{line: 652, col: 37, offset: 18907},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 41, offset: 19325},
+							pos:  position{line: 652, col: 41, offset: 18911},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 44, offset: 19328},
+							pos:   position{line: 652, col: 44, offset: 18914},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 49, offset: 19333},
+								pos:  position{line: 652, col: 49, offset: 18919},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 62, offset: 19346},
+							pos:  position{line: 652, col: 62, offset: 18932},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 652, col: 65, offset: 19349},
+							pos:        position{line: 652, col: 65, offset: 18935},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4674,53 +4674,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 656, col: 1, offset: 19455},
+			pos:  position{line: 656, col: 1, offset: 19029},
 			expr: &choiceExpr{
-				pos: position{line: 657, col: 5, offset: 19472},
+				pos: position{line: 657, col: 5, offset: 19046},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 657, col: 5, offset: 19472},
+						pos: position{line: 657, col: 5, offset: 19046},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 657, col: 5, offset: 19472},
+							pos: position{line: 657, col: 5, offset: 19046},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 657, col: 5, offset: 19472},
+									pos:   position{line: 657, col: 5, offset: 19046},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 657, col: 11, offset: 19478},
+										pos:  position{line: 657, col: 11, offset: 19052},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 657, col: 16, offset: 19483},
+									pos:   position{line: 657, col: 16, offset: 19057},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 657, col: 21, offset: 19488},
+										pos: position{line: 657, col: 21, offset: 19062},
 										expr: &actionExpr{
-											pos: position{line: 657, col: 22, offset: 19489},
+											pos: position{line: 657, col: 22, offset: 19063},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 657, col: 22, offset: 19489},
+												pos: position{line: 657, col: 22, offset: 19063},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 657, col: 22, offset: 19489},
+														pos:  position{line: 657, col: 22, offset: 19063},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 657, col: 25, offset: 19492},
+														pos:        position{line: 657, col: 25, offset: 19066},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 657, col: 29, offset: 19496},
+														pos:  position{line: 657, col: 29, offset: 19070},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 657, col: 32, offset: 19499},
+														pos:   position{line: 657, col: 32, offset: 19073},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 657, col: 34, offset: 19501},
+															pos:  position{line: 657, col: 34, offset: 19075},
 															name: "Expr",
 														},
 													},
@@ -4733,10 +4733,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 19613},
+						pos: position{line: 660, col: 5, offset: 19187},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 660, col: 5, offset: 19613},
+							pos:  position{line: 660, col: 5, offset: 19187},
 							name: "__",
 						},
 					},
@@ -4745,31 +4745,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 662, col: 1, offset: 19649},
+			pos:  position{line: 662, col: 1, offset: 19223},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 19663},
+				pos: position{line: 663, col: 5, offset: 19237},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 19663},
+						pos: position{line: 663, col: 5, offset: 19237},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 19663},
+							pos: position{line: 663, col: 5, offset: 19237},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 663, col: 5, offset: 19663},
+									pos:   position{line: 663, col: 5, offset: 19237},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 663, col: 11, offset: 19669},
+										pos:  position{line: 663, col: 11, offset: 19243},
 										name: "DotId",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 17, offset: 19675},
+									pos:   position{line: 663, col: 17, offset: 19249},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 663, col: 22, offset: 19680},
+										pos: position{line: 663, col: 22, offset: 19254},
 										expr: &ruleRefExpr{
-											pos:  position{line: 663, col: 23, offset: 19681},
+											pos:  position{line: 663, col: 23, offset: 19255},
 											name: "Deref",
 										},
 									},
@@ -4778,26 +4778,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 666, col: 5, offset: 19752},
+						pos: position{line: 666, col: 5, offset: 19326},
 						run: (*parser).callonDerefExpr9,
 						expr: &seqExpr{
-							pos: position{line: 666, col: 5, offset: 19752},
+							pos: position{line: 666, col: 5, offset: 19326},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 666, col: 5, offset: 19752},
+									pos:   position{line: 666, col: 5, offset: 19326},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 666, col: 11, offset: 19758},
+										pos:  position{line: 666, col: 11, offset: 19332},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 666, col: 22, offset: 19769},
+									pos:   position{line: 666, col: 22, offset: 19343},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 666, col: 27, offset: 19774},
+										pos: position{line: 666, col: 27, offset: 19348},
 										expr: &ruleRefExpr{
-											pos:  position{line: 666, col: 28, offset: 19775},
+											pos:  position{line: 666, col: 28, offset: 19349},
 											name: "Deref",
 										},
 									},
@@ -4806,10 +4806,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 669, col: 5, offset: 19846},
+						pos: position{line: 669, col: 5, offset: 19420},
 						run: (*parser).callonDerefExpr16,
 						expr: &litMatcher{
-							pos:        position{line: 669, col: 5, offset: 19846},
+							pos:        position{line: 669, col: 5, offset: 19420},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -4819,26 +4819,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotId",
-			pos:  position{line: 673, col: 1, offset: 19919},
+			pos:  position{line: 673, col: 1, offset: 19487},
 			expr: &choiceExpr{
-				pos: position{line: 674, col: 5, offset: 19929},
+				pos: position{line: 674, col: 5, offset: 19497},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 19929},
+						pos: position{line: 674, col: 5, offset: 19497},
 						run: (*parser).callonDotId2,
 						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 19929},
+							pos: position{line: 674, col: 5, offset: 19497},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 674, col: 5, offset: 19929},
+									pos:        position{line: 674, col: 5, offset: 19497},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 674, col: 9, offset: 19933},
+									pos:   position{line: 674, col: 9, offset: 19501},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 674, col: 15, offset: 19939},
+										pos:  position{line: 674, col: 15, offset: 19507},
 										name: "Identifier",
 									},
 								},
@@ -4846,31 +4846,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 20163},
+						pos: position{line: 683, col: 5, offset: 19721},
 						run: (*parser).callonDotId7,
 						expr: &seqExpr{
-							pos: position{line: 683, col: 5, offset: 20163},
+							pos: position{line: 683, col: 5, offset: 19721},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 683, col: 5, offset: 20163},
+									pos:        position{line: 683, col: 5, offset: 19721},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 683, col: 9, offset: 20167},
+									pos:        position{line: 683, col: 9, offset: 19725},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 683, col: 13, offset: 20171},
+									pos:   position{line: 683, col: 13, offset: 19729},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 683, col: 18, offset: 20176},
+										pos:  position{line: 683, col: 18, offset: 19734},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 683, col: 23, offset: 20181},
+									pos:        position{line: 683, col: 23, offset: 19739},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4882,52 +4882,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 693, col: 1, offset: 20394},
+			pos:  position{line: 693, col: 1, offset: 19942},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20404},
+				pos: position{line: 694, col: 5, offset: 19952},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 20404},
+						pos: position{line: 694, col: 5, offset: 19952},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 694, col: 5, offset: 20404},
+							pos: position{line: 694, col: 5, offset: 19952},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 694, col: 5, offset: 20404},
+									pos:        position{line: 694, col: 5, offset: 19952},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 9, offset: 20408},
+									pos:   position{line: 694, col: 9, offset: 19956},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 14, offset: 20413},
+										pos:  position{line: 694, col: 14, offset: 19961},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 694, col: 27, offset: 20426},
+									pos:  position{line: 694, col: 27, offset: 19974},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 694, col: 30, offset: 20429},
+									pos:        position{line: 694, col: 30, offset: 19977},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 694, col: 34, offset: 20433},
+									pos:  position{line: 694, col: 34, offset: 19981},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 37, offset: 20436},
+									pos:   position{line: 694, col: 37, offset: 19984},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 40, offset: 20439},
+										pos:  position{line: 694, col: 40, offset: 19987},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 694, col: 53, offset: 20452},
+									pos:        position{line: 694, col: 53, offset: 20000},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4935,39 +4935,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20627},
+						pos: position{line: 700, col: 5, offset: 20171},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 700, col: 5, offset: 20627},
+							pos: position{line: 700, col: 5, offset: 20171},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 700, col: 5, offset: 20627},
+									pos:        position{line: 700, col: 5, offset: 20171},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 9, offset: 20631},
+									pos:  position{line: 700, col: 9, offset: 20175},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 12, offset: 20634},
+									pos:        position{line: 700, col: 12, offset: 20178},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 16, offset: 20638},
+									pos:  position{line: 700, col: 16, offset: 20182},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 19, offset: 20641},
+									pos:   position{line: 700, col: 19, offset: 20185},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 22, offset: 20644},
+										pos:  position{line: 700, col: 22, offset: 20188},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 35, offset: 20657},
+									pos:        position{line: 700, col: 35, offset: 20201},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4975,39 +4975,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20832},
+						pos: position{line: 706, col: 5, offset: 20372},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 706, col: 5, offset: 20832},
+							pos: position{line: 706, col: 5, offset: 20372},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 706, col: 5, offset: 20832},
+									pos:        position{line: 706, col: 5, offset: 20372},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 706, col: 9, offset: 20836},
+									pos:   position{line: 706, col: 9, offset: 20376},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 14, offset: 20841},
+										pos:  position{line: 706, col: 14, offset: 20381},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 27, offset: 20854},
+									pos:  position{line: 706, col: 27, offset: 20394},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 30, offset: 20857},
+									pos:        position{line: 706, col: 30, offset: 20397},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 34, offset: 20861},
+									pos:  position{line: 706, col: 34, offset: 20401},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 37, offset: 20864},
+									pos:        position{line: 706, col: 37, offset: 20404},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5015,26 +5015,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 21041},
+						pos: position{line: 712, col: 5, offset: 20577},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 21041},
+							pos: position{line: 712, col: 5, offset: 20577},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 712, col: 5, offset: 21041},
+									pos:        position{line: 712, col: 5, offset: 20577},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 9, offset: 21045},
+									pos:   position{line: 712, col: 9, offset: 20581},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 712, col: 14, offset: 21050},
+										pos:  position{line: 712, col: 14, offset: 20586},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 19, offset: 21055},
+									pos:        position{line: 712, col: 19, offset: 20591},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5042,29 +5042,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 21104},
+						pos: position{line: 713, col: 5, offset: 20640},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 713, col: 5, offset: 21104},
+							pos: position{line: 713, col: 5, offset: 20640},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 713, col: 5, offset: 21104},
+									pos:        position{line: 713, col: 5, offset: 20640},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 713, col: 9, offset: 21108},
+									pos: position{line: 713, col: 9, offset: 20644},
 									expr: &litMatcher{
-										pos:        position{line: 713, col: 11, offset: 21110},
+										pos:        position{line: 713, col: 11, offset: 20646},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 713, col: 16, offset: 21115},
+									pos:   position{line: 713, col: 16, offset: 20651},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 713, col: 19, offset: 21118},
+										pos:  position{line: 713, col: 19, offset: 20654},
 										name: "Identifier",
 									},
 								},
@@ -5076,43 +5076,43 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 715, col: 1, offset: 21169},
+			pos:  position{line: 715, col: 1, offset: 20705},
 			expr: &choiceExpr{
-				pos: position{line: 716, col: 5, offset: 21181},
+				pos: position{line: 716, col: 5, offset: 20717},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 716, col: 5, offset: 21181},
+						pos:  position{line: 716, col: 5, offset: 20717},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 717, col: 5, offset: 21193},
+						pos: position{line: 717, col: 5, offset: 20729},
 						run: (*parser).callonPrimary3,
 						expr: &seqExpr{
-							pos: position{line: 717, col: 5, offset: 21193},
+							pos: position{line: 717, col: 5, offset: 20729},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 717, col: 5, offset: 21193},
+									pos:        position{line: 717, col: 5, offset: 20729},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 9, offset: 21197},
+									pos:  position{line: 717, col: 9, offset: 20733},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 717, col: 12, offset: 21200},
+									pos:   position{line: 717, col: 12, offset: 20736},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 717, col: 17, offset: 21205},
+										pos:  position{line: 717, col: 17, offset: 20741},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 22, offset: 21210},
+									pos:  position{line: 717, col: 22, offset: 20746},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 717, col: 25, offset: 21213},
+									pos:        position{line: 717, col: 25, offset: 20749},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5124,44 +5124,44 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 719, col: 1, offset: 21239},
+			pos:  position{line: 719, col: 1, offset: 20775},
 			expr: &choiceExpr{
-				pos: position{line: 720, col: 5, offset: 21251},
+				pos: position{line: 720, col: 5, offset: 20787},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 720, col: 5, offset: 21251},
+						pos:  position{line: 720, col: 5, offset: 20787},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 5, offset: 21267},
+						pos:  position{line: 721, col: 5, offset: 20803},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 722, col: 5, offset: 21285},
+						pos:  position{line: 722, col: 5, offset: 20821},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 723, col: 5, offset: 21303},
+						pos:  position{line: 723, col: 5, offset: 20839},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 724, col: 5, offset: 21321},
+						pos:  position{line: 724, col: 5, offset: 20857},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 725, col: 5, offset: 21340},
+						pos:  position{line: 725, col: 5, offset: 20876},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 726, col: 5, offset: 21357},
+						pos:  position{line: 726, col: 5, offset: 20893},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 727, col: 5, offset: 21376},
+						pos:  position{line: 727, col: 5, offset: 20912},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 728, col: 5, offset: 21395},
+						pos:  position{line: 728, col: 5, offset: 20931},
 						name: "NullLiteral",
 					},
 				},
@@ -5169,15 +5169,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 730, col: 1, offset: 21408},
+			pos:  position{line: 730, col: 1, offset: 20944},
 			expr: &actionExpr{
-				pos: position{line: 731, col: 5, offset: 21426},
+				pos: position{line: 731, col: 5, offset: 20962},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 731, col: 5, offset: 21426},
+					pos:   position{line: 731, col: 5, offset: 20962},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 731, col: 7, offset: 21428},
+						pos:  position{line: 731, col: 7, offset: 20964},
 						name: "QuotedString",
 					},
 				},
@@ -5185,25 +5185,25 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpLiteral",
-			pos:  position{line: 735, col: 1, offset: 21538},
+			pos:  position{line: 735, col: 1, offset: 21074},
 			expr: &actionExpr{
-				pos: position{line: 736, col: 5, offset: 21556},
+				pos: position{line: 736, col: 5, offset: 21092},
 				run: (*parser).callonRegexpLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 736, col: 5, offset: 21556},
+					pos: position{line: 736, col: 5, offset: 21092},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 736, col: 5, offset: 21556},
+							pos:   position{line: 736, col: 5, offset: 21092},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 736, col: 7, offset: 21558},
+								pos:  position{line: 736, col: 7, offset: 21094},
 								name: "Regexp",
 							},
 						},
 						&notExpr{
-							pos: position{line: 736, col: 14, offset: 21565},
+							pos: position{line: 736, col: 14, offset: 21101},
 							expr: &ruleRefExpr{
-								pos:  position{line: 736, col: 15, offset: 21566},
+								pos:  position{line: 736, col: 15, offset: 21102},
 								name: "KeyWordStart",
 							},
 						},
@@ -5213,28 +5213,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 740, col: 1, offset: 21676},
+			pos:  position{line: 740, col: 1, offset: 21212},
 			expr: &choiceExpr{
-				pos: position{line: 741, col: 5, offset: 21694},
+				pos: position{line: 741, col: 5, offset: 21230},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 741, col: 5, offset: 21694},
+						pos: position{line: 741, col: 5, offset: 21230},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 741, col: 5, offset: 21694},
+							pos: position{line: 741, col: 5, offset: 21230},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 741, col: 5, offset: 21694},
+									pos:   position{line: 741, col: 5, offset: 21230},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 741, col: 7, offset: 21696},
+										pos:  position{line: 741, col: 7, offset: 21232},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 741, col: 14, offset: 21703},
+									pos: position{line: 741, col: 14, offset: 21239},
 									expr: &ruleRefExpr{
-										pos:  position{line: 741, col: 15, offset: 21704},
+										pos:  position{line: 741, col: 15, offset: 21240},
 										name: "IdentifierRest",
 									},
 								},
@@ -5242,13 +5242,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 21816},
+						pos: position{line: 744, col: 5, offset: 21352},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 744, col: 5, offset: 21816},
+							pos:   position{line: 744, col: 5, offset: 21352},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 7, offset: 21818},
+								pos:  position{line: 744, col: 7, offset: 21354},
 								name: "IP4Net",
 							},
 						},
@@ -5258,28 +5258,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 748, col: 1, offset: 21919},
+			pos:  position{line: 748, col: 1, offset: 21455},
 			expr: &choiceExpr{
-				pos: position{line: 749, col: 5, offset: 21938},
+				pos: position{line: 749, col: 5, offset: 21474},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 749, col: 5, offset: 21938},
+						pos: position{line: 749, col: 5, offset: 21474},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 749, col: 5, offset: 21938},
+							pos: position{line: 749, col: 5, offset: 21474},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 749, col: 5, offset: 21938},
+									pos:   position{line: 749, col: 5, offset: 21474},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 7, offset: 21940},
+										pos:  position{line: 749, col: 7, offset: 21476},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 749, col: 11, offset: 21944},
+									pos: position{line: 749, col: 11, offset: 21480},
 									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 12, offset: 21945},
+										pos:  position{line: 749, col: 12, offset: 21481},
 										name: "IdentifierRest",
 									},
 								},
@@ -5287,13 +5287,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 22056},
+						pos: position{line: 752, col: 5, offset: 21592},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 752, col: 5, offset: 22056},
+							pos:   position{line: 752, col: 5, offset: 21592},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 7, offset: 22058},
+								pos:  position{line: 752, col: 7, offset: 21594},
 								name: "IP",
 							},
 						},
@@ -5303,15 +5303,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 756, col: 1, offset: 22154},
+			pos:  position{line: 756, col: 1, offset: 21690},
 			expr: &actionExpr{
-				pos: position{line: 757, col: 5, offset: 22171},
+				pos: position{line: 757, col: 5, offset: 21707},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 757, col: 5, offset: 22171},
+					pos:   position{line: 757, col: 5, offset: 21707},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 757, col: 7, offset: 22173},
+						pos:  position{line: 757, col: 7, offset: 21709},
 						name: "FloatString",
 					},
 				},
@@ -5319,15 +5319,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 761, col: 1, offset: 22283},
+			pos:  position{line: 761, col: 1, offset: 21819},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 5, offset: 22302},
+				pos: position{line: 762, col: 5, offset: 21838},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 762, col: 5, offset: 22302},
+					pos:   position{line: 762, col: 5, offset: 21838},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 762, col: 7, offset: 22304},
+						pos:  position{line: 762, col: 7, offset: 21840},
 						name: "IntString",
 					},
 				},
@@ -5335,24 +5335,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 766, col: 1, offset: 22410},
+			pos:  position{line: 766, col: 1, offset: 21946},
 			expr: &choiceExpr{
-				pos: position{line: 767, col: 5, offset: 22429},
+				pos: position{line: 767, col: 5, offset: 21965},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 767, col: 5, offset: 22429},
+						pos: position{line: 767, col: 5, offset: 21965},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 767, col: 5, offset: 22429},
+							pos:        position{line: 767, col: 5, offset: 21965},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 768, col: 5, offset: 22539},
+						pos: position{line: 768, col: 5, offset: 22075},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 768, col: 5, offset: 22539},
+							pos:        position{line: 768, col: 5, offset: 22075},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -5362,12 +5362,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 770, col: 1, offset: 22647},
+			pos:  position{line: 770, col: 1, offset: 22183},
 			expr: &actionExpr{
-				pos: position{line: 771, col: 5, offset: 22663},
+				pos: position{line: 771, col: 5, offset: 22199},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 771, col: 5, offset: 22663},
+					pos:        position{line: 771, col: 5, offset: 22199},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -5375,15 +5375,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 773, col: 1, offset: 22766},
+			pos:  position{line: 773, col: 1, offset: 22302},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 5, offset: 22782},
+				pos: position{line: 774, col: 5, offset: 22318},
 				run: (*parser).callonTypeLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 774, col: 5, offset: 22782},
+					pos:   position{line: 774, col: 5, offset: 22318},
 					label: "typ",
 					expr: &ruleRefExpr{
-						pos:  position{line: 774, col: 9, offset: 22786},
+						pos:  position{line: 774, col: 9, offset: 22322},
 						name: "TypeExternal",
 					},
 				},
@@ -5391,16 +5391,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 778, col: 1, offset: 22880},
+			pos:  position{line: 778, col: 1, offset: 22418},
 			expr: &choiceExpr{
-				pos: position{line: 779, col: 5, offset: 22893},
+				pos: position{line: 779, col: 5, offset: 22431},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 779, col: 5, offset: 22893},
+						pos:  position{line: 779, col: 5, offset: 22431},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 780, col: 5, offset: 22910},
+						pos:  position{line: 780, col: 5, offset: 22448},
 						name: "PrimitiveType",
 					},
 				},
@@ -5408,48 +5408,48 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 782, col: 1, offset: 22925},
+			pos:  position{line: 782, col: 1, offset: 22463},
 			expr: &choiceExpr{
-				pos: position{line: 783, col: 5, offset: 22942},
+				pos: position{line: 783, col: 5, offset: 22480},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 783, col: 5, offset: 22942},
+						pos: position{line: 783, col: 5, offset: 22480},
 						run: (*parser).callonTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 783, col: 5, offset: 22942},
+							pos: position{line: 783, col: 5, offset: 22480},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 783, col: 5, offset: 22942},
+									pos:        position{line: 783, col: 5, offset: 22480},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 12, offset: 22949},
+									pos:  position{line: 783, col: 12, offset: 22487},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 783, col: 15, offset: 22952},
+									pos:        position{line: 783, col: 15, offset: 22490},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 19, offset: 22956},
+									pos:  position{line: 783, col: 19, offset: 22494},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 783, col: 22, offset: 22959},
+									pos:   position{line: 783, col: 22, offset: 22497},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 783, col: 26, offset: 22963},
+										pos:  position{line: 783, col: 26, offset: 22501},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 31, offset: 22968},
+									pos:  position{line: 783, col: 31, offset: 22506},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 783, col: 34, offset: 22971},
+									pos:        position{line: 783, col: 34, offset: 22509},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5457,43 +5457,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 22998},
+						pos: position{line: 784, col: 5, offset: 22536},
 						run: (*parser).callonTypeExternal12,
 						expr: &seqExpr{
-							pos: position{line: 784, col: 5, offset: 22998},
+							pos: position{line: 784, col: 5, offset: 22536},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 784, col: 5, offset: 22998},
+									pos:        position{line: 784, col: 5, offset: 22536},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 12, offset: 23005},
+									pos:  position{line: 784, col: 12, offset: 22543},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 15, offset: 23008},
+									pos:        position{line: 784, col: 15, offset: 22546},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 19, offset: 23012},
+									pos:  position{line: 784, col: 19, offset: 22550},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 784, col: 22, offset: 23015},
+									pos:   position{line: 784, col: 22, offset: 22553},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 784, col: 26, offset: 23019},
+										pos:  position{line: 784, col: 26, offset: 22557},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 36, offset: 23029},
+									pos:  position{line: 784, col: 36, offset: 22567},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 39, offset: 23032},
+									pos:        position{line: 784, col: 39, offset: 22570},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5501,27 +5501,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 785, col: 5, offset: 23060},
+						pos:  position{line: 785, col: 5, offset: 22598},
 						name: "ComplexType",
 					},
 					&actionExpr{
-						pos: position{line: 786, col: 5, offset: 23076},
+						pos: position{line: 786, col: 5, offset: 22614},
 						run: (*parser).callonTypeExternal23,
 						expr: &seqExpr{
-							pos: position{line: 786, col: 5, offset: 23076},
+							pos: position{line: 786, col: 5, offset: 22614},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 786, col: 5, offset: 23076},
+									pos:   position{line: 786, col: 5, offset: 22614},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 786, col: 9, offset: 23080},
+										pos:  position{line: 786, col: 9, offset: 22618},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 786, col: 31, offset: 23102},
+									pos: position{line: 786, col: 31, offset: 22640},
 									expr: &ruleRefExpr{
-										pos:  position{line: 786, col: 32, offset: 23103},
+										pos:  position{line: 786, col: 32, offset: 22641},
 										name: "IdentifierRest",
 									},
 								},
@@ -5533,16 +5533,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 788, col: 1, offset: 23139},
+			pos:  position{line: 788, col: 1, offset: 22677},
 			expr: &choiceExpr{
-				pos: position{line: 789, col: 5, offset: 23148},
+				pos: position{line: 789, col: 5, offset: 22686},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 789, col: 5, offset: 23148},
+						pos:  position{line: 789, col: 5, offset: 22686},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 790, col: 5, offset: 23166},
+						pos:  position{line: 790, col: 5, offset: 22704},
 						name: "ComplexType",
 					},
 				},
@@ -5550,77 +5550,77 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 792, col: 1, offset: 23179},
+			pos:  position{line: 792, col: 1, offset: 22717},
 			expr: &choiceExpr{
-				pos: position{line: 793, col: 5, offset: 23197},
+				pos: position{line: 793, col: 5, offset: 22735},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 793, col: 5, offset: 23197},
+						pos: position{line: 793, col: 5, offset: 22735},
 						run: (*parser).callonAmbiguousType2,
 						expr: &litMatcher{
-							pos:        position{line: 793, col: 5, offset: 23197},
+							pos:        position{line: 793, col: 5, offset: 22735},
 							val:        "null",
 							ignoreCase: false,
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 796, col: 5, offset: 23275},
+						pos:   position{line: 796, col: 5, offset: 22813},
 						label: "name",
 						expr: &ruleRefExpr{
-							pos:  position{line: 796, col: 10, offset: 23280},
+							pos:  position{line: 796, col: 10, offset: 22818},
 							name: "PrimitiveType",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 797, col: 5, offset: 23298},
+						pos: position{line: 797, col: 5, offset: 22836},
 						run: (*parser).callonAmbiguousType6,
 						expr: &seqExpr{
-							pos: position{line: 797, col: 5, offset: 23298},
+							pos: position{line: 797, col: 5, offset: 22836},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 797, col: 5, offset: 23298},
+									pos:   position{line: 797, col: 5, offset: 22836},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 797, col: 10, offset: 23303},
+										pos:  position{line: 797, col: 10, offset: 22841},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 25, offset: 23318},
+									pos:  position{line: 797, col: 25, offset: 22856},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 28, offset: 23321},
+									pos:        position{line: 797, col: 28, offset: 22859},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 32, offset: 23325},
+									pos:  position{line: 797, col: 32, offset: 22863},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 35, offset: 23328},
+									pos:        position{line: 797, col: 35, offset: 22866},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 39, offset: 23332},
+									pos:  position{line: 797, col: 39, offset: 22870},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 797, col: 42, offset: 23335},
+									pos:   position{line: 797, col: 42, offset: 22873},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 797, col: 46, offset: 23339},
+										pos:  position{line: 797, col: 46, offset: 22877},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 51, offset: 23344},
+									pos:  position{line: 797, col: 51, offset: 22882},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 54, offset: 23347},
+									pos:        position{line: 797, col: 54, offset: 22885},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5628,42 +5628,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 800, col: 5, offset: 23446},
+						pos: position{line: 800, col: 5, offset: 22984},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 800, col: 5, offset: 23446},
+							pos:   position{line: 800, col: 5, offset: 22984},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 800, col: 10, offset: 23451},
+								pos:  position{line: 800, col: 10, offset: 22989},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 803, col: 5, offset: 23551},
+						pos: position{line: 803, col: 5, offset: 23089},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 803, col: 5, offset: 23551},
+							pos: position{line: 803, col: 5, offset: 23089},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 803, col: 5, offset: 23551},
+									pos:        position{line: 803, col: 5, offset: 23089},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 803, col: 9, offset: 23555},
+									pos:  position{line: 803, col: 9, offset: 23093},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 803, col: 12, offset: 23558},
+									pos:   position{line: 803, col: 12, offset: 23096},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 803, col: 14, offset: 23560},
+										pos:  position{line: 803, col: 14, offset: 23098},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 803, col: 25, offset: 23571},
+									pos:        position{line: 803, col: 25, offset: 23109},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5675,15 +5675,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 805, col: 1, offset: 23594},
+			pos:  position{line: 805, col: 1, offset: 23132},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 23608},
+				pos: position{line: 806, col: 5, offset: 23146},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 806, col: 5, offset: 23608},
+					pos:   position{line: 806, col: 5, offset: 23146},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 806, col: 11, offset: 23614},
+						pos:  position{line: 806, col: 11, offset: 23152},
 						name: "TypeList",
 					},
 				},
@@ -5691,28 +5691,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 810, col: 1, offset: 23708},
+			pos:  position{line: 810, col: 1, offset: 23246},
 			expr: &actionExpr{
-				pos: position{line: 811, col: 5, offset: 23721},
+				pos: position{line: 811, col: 5, offset: 23259},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 811, col: 5, offset: 23721},
+					pos: position{line: 811, col: 5, offset: 23259},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 811, col: 5, offset: 23721},
+							pos:   position{line: 811, col: 5, offset: 23259},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 811, col: 11, offset: 23727},
+								pos:  position{line: 811, col: 11, offset: 23265},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 811, col: 16, offset: 23732},
+							pos:   position{line: 811, col: 16, offset: 23270},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 811, col: 21, offset: 23737},
+								pos: position{line: 811, col: 21, offset: 23275},
 								expr: &ruleRefExpr{
-									pos:  position{line: 811, col: 21, offset: 23737},
+									pos:  position{line: 811, col: 21, offset: 23275},
 									name: "TypeListTail",
 								},
 							},
@@ -5723,31 +5723,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 815, col: 1, offset: 23831},
+			pos:  position{line: 815, col: 1, offset: 23369},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 16, offset: 23846},
+				pos: position{line: 815, col: 16, offset: 23384},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 16, offset: 23846},
+					pos: position{line: 815, col: 16, offset: 23384},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 16, offset: 23846},
+							pos:  position{line: 815, col: 16, offset: 23384},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 815, col: 19, offset: 23849},
+							pos:        position{line: 815, col: 19, offset: 23387},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 23, offset: 23853},
+							pos:  position{line: 815, col: 23, offset: 23391},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 26, offset: 23856},
+							pos:   position{line: 815, col: 26, offset: 23394},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 30, offset: 23860},
+								pos:  position{line: 815, col: 30, offset: 23398},
 								name: "Type",
 							},
 						},
@@ -5757,39 +5757,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 817, col: 1, offset: 23886},
+			pos:  position{line: 817, col: 1, offset: 23424},
 			expr: &choiceExpr{
-				pos: position{line: 818, col: 5, offset: 23902},
+				pos: position{line: 818, col: 5, offset: 23440},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 818, col: 5, offset: 23902},
+						pos: position{line: 818, col: 5, offset: 23440},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 818, col: 5, offset: 23902},
+							pos: position{line: 818, col: 5, offset: 23440},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 818, col: 5, offset: 23902},
+									pos:        position{line: 818, col: 5, offset: 23440},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 818, col: 9, offset: 23906},
+									pos:  position{line: 818, col: 9, offset: 23444},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 818, col: 12, offset: 23909},
+									pos:   position{line: 818, col: 12, offset: 23447},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 818, col: 19, offset: 23916},
+										pos:  position{line: 818, col: 19, offset: 23454},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 818, col: 33, offset: 23930},
+									pos:  position{line: 818, col: 33, offset: 23468},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 818, col: 36, offset: 23933},
+									pos:        position{line: 818, col: 36, offset: 23471},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5797,34 +5797,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 821, col: 5, offset: 24026},
+						pos: position{line: 821, col: 5, offset: 23564},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 821, col: 5, offset: 24026},
+							pos: position{line: 821, col: 5, offset: 23564},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 821, col: 5, offset: 24026},
+									pos:        position{line: 821, col: 5, offset: 23564},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 9, offset: 24030},
+									pos:  position{line: 821, col: 9, offset: 23568},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 821, col: 12, offset: 24033},
+									pos:   position{line: 821, col: 12, offset: 23571},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 821, col: 16, offset: 24037},
+										pos:  position{line: 821, col: 16, offset: 23575},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 21, offset: 24042},
+									pos:  position{line: 821, col: 21, offset: 23580},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 821, col: 24, offset: 24045},
+									pos:        position{line: 821, col: 24, offset: 23583},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5832,34 +5832,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 824, col: 5, offset: 24132},
+						pos: position{line: 824, col: 5, offset: 23670},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 824, col: 5, offset: 24132},
+							pos: position{line: 824, col: 5, offset: 23670},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 824, col: 5, offset: 24132},
+									pos:        position{line: 824, col: 5, offset: 23670},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 824, col: 10, offset: 24137},
+									pos:  position{line: 824, col: 10, offset: 23675},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 824, col: 13, offset: 24140},
+									pos:   position{line: 824, col: 13, offset: 23678},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 824, col: 17, offset: 24144},
+										pos:  position{line: 824, col: 17, offset: 23682},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 824, col: 22, offset: 24149},
+									pos:  position{line: 824, col: 22, offset: 23687},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 824, col: 25, offset: 24152},
+									pos:        position{line: 824, col: 25, offset: 23690},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -5867,55 +5867,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 827, col: 5, offset: 24238},
+						pos: position{line: 827, col: 5, offset: 23776},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 827, col: 5, offset: 24238},
+							pos: position{line: 827, col: 5, offset: 23776},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 827, col: 5, offset: 24238},
+									pos:        position{line: 827, col: 5, offset: 23776},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 10, offset: 24243},
+									pos:  position{line: 827, col: 10, offset: 23781},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 827, col: 13, offset: 24246},
+									pos:   position{line: 827, col: 13, offset: 23784},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 827, col: 21, offset: 24254},
+										pos:  position{line: 827, col: 21, offset: 23792},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 26, offset: 24259},
+									pos:  position{line: 827, col: 26, offset: 23797},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 827, col: 29, offset: 24262},
+									pos:        position{line: 827, col: 29, offset: 23800},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 33, offset: 24266},
+									pos:  position{line: 827, col: 33, offset: 23804},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 827, col: 36, offset: 24269},
+									pos:   position{line: 827, col: 36, offset: 23807},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 827, col: 44, offset: 24277},
+										pos:  position{line: 827, col: 44, offset: 23815},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 49, offset: 24282},
+									pos:  position{line: 827, col: 49, offset: 23820},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 827, col: 52, offset: 24285},
+									pos:        position{line: 827, col: 52, offset: 23823},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -5927,16 +5927,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 831, col: 1, offset: 24397},
+			pos:  position{line: 831, col: 1, offset: 23935},
 			expr: &choiceExpr{
-				pos: position{line: 832, col: 5, offset: 24415},
+				pos: position{line: 832, col: 5, offset: 23953},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 832, col: 5, offset: 24415},
+						pos:  position{line: 832, col: 5, offset: 23953},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 833, col: 5, offset: 24441},
+						pos:  position{line: 833, col: 5, offset: 23979},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -5944,65 +5944,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 839, col: 1, offset: 24700},
+			pos:  position{line: 839, col: 1, offset: 24238},
 			expr: &actionExpr{
-				pos: position{line: 840, col: 5, offset: 24726},
+				pos: position{line: 840, col: 5, offset: 24264},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 840, col: 9, offset: 24730},
+					pos: position{line: 840, col: 9, offset: 24268},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 840, col: 9, offset: 24730},
+							pos:        position{line: 840, col: 9, offset: 24268},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 19, offset: 24740},
+							pos:        position{line: 840, col: 19, offset: 24278},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 30, offset: 24751},
+							pos:        position{line: 840, col: 30, offset: 24289},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 41, offset: 24762},
+							pos:        position{line: 840, col: 41, offset: 24300},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 9, offset: 24779},
+							pos:        position{line: 841, col: 9, offset: 24317},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 18, offset: 24788},
+							pos:        position{line: 841, col: 18, offset: 24326},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 28, offset: 24798},
+							pos:        position{line: 841, col: 28, offset: 24336},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 38, offset: 24808},
+							pos:        position{line: 841, col: 38, offset: 24346},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 9, offset: 24824},
+							pos:        position{line: 842, col: 9, offset: 24362},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 843, col: 9, offset: 24842},
+							pos:        position{line: 843, col: 9, offset: 24380},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 843, col: 18, offset: 24851},
+							pos:        position{line: 843, col: 18, offset: 24389},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -6012,50 +6012,50 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 852, col: 1, offset: 25333},
+			pos:  position{line: 852, col: 1, offset: 24871},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 25359},
+				pos: position{line: 853, col: 5, offset: 24897},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 853, col: 9, offset: 25363},
+					pos: position{line: 853, col: 9, offset: 24901},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 853, col: 9, offset: 25363},
+							pos:        position{line: 853, col: 9, offset: 24901},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 853, col: 22, offset: 25376},
+							pos:        position{line: 853, col: 22, offset: 24914},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 854, col: 9, offset: 25391},
+							pos:        position{line: 854, col: 9, offset: 24929},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 855, col: 9, offset: 25407},
+							pos:        position{line: 855, col: 9, offset: 24945},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 9, offset: 25425},
+							pos:        position{line: 856, col: 9, offset: 24963},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 16, offset: 25432},
+							pos:        position{line: 856, col: 16, offset: 24970},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 857, col: 9, offset: 25446},
+							pos:        position{line: 857, col: 9, offset: 24984},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 857, col: 18, offset: 25455},
+							pos:        position{line: 857, col: 18, offset: 24993},
 							val:        "error",
 							ignoreCase: false,
 						},
@@ -6065,28 +6065,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 861, col: 1, offset: 25570},
+			pos:  position{line: 861, col: 1, offset: 25108},
 			expr: &actionExpr{
-				pos: position{line: 862, col: 5, offset: 25588},
+				pos: position{line: 862, col: 5, offset: 25126},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 862, col: 5, offset: 25588},
+					pos: position{line: 862, col: 5, offset: 25126},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 25588},
+							pos:   position{line: 862, col: 5, offset: 25126},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 11, offset: 25594},
+								pos:  position{line: 862, col: 11, offset: 25132},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 21, offset: 25604},
+							pos:   position{line: 862, col: 21, offset: 25142},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 862, col: 26, offset: 25609},
+								pos: position{line: 862, col: 26, offset: 25147},
 								expr: &ruleRefExpr{
-									pos:  position{line: 862, col: 26, offset: 25609},
+									pos:  position{line: 862, col: 26, offset: 25147},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -6097,31 +6097,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 866, col: 1, offset: 25708},
+			pos:  position{line: 866, col: 1, offset: 25246},
 			expr: &actionExpr{
-				pos: position{line: 866, col: 21, offset: 25728},
+				pos: position{line: 866, col: 21, offset: 25266},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 866, col: 21, offset: 25728},
+					pos: position{line: 866, col: 21, offset: 25266},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 21, offset: 25728},
+							pos:  position{line: 866, col: 21, offset: 25266},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 866, col: 24, offset: 25731},
+							pos:        position{line: 866, col: 24, offset: 25269},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 28, offset: 25735},
+							pos:  position{line: 866, col: 28, offset: 25273},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 866, col: 31, offset: 25738},
+							pos:   position{line: 866, col: 31, offset: 25276},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 35, offset: 25742},
+								pos:  position{line: 866, col: 35, offset: 25280},
 								name: "TypeField",
 							},
 						},
@@ -6131,39 +6131,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 868, col: 1, offset: 25773},
+			pos:  position{line: 868, col: 1, offset: 25311},
 			expr: &actionExpr{
-				pos: position{line: 869, col: 5, offset: 25787},
+				pos: position{line: 869, col: 5, offset: 25325},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 869, col: 5, offset: 25787},
+					pos: position{line: 869, col: 5, offset: 25325},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 869, col: 5, offset: 25787},
+							pos:   position{line: 869, col: 5, offset: 25325},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 869, col: 10, offset: 25792},
+								pos:  position{line: 869, col: 10, offset: 25330},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 25, offset: 25807},
+							pos:  position{line: 869, col: 25, offset: 25345},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 869, col: 28, offset: 25810},
+							pos:        position{line: 869, col: 28, offset: 25348},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 32, offset: 25814},
+							pos:  position{line: 869, col: 32, offset: 25352},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 869, col: 35, offset: 25817},
+							pos:   position{line: 869, col: 35, offset: 25355},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 869, col: 39, offset: 25821},
+								pos:  position{line: 869, col: 39, offset: 25359},
 								name: "Type",
 							},
 						},
@@ -6173,16 +6173,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 873, col: 1, offset: 25903},
+			pos:  position{line: 873, col: 1, offset: 25441},
 			expr: &choiceExpr{
-				pos: position{line: 874, col: 5, offset: 25921},
+				pos: position{line: 874, col: 5, offset: 25459},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 874, col: 5, offset: 25921},
+						pos:  position{line: 874, col: 5, offset: 25459},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 874, col: 24, offset: 25940},
+						pos:  position{line: 874, col: 24, offset: 25478},
 						name: "RelativeOperator",
 					},
 				},
@@ -6190,12 +6190,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 876, col: 1, offset: 25958},
+			pos:  position{line: 876, col: 1, offset: 25496},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 12, offset: 25969},
+				pos: position{line: 876, col: 12, offset: 25507},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 876, col: 12, offset: 25969},
+					pos:        position{line: 876, col: 12, offset: 25507},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -6203,12 +6203,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 878, col: 1, offset: 25999},
+			pos:  position{line: 878, col: 1, offset: 25537},
 			expr: &actionExpr{
-				pos: position{line: 878, col: 11, offset: 26009},
+				pos: position{line: 878, col: 11, offset: 25547},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 878, col: 11, offset: 26009},
+					pos:        position{line: 878, col: 11, offset: 25547},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -6216,12 +6216,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 880, col: 1, offset: 26037},
+			pos:  position{line: 880, col: 1, offset: 25575},
 			expr: &actionExpr{
-				pos: position{line: 880, col: 11, offset: 26047},
+				pos: position{line: 880, col: 11, offset: 25585},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 880, col: 11, offset: 26047},
+					pos:        position{line: 880, col: 11, offset: 25585},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -6229,12 +6229,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 882, col: 1, offset: 26075},
+			pos:  position{line: 882, col: 1, offset: 25613},
 			expr: &actionExpr{
-				pos: position{line: 882, col: 12, offset: 26086},
+				pos: position{line: 882, col: 12, offset: 25624},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 882, col: 12, offset: 26086},
+					pos:        position{line: 882, col: 12, offset: 25624},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -6242,12 +6242,12 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 884, col: 1, offset: 26116},
+			pos:  position{line: 884, col: 1, offset: 25654},
 			expr: &actionExpr{
-				pos: position{line: 884, col: 11, offset: 26126},
+				pos: position{line: 884, col: 11, offset: 25664},
 				run: (*parser).callonByToken1,
 				expr: &litMatcher{
-					pos:        position{line: 884, col: 11, offset: 26126},
+					pos:        position{line: 884, col: 11, offset: 25664},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -6255,9 +6255,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 886, col: 1, offset: 26154},
+			pos:  position{line: 886, col: 1, offset: 25692},
 			expr: &charClassMatcher{
-				pos:        position{line: 886, col: 19, offset: 26172},
+				pos:        position{line: 886, col: 19, offset: 25710},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -6267,16 +6267,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 888, col: 1, offset: 26184},
+			pos:  position{line: 888, col: 1, offset: 25722},
 			expr: &choiceExpr{
-				pos: position{line: 888, col: 18, offset: 26201},
+				pos: position{line: 888, col: 18, offset: 25739},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 888, col: 18, offset: 26201},
+						pos:  position{line: 888, col: 18, offset: 25739},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 888, col: 36, offset: 26219},
+						pos:        position{line: 888, col: 36, offset: 25757},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -6287,15 +6287,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 890, col: 1, offset: 26226},
+			pos:  position{line: 890, col: 1, offset: 25764},
 			expr: &actionExpr{
-				pos: position{line: 891, col: 5, offset: 26241},
+				pos: position{line: 891, col: 5, offset: 25779},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 891, col: 5, offset: 26241},
+					pos:   position{line: 891, col: 5, offset: 25779},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 891, col: 8, offset: 26244},
+						pos:  position{line: 891, col: 8, offset: 25782},
 						name: "IdentifierName",
 					},
 				},
@@ -6303,29 +6303,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 893, col: 1, offset: 26331},
+			pos:  position{line: 893, col: 1, offset: 25861},
 			expr: &choiceExpr{
-				pos: position{line: 894, col: 5, offset: 26350},
+				pos: position{line: 894, col: 5, offset: 25880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 894, col: 5, offset: 26350},
+						pos: position{line: 894, col: 5, offset: 25880},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 894, col: 5, offset: 26350},
+							pos: position{line: 894, col: 5, offset: 25880},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 894, col: 5, offset: 26350},
+									pos: position{line: 894, col: 5, offset: 25880},
 									expr: &seqExpr{
-										pos: position{line: 894, col: 7, offset: 26352},
+										pos: position{line: 894, col: 7, offset: 25882},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 894, col: 7, offset: 26352},
+												pos:  position{line: 894, col: 7, offset: 25882},
 												name: "IdGuard",
 											},
 											&notExpr{
-												pos: position{line: 894, col: 15, offset: 26360},
+												pos: position{line: 894, col: 15, offset: 25890},
 												expr: &ruleRefExpr{
-													pos:  position{line: 894, col: 16, offset: 26361},
+													pos:  position{line: 894, col: 16, offset: 25891},
 													name: "IdentifierRest",
 												},
 											},
@@ -6333,13 +6333,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 894, col: 32, offset: 26377},
+									pos:  position{line: 894, col: 32, offset: 25907},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 894, col: 48, offset: 26393},
+									pos: position{line: 894, col: 48, offset: 25923},
 									expr: &ruleRefExpr{
-										pos:  position{line: 894, col: 48, offset: 26393},
+										pos:  position{line: 894, col: 48, offset: 25923},
 										name: "IdentifierRest",
 									},
 								},
@@ -6347,30 +6347,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 895, col: 5, offset: 26445},
+						pos: position{line: 895, col: 5, offset: 25975},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 895, col: 5, offset: 26445},
+							pos:        position{line: 895, col: 5, offset: 25975},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 26484},
+						pos: position{line: 896, col: 5, offset: 26014},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 896, col: 5, offset: 26484},
+							pos: position{line: 896, col: 5, offset: 26014},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 896, col: 5, offset: 26484},
+									pos:        position{line: 896, col: 5, offset: 26014},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 896, col: 10, offset: 26489},
+									pos:   position{line: 896, col: 10, offset: 26019},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 896, col: 13, offset: 26492},
+										pos:  position{line: 896, col: 13, offset: 26022},
 										name: "IdGuard",
 									},
 								},
@@ -6378,10 +6378,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 898, col: 5, offset: 26583},
+						pos: position{line: 898, col: 5, offset: 26113},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 898, col: 5, offset: 26583},
+							pos:        position{line: 898, col: 5, offset: 26113},
 							val:        "type",
 							ignoreCase: false,
 						},
@@ -6391,24 +6391,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdGuard",
-			pos:  position{line: 901, col: 1, offset: 26623},
+			pos:  position{line: 901, col: 1, offset: 26153},
 			expr: &choiceExpr{
-				pos: position{line: 902, col: 5, offset: 26635},
+				pos: position{line: 902, col: 5, offset: 26165},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 902, col: 5, offset: 26635},
+						pos:  position{line: 902, col: 5, offset: 26165},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 903, col: 5, offset: 26654},
+						pos:  position{line: 903, col: 5, offset: 26184},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 904, col: 5, offset: 26670},
+						pos:  position{line: 904, col: 5, offset: 26200},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 905, col: 5, offset: 26687},
+						pos:  position{line: 905, col: 5, offset: 26217},
 						name: "SearchGuard",
 					},
 				},
@@ -6416,54 +6416,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 907, col: 1, offset: 26700},
+			pos:  position{line: 907, col: 1, offset: 26230},
 			expr: &choiceExpr{
-				pos: position{line: 908, col: 5, offset: 26713},
+				pos: position{line: 908, col: 5, offset: 26243},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 908, col: 5, offset: 26713},
+						pos:  position{line: 908, col: 5, offset: 26243},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 909, col: 5, offset: 26725},
+						pos:  position{line: 909, col: 5, offset: 26255},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 910, col: 5, offset: 26737},
+						pos:  position{line: 910, col: 5, offset: 26267},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 911, col: 5, offset: 26747},
+						pos: position{line: 911, col: 5, offset: 26277},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 5, offset: 26747},
+								pos:  position{line: 911, col: 5, offset: 26277},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 11, offset: 26753},
+								pos:  position{line: 911, col: 11, offset: 26283},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 911, col: 13, offset: 26755},
+								pos:        position{line: 911, col: 13, offset: 26285},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 19, offset: 26761},
+								pos:  position{line: 911, col: 19, offset: 26291},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 21, offset: 26763},
+								pos:  position{line: 911, col: 21, offset: 26293},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 912, col: 5, offset: 26775},
+						pos:  position{line: 912, col: 5, offset: 26305},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 913, col: 5, offset: 26784},
+						pos:  position{line: 913, col: 5, offset: 26314},
 						name: "Weeks",
 					},
 				},
@@ -6471,32 +6471,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 915, col: 1, offset: 26791},
+			pos:  position{line: 915, col: 1, offset: 26321},
 			expr: &choiceExpr{
-				pos: position{line: 916, col: 5, offset: 26808},
+				pos: position{line: 916, col: 5, offset: 26338},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 916, col: 5, offset: 26808},
+						pos:        position{line: 916, col: 5, offset: 26338},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 917, col: 5, offset: 26822},
+						pos:        position{line: 917, col: 5, offset: 26352},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 918, col: 5, offset: 26835},
+						pos:        position{line: 918, col: 5, offset: 26365},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 919, col: 5, offset: 26846},
+						pos:        position{line: 919, col: 5, offset: 26376},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 920, col: 5, offset: 26856},
+						pos:        position{line: 920, col: 5, offset: 26386},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -6505,32 +6505,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 922, col: 1, offset: 26861},
+			pos:  position{line: 922, col: 1, offset: 26391},
 			expr: &choiceExpr{
-				pos: position{line: 923, col: 5, offset: 26878},
+				pos: position{line: 923, col: 5, offset: 26408},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 923, col: 5, offset: 26878},
+						pos:        position{line: 923, col: 5, offset: 26408},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 924, col: 5, offset: 26892},
+						pos:        position{line: 924, col: 5, offset: 26422},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 925, col: 5, offset: 26905},
+						pos:        position{line: 925, col: 5, offset: 26435},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 926, col: 5, offset: 26916},
+						pos:        position{line: 926, col: 5, offset: 26446},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 927, col: 5, offset: 26926},
+						pos:        position{line: 927, col: 5, offset: 26456},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -6539,32 +6539,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 929, col: 1, offset: 26931},
+			pos:  position{line: 929, col: 1, offset: 26461},
 			expr: &choiceExpr{
-				pos: position{line: 930, col: 5, offset: 26946},
+				pos: position{line: 930, col: 5, offset: 26476},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 930, col: 5, offset: 26946},
+						pos:        position{line: 930, col: 5, offset: 26476},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 931, col: 5, offset: 26958},
+						pos:        position{line: 931, col: 5, offset: 26488},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 932, col: 5, offset: 26968},
+						pos:        position{line: 932, col: 5, offset: 26498},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 933, col: 5, offset: 26977},
+						pos:        position{line: 933, col: 5, offset: 26507},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 934, col: 5, offset: 26985},
+						pos:        position{line: 934, col: 5, offset: 26515},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -6573,22 +6573,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 936, col: 1, offset: 26993},
+			pos:  position{line: 936, col: 1, offset: 26523},
 			expr: &choiceExpr{
-				pos: position{line: 936, col: 13, offset: 27005},
+				pos: position{line: 936, col: 13, offset: 26535},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 936, col: 13, offset: 27005},
+						pos:        position{line: 936, col: 13, offset: 26535},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 936, col: 20, offset: 27012},
+						pos:        position{line: 936, col: 20, offset: 26542},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 936, col: 26, offset: 27018},
+						pos:        position{line: 936, col: 26, offset: 26548},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -6597,32 +6597,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 938, col: 1, offset: 27023},
+			pos:  position{line: 938, col: 1, offset: 26553},
 			expr: &choiceExpr{
-				pos: position{line: 938, col: 14, offset: 27036},
+				pos: position{line: 938, col: 14, offset: 26566},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 938, col: 14, offset: 27036},
+						pos:        position{line: 938, col: 14, offset: 26566},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 22, offset: 27044},
+						pos:        position{line: 938, col: 22, offset: 26574},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 29, offset: 27051},
+						pos:        position{line: 938, col: 29, offset: 26581},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 35, offset: 27057},
+						pos:        position{line: 938, col: 35, offset: 26587},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 40, offset: 27062},
+						pos:        position{line: 938, col: 40, offset: 26592},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -6631,39 +6631,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 940, col: 1, offset: 27067},
+			pos:  position{line: 940, col: 1, offset: 26597},
 			expr: &choiceExpr{
-				pos: position{line: 941, col: 5, offset: 27079},
+				pos: position{line: 941, col: 5, offset: 26609},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 941, col: 5, offset: 27079},
+						pos: position{line: 941, col: 5, offset: 26609},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 941, col: 5, offset: 27079},
+							pos:        position{line: 941, col: 5, offset: 26609},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 27165},
+						pos: position{line: 942, col: 5, offset: 26695},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 27165},
+							pos: position{line: 942, col: 5, offset: 26695},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 942, col: 5, offset: 27165},
+									pos:   position{line: 942, col: 5, offset: 26695},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 9, offset: 27169},
+										pos:  position{line: 942, col: 9, offset: 26699},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 14, offset: 27174},
+									pos:  position{line: 942, col: 14, offset: 26704},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 17, offset: 27177},
+									pos:  position{line: 942, col: 17, offset: 26707},
 									name: "SecondsToken",
 								},
 							},
@@ -6674,39 +6674,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 944, col: 1, offset: 27266},
+			pos:  position{line: 944, col: 1, offset: 26796},
 			expr: &choiceExpr{
-				pos: position{line: 945, col: 5, offset: 27278},
+				pos: position{line: 945, col: 5, offset: 26808},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 945, col: 5, offset: 27278},
+						pos: position{line: 945, col: 5, offset: 26808},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 945, col: 5, offset: 27278},
+							pos:        position{line: 945, col: 5, offset: 26808},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 946, col: 5, offset: 27365},
+						pos: position{line: 946, col: 5, offset: 26895},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 946, col: 5, offset: 27365},
+							pos: position{line: 946, col: 5, offset: 26895},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 946, col: 5, offset: 27365},
+									pos:   position{line: 946, col: 5, offset: 26895},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 946, col: 9, offset: 27369},
+										pos:  position{line: 946, col: 9, offset: 26899},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 946, col: 14, offset: 27374},
+									pos:  position{line: 946, col: 14, offset: 26904},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 946, col: 17, offset: 27377},
+									pos:  position{line: 946, col: 17, offset: 26907},
 									name: "MinutesToken",
 								},
 							},
@@ -6717,39 +6717,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 948, col: 1, offset: 27475},
+			pos:  position{line: 948, col: 1, offset: 27005},
 			expr: &choiceExpr{
-				pos: position{line: 949, col: 5, offset: 27485},
+				pos: position{line: 949, col: 5, offset: 27015},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 949, col: 5, offset: 27485},
+						pos: position{line: 949, col: 5, offset: 27015},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 949, col: 5, offset: 27485},
+							pos:        position{line: 949, col: 5, offset: 27015},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 27572},
+						pos: position{line: 950, col: 5, offset: 27102},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 27572},
+							pos: position{line: 950, col: 5, offset: 27102},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 950, col: 5, offset: 27572},
+									pos:   position{line: 950, col: 5, offset: 27102},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 9, offset: 27576},
+										pos:  position{line: 950, col: 9, offset: 27106},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 14, offset: 27581},
+									pos:  position{line: 950, col: 14, offset: 27111},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 17, offset: 27584},
+									pos:  position{line: 950, col: 17, offset: 27114},
 									name: "HoursToken",
 								},
 							},
@@ -6760,39 +6760,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 952, col: 1, offset: 27682},
+			pos:  position{line: 952, col: 1, offset: 27212},
 			expr: &choiceExpr{
-				pos: position{line: 953, col: 5, offset: 27691},
+				pos: position{line: 953, col: 5, offset: 27221},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 953, col: 5, offset: 27691},
+						pos: position{line: 953, col: 5, offset: 27221},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 953, col: 5, offset: 27691},
+							pos:        position{line: 953, col: 5, offset: 27221},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 954, col: 5, offset: 27780},
+						pos: position{line: 954, col: 5, offset: 27310},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 954, col: 5, offset: 27780},
+							pos: position{line: 954, col: 5, offset: 27310},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 954, col: 5, offset: 27780},
+									pos:   position{line: 954, col: 5, offset: 27310},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 9, offset: 27784},
+										pos:  position{line: 954, col: 9, offset: 27314},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 14, offset: 27789},
+									pos:  position{line: 954, col: 14, offset: 27319},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 17, offset: 27792},
+									pos:  position{line: 954, col: 17, offset: 27322},
 									name: "DaysToken",
 								},
 							},
@@ -6803,39 +6803,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 956, col: 1, offset: 27894},
+			pos:  position{line: 956, col: 1, offset: 27424},
 			expr: &choiceExpr{
-				pos: position{line: 957, col: 5, offset: 27904},
+				pos: position{line: 957, col: 5, offset: 27434},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 957, col: 5, offset: 27904},
+						pos: position{line: 957, col: 5, offset: 27434},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 957, col: 5, offset: 27904},
+							pos:        position{line: 957, col: 5, offset: 27434},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 27996},
+						pos: position{line: 958, col: 5, offset: 27526},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 958, col: 5, offset: 27996},
+							pos: position{line: 958, col: 5, offset: 27526},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 958, col: 5, offset: 27996},
+									pos:   position{line: 958, col: 5, offset: 27526},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 9, offset: 28000},
+										pos:  position{line: 958, col: 9, offset: 27530},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 14, offset: 28005},
+									pos:  position{line: 958, col: 14, offset: 27535},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 17, offset: 28008},
+									pos:  position{line: 958, col: 17, offset: 27538},
 									name: "WeeksToken",
 								},
 							},
@@ -6846,42 +6846,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 961, col: 1, offset: 28139},
+			pos:  position{line: 961, col: 1, offset: 27669},
 			expr: &actionExpr{
-				pos: position{line: 962, col: 5, offset: 28146},
+				pos: position{line: 962, col: 5, offset: 27676},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 962, col: 5, offset: 28146},
+					pos: position{line: 962, col: 5, offset: 27676},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 5, offset: 28146},
+							pos:  position{line: 962, col: 5, offset: 27676},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 962, col: 10, offset: 28151},
+							pos:        position{line: 962, col: 10, offset: 27681},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 14, offset: 28155},
+							pos:  position{line: 962, col: 14, offset: 27685},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 962, col: 19, offset: 28160},
+							pos:        position{line: 962, col: 19, offset: 27690},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 23, offset: 28164},
+							pos:  position{line: 962, col: 23, offset: 27694},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 962, col: 28, offset: 28169},
+							pos:        position{line: 962, col: 28, offset: 27699},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 32, offset: 28173},
+							pos:  position{line: 962, col: 32, offset: 27703},
 							name: "UInt",
 						},
 					},
@@ -6890,42 +6890,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 964, col: 1, offset: 28210},
+			pos:  position{line: 964, col: 1, offset: 27740},
 			expr: &actionExpr{
-				pos: position{line: 965, col: 5, offset: 28218},
+				pos: position{line: 965, col: 5, offset: 27748},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 965, col: 5, offset: 28218},
+					pos: position{line: 965, col: 5, offset: 27748},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 965, col: 5, offset: 28218},
+							pos: position{line: 965, col: 5, offset: 27748},
 							expr: &seqExpr{
-								pos: position{line: 965, col: 8, offset: 28221},
+								pos: position{line: 965, col: 8, offset: 27751},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 965, col: 8, offset: 28221},
+										pos:  position{line: 965, col: 8, offset: 27751},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 965, col: 12, offset: 28225},
+										pos:        position{line: 965, col: 12, offset: 27755},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 965, col: 16, offset: 28229},
+										pos:  position{line: 965, col: 16, offset: 27759},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 965, col: 20, offset: 28233},
+										pos: position{line: 965, col: 20, offset: 27763},
 										expr: &choiceExpr{
-											pos: position{line: 965, col: 22, offset: 28235},
+											pos: position{line: 965, col: 22, offset: 27765},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 22, offset: 28235},
+													pos:  position{line: 965, col: 22, offset: 27765},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 965, col: 33, offset: 28246},
+													pos:        position{line: 965, col: 33, offset: 27776},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -6936,10 +6936,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 39, offset: 28252},
+							pos:   position{line: 965, col: 39, offset: 27782},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 41, offset: 28254},
+								pos:  position{line: 965, col: 41, offset: 27784},
 								name: "IP6Variations",
 							},
 						},
@@ -6949,32 +6949,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 969, col: 1, offset: 28418},
+			pos:  position{line: 969, col: 1, offset: 27948},
 			expr: &choiceExpr{
-				pos: position{line: 970, col: 5, offset: 28436},
+				pos: position{line: 970, col: 5, offset: 27966},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 970, col: 5, offset: 28436},
+						pos: position{line: 970, col: 5, offset: 27966},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 970, col: 5, offset: 28436},
+							pos: position{line: 970, col: 5, offset: 27966},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 970, col: 5, offset: 28436},
+									pos:   position{line: 970, col: 5, offset: 27966},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 970, col: 7, offset: 28438},
+										pos: position{line: 970, col: 7, offset: 27968},
 										expr: &ruleRefExpr{
-											pos:  position{line: 970, col: 7, offset: 28438},
+											pos:  position{line: 970, col: 7, offset: 27968},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 970, col: 17, offset: 28448},
+									pos:   position{line: 970, col: 17, offset: 27978},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 19, offset: 28450},
+										pos:  position{line: 970, col: 19, offset: 27980},
 										name: "IP6Tail",
 									},
 								},
@@ -6982,51 +6982,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 973, col: 5, offset: 28514},
+						pos: position{line: 973, col: 5, offset: 28044},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 973, col: 5, offset: 28514},
+							pos: position{line: 973, col: 5, offset: 28044},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 973, col: 5, offset: 28514},
+									pos:   position{line: 973, col: 5, offset: 28044},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 973, col: 7, offset: 28516},
+										pos:  position{line: 973, col: 7, offset: 28046},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 11, offset: 28520},
+									pos:   position{line: 973, col: 11, offset: 28050},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 973, col: 13, offset: 28522},
+										pos: position{line: 973, col: 13, offset: 28052},
 										expr: &ruleRefExpr{
-											pos:  position{line: 973, col: 13, offset: 28522},
+											pos:  position{line: 973, col: 13, offset: 28052},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 973, col: 23, offset: 28532},
+									pos:        position{line: 973, col: 23, offset: 28062},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 28, offset: 28537},
+									pos:   position{line: 973, col: 28, offset: 28067},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 973, col: 30, offset: 28539},
+										pos: position{line: 973, col: 30, offset: 28069},
 										expr: &ruleRefExpr{
-											pos:  position{line: 973, col: 30, offset: 28539},
+											pos:  position{line: 973, col: 30, offset: 28069},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 40, offset: 28549},
+									pos:   position{line: 973, col: 40, offset: 28079},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 973, col: 42, offset: 28551},
+										pos:  position{line: 973, col: 42, offset: 28081},
 										name: "IP6Tail",
 									},
 								},
@@ -7034,32 +7034,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 976, col: 5, offset: 28650},
+						pos: position{line: 976, col: 5, offset: 28180},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 976, col: 5, offset: 28650},
+							pos: position{line: 976, col: 5, offset: 28180},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 976, col: 5, offset: 28650},
+									pos:        position{line: 976, col: 5, offset: 28180},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 10, offset: 28655},
+									pos:   position{line: 976, col: 10, offset: 28185},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 976, col: 12, offset: 28657},
+										pos: position{line: 976, col: 12, offset: 28187},
 										expr: &ruleRefExpr{
-											pos:  position{line: 976, col: 12, offset: 28657},
+											pos:  position{line: 976, col: 12, offset: 28187},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 22, offset: 28667},
+									pos:   position{line: 976, col: 22, offset: 28197},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 24, offset: 28669},
+										pos:  position{line: 976, col: 24, offset: 28199},
 										name: "IP6Tail",
 									},
 								},
@@ -7067,32 +7067,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 28740},
+						pos: position{line: 979, col: 5, offset: 28270},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 979, col: 5, offset: 28740},
+							pos: position{line: 979, col: 5, offset: 28270},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 979, col: 5, offset: 28740},
+									pos:   position{line: 979, col: 5, offset: 28270},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 979, col: 7, offset: 28742},
+										pos:  position{line: 979, col: 7, offset: 28272},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 979, col: 11, offset: 28746},
+									pos:   position{line: 979, col: 11, offset: 28276},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 979, col: 13, offset: 28748},
+										pos: position{line: 979, col: 13, offset: 28278},
 										expr: &ruleRefExpr{
-											pos:  position{line: 979, col: 13, offset: 28748},
+											pos:  position{line: 979, col: 13, offset: 28278},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 979, col: 23, offset: 28758},
+									pos:        position{line: 979, col: 23, offset: 28288},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -7100,10 +7100,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 28826},
+						pos: position{line: 982, col: 5, offset: 28356},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 982, col: 5, offset: 28826},
+							pos:        position{line: 982, col: 5, offset: 28356},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -7113,16 +7113,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 986, col: 1, offset: 28863},
+			pos:  position{line: 986, col: 1, offset: 28393},
 			expr: &choiceExpr{
-				pos: position{line: 987, col: 5, offset: 28875},
+				pos: position{line: 987, col: 5, offset: 28405},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 987, col: 5, offset: 28875},
+						pos:  position{line: 987, col: 5, offset: 28405},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 988, col: 5, offset: 28882},
+						pos:  position{line: 988, col: 5, offset: 28412},
 						name: "Hex",
 					},
 				},
@@ -7130,23 +7130,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 990, col: 1, offset: 28887},
+			pos:  position{line: 990, col: 1, offset: 28417},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 12, offset: 28898},
+				pos: position{line: 990, col: 12, offset: 28428},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 990, col: 12, offset: 28898},
+					pos: position{line: 990, col: 12, offset: 28428},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 990, col: 12, offset: 28898},
+							pos:        position{line: 990, col: 12, offset: 28428},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 990, col: 16, offset: 28902},
+							pos:   position{line: 990, col: 16, offset: 28432},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 990, col: 18, offset: 28904},
+								pos:  position{line: 990, col: 18, offset: 28434},
 								name: "Hex",
 							},
 						},
@@ -7156,23 +7156,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 992, col: 1, offset: 28942},
+			pos:  position{line: 992, col: 1, offset: 28472},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 12, offset: 28953},
+				pos: position{line: 992, col: 12, offset: 28483},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 992, col: 12, offset: 28953},
+					pos: position{line: 992, col: 12, offset: 28483},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 992, col: 12, offset: 28953},
+							pos:   position{line: 992, col: 12, offset: 28483},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 992, col: 14, offset: 28955},
+								pos:  position{line: 992, col: 14, offset: 28485},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 992, col: 18, offset: 28959},
+							pos:        position{line: 992, col: 18, offset: 28489},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -7182,31 +7182,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 994, col: 1, offset: 28997},
+			pos:  position{line: 994, col: 1, offset: 28527},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 5, offset: 29008},
+				pos: position{line: 995, col: 5, offset: 28538},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 995, col: 5, offset: 29008},
+					pos: position{line: 995, col: 5, offset: 28538},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 995, col: 5, offset: 29008},
+							pos:   position{line: 995, col: 5, offset: 28538},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 7, offset: 29010},
+								pos:  position{line: 995, col: 7, offset: 28540},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 995, col: 10, offset: 29013},
+							pos:        position{line: 995, col: 10, offset: 28543},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 995, col: 14, offset: 29017},
+							pos:   position{line: 995, col: 14, offset: 28547},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 16, offset: 29019},
+								pos:  position{line: 995, col: 16, offset: 28549},
 								name: "UInt",
 							},
 						},
@@ -7216,31 +7216,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 999, col: 1, offset: 29092},
+			pos:  position{line: 999, col: 1, offset: 28622},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 5, offset: 29103},
+				pos: position{line: 1000, col: 5, offset: 28633},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1000, col: 5, offset: 29103},
+					pos: position{line: 1000, col: 5, offset: 28633},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1000, col: 5, offset: 29103},
+							pos:   position{line: 1000, col: 5, offset: 28633},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 7, offset: 29105},
+								pos:  position{line: 1000, col: 7, offset: 28635},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1000, col: 11, offset: 29109},
+							pos:        position{line: 1000, col: 11, offset: 28639},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1000, col: 15, offset: 29113},
+							pos:   position{line: 1000, col: 15, offset: 28643},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 17, offset: 29115},
+								pos:  position{line: 1000, col: 17, offset: 28645},
 								name: "UInt",
 							},
 						},
@@ -7250,15 +7250,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1004, col: 1, offset: 29178},
+			pos:  position{line: 1004, col: 1, offset: 28708},
 			expr: &actionExpr{
-				pos: position{line: 1005, col: 4, offset: 29186},
+				pos: position{line: 1005, col: 4, offset: 28716},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1005, col: 4, offset: 29186},
+					pos:   position{line: 1005, col: 4, offset: 28716},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1005, col: 6, offset: 29188},
+						pos:  position{line: 1005, col: 6, offset: 28718},
 						name: "UIntString",
 					},
 				},
@@ -7266,16 +7266,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1007, col: 1, offset: 29228},
+			pos:  position{line: 1007, col: 1, offset: 28758},
 			expr: &choiceExpr{
-				pos: position{line: 1008, col: 5, offset: 29242},
+				pos: position{line: 1008, col: 5, offset: 28772},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 29242},
+						pos:  position{line: 1008, col: 5, offset: 28772},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 29257},
+						pos:  position{line: 1009, col: 5, offset: 28787},
 						name: "MinusIntString",
 					},
 				},
@@ -7283,14 +7283,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1011, col: 1, offset: 29273},
+			pos:  position{line: 1011, col: 1, offset: 28803},
 			expr: &actionExpr{
-				pos: position{line: 1011, col: 14, offset: 29286},
+				pos: position{line: 1011, col: 14, offset: 28816},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1011, col: 14, offset: 29286},
+					pos: position{line: 1011, col: 14, offset: 28816},
 					expr: &charClassMatcher{
-						pos:        position{line: 1011, col: 14, offset: 29286},
+						pos:        position{line: 1011, col: 14, offset: 28816},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7301,20 +7301,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1013, col: 1, offset: 29325},
+			pos:  position{line: 1013, col: 1, offset: 28855},
 			expr: &actionExpr{
-				pos: position{line: 1014, col: 5, offset: 29344},
+				pos: position{line: 1014, col: 5, offset: 28874},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1014, col: 5, offset: 29344},
+					pos: position{line: 1014, col: 5, offset: 28874},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1014, col: 5, offset: 29344},
+							pos:        position{line: 1014, col: 5, offset: 28874},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1014, col: 9, offset: 29348},
+							pos:  position{line: 1014, col: 9, offset: 28878},
 							name: "UIntString",
 						},
 					},
@@ -7323,28 +7323,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1016, col: 1, offset: 29391},
+			pos:  position{line: 1016, col: 1, offset: 28921},
 			expr: &choiceExpr{
-				pos: position{line: 1017, col: 5, offset: 29407},
+				pos: position{line: 1017, col: 5, offset: 28937},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1017, col: 5, offset: 29407},
+						pos: position{line: 1017, col: 5, offset: 28937},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1017, col: 5, offset: 29407},
+							pos: position{line: 1017, col: 5, offset: 28937},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1017, col: 5, offset: 29407},
+									pos: position{line: 1017, col: 5, offset: 28937},
 									expr: &litMatcher{
-										pos:        position{line: 1017, col: 5, offset: 29407},
+										pos:        position{line: 1017, col: 5, offset: 28937},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1017, col: 10, offset: 29412},
+									pos: position{line: 1017, col: 10, offset: 28942},
 									expr: &charClassMatcher{
-										pos:        position{line: 1017, col: 10, offset: 29412},
+										pos:        position{line: 1017, col: 10, offset: 28942},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7352,14 +7352,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1017, col: 17, offset: 29419},
+									pos:        position{line: 1017, col: 17, offset: 28949},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1017, col: 21, offset: 29423},
+									pos: position{line: 1017, col: 21, offset: 28953},
 									expr: &charClassMatcher{
-										pos:        position{line: 1017, col: 21, offset: 29423},
+										pos:        position{line: 1017, col: 21, offset: 28953},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7367,9 +7367,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1017, col: 28, offset: 29430},
+									pos: position{line: 1017, col: 28, offset: 28960},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1017, col: 28, offset: 29430},
+										pos:  position{line: 1017, col: 28, offset: 28960},
 										name: "ExponentPart",
 									},
 								},
@@ -7377,28 +7377,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 29489},
+						pos: position{line: 1020, col: 5, offset: 29019},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1020, col: 5, offset: 29489},
+							pos: position{line: 1020, col: 5, offset: 29019},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1020, col: 5, offset: 29489},
+									pos: position{line: 1020, col: 5, offset: 29019},
 									expr: &litMatcher{
-										pos:        position{line: 1020, col: 5, offset: 29489},
+										pos:        position{line: 1020, col: 5, offset: 29019},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 10, offset: 29494},
+									pos:        position{line: 1020, col: 10, offset: 29024},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1020, col: 14, offset: 29498},
+									pos: position{line: 1020, col: 14, offset: 29028},
 									expr: &charClassMatcher{
-										pos:        position{line: 1020, col: 14, offset: 29498},
+										pos:        position{line: 1020, col: 14, offset: 29028},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7406,9 +7406,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1020, col: 21, offset: 29505},
+									pos: position{line: 1020, col: 21, offset: 29035},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 21, offset: 29505},
+										pos:  position{line: 1020, col: 21, offset: 29035},
 										name: "ExponentPart",
 									},
 								},
@@ -7420,19 +7420,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1024, col: 1, offset: 29561},
+			pos:  position{line: 1024, col: 1, offset: 29091},
 			expr: &seqExpr{
-				pos: position{line: 1024, col: 16, offset: 29576},
+				pos: position{line: 1024, col: 16, offset: 29106},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1024, col: 16, offset: 29576},
+						pos:        position{line: 1024, col: 16, offset: 29106},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1024, col: 21, offset: 29581},
+						pos: position{line: 1024, col: 21, offset: 29111},
 						expr: &charClassMatcher{
-							pos:        position{line: 1024, col: 21, offset: 29581},
+							pos:        position{line: 1024, col: 21, offset: 29111},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -7440,7 +7440,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1024, col: 27, offset: 29587},
+						pos:  position{line: 1024, col: 27, offset: 29117},
 						name: "UIntString",
 					},
 				},
@@ -7448,14 +7448,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1026, col: 1, offset: 29599},
+			pos:  position{line: 1026, col: 1, offset: 29129},
 			expr: &actionExpr{
-				pos: position{line: 1026, col: 7, offset: 29605},
+				pos: position{line: 1026, col: 7, offset: 29135},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1026, col: 7, offset: 29605},
+					pos: position{line: 1026, col: 7, offset: 29135},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1026, col: 7, offset: 29605},
+						pos:  position{line: 1026, col: 7, offset: 29135},
 						name: "HexDigit",
 					},
 				},
@@ -7463,9 +7463,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1028, col: 1, offset: 29647},
+			pos:  position{line: 1028, col: 1, offset: 29177},
 			expr: &charClassMatcher{
-				pos:        position{line: 1028, col: 12, offset: 29658},
+				pos:        position{line: 1028, col: 12, offset: 29188},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -7474,34 +7474,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1031, col: 1, offset: 29672},
+			pos:  position{line: 1031, col: 1, offset: 29202},
 			expr: &choiceExpr{
-				pos: position{line: 1032, col: 5, offset: 29689},
+				pos: position{line: 1032, col: 5, offset: 29219},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 29689},
+						pos: position{line: 1032, col: 5, offset: 29219},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1032, col: 5, offset: 29689},
+							pos: position{line: 1032, col: 5, offset: 29219},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1032, col: 5, offset: 29689},
+									pos:        position{line: 1032, col: 5, offset: 29219},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1032, col: 9, offset: 29693},
+									pos:   position{line: 1032, col: 9, offset: 29223},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1032, col: 11, offset: 29695},
+										pos: position{line: 1032, col: 11, offset: 29225},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1032, col: 11, offset: 29695},
+											pos:  position{line: 1032, col: 11, offset: 29225},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 29, offset: 29713},
+									pos:        position{line: 1032, col: 29, offset: 29243},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -7509,29 +7509,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1033, col: 5, offset: 29750},
+						pos: position{line: 1033, col: 5, offset: 29280},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1033, col: 5, offset: 29750},
+							pos: position{line: 1033, col: 5, offset: 29280},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1033, col: 5, offset: 29750},
+									pos:        position{line: 1033, col: 5, offset: 29280},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 9, offset: 29754},
+									pos:   position{line: 1033, col: 9, offset: 29284},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1033, col: 11, offset: 29756},
+										pos: position{line: 1033, col: 11, offset: 29286},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1033, col: 11, offset: 29756},
+											pos:  position{line: 1033, col: 11, offset: 29286},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1033, col: 29, offset: 29774},
+									pos:        position{line: 1033, col: 29, offset: 29304},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -7543,55 +7543,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1035, col: 1, offset: 29808},
+			pos:  position{line: 1035, col: 1, offset: 29338},
 			expr: &choiceExpr{
-				pos: position{line: 1036, col: 5, offset: 29829},
+				pos: position{line: 1036, col: 5, offset: 29359},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 29829},
+						pos: position{line: 1036, col: 5, offset: 29359},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1036, col: 5, offset: 29829},
+							pos: position{line: 1036, col: 5, offset: 29359},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1036, col: 5, offset: 29829},
+									pos: position{line: 1036, col: 5, offset: 29359},
 									expr: &choiceExpr{
-										pos: position{line: 1036, col: 7, offset: 29831},
+										pos: position{line: 1036, col: 7, offset: 29361},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1036, col: 7, offset: 29831},
+												pos:        position{line: 1036, col: 7, offset: 29361},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1036, col: 13, offset: 29837},
+												pos:  position{line: 1036, col: 13, offset: 29367},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1036, col: 26, offset: 29850,
+									line: 1036, col: 26, offset: 29380,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 29887},
+						pos: position{line: 1037, col: 5, offset: 29417},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 29887},
+							pos: position{line: 1037, col: 5, offset: 29417},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1037, col: 5, offset: 29887},
+									pos:        position{line: 1037, col: 5, offset: 29417},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 10, offset: 29892},
+									pos:   position{line: 1037, col: 10, offset: 29422},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 12, offset: 29894},
+										pos:  position{line: 1037, col: 12, offset: 29424},
 										name: "EscapeSequence",
 									},
 								},
@@ -7603,28 +7603,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1039, col: 1, offset: 29928},
+			pos:  position{line: 1039, col: 1, offset: 29458},
 			expr: &actionExpr{
-				pos: position{line: 1040, col: 5, offset: 29940},
+				pos: position{line: 1040, col: 5, offset: 29470},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1040, col: 5, offset: 29940},
+					pos: position{line: 1040, col: 5, offset: 29470},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1040, col: 5, offset: 29940},
+							pos:   position{line: 1040, col: 5, offset: 29470},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1040, col: 10, offset: 29945},
+								pos:  position{line: 1040, col: 10, offset: 29475},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1040, col: 23, offset: 29958},
+							pos:   position{line: 1040, col: 23, offset: 29488},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1040, col: 28, offset: 29963},
+								pos: position{line: 1040, col: 28, offset: 29493},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1040, col: 28, offset: 29963},
+									pos:  position{line: 1040, col: 28, offset: 29493},
 									name: "KeyWordRest",
 								},
 							},
@@ -7635,15 +7635,15 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1042, col: 1, offset: 30025},
+			pos:  position{line: 1042, col: 1, offset: 29555},
 			expr: &choiceExpr{
-				pos: position{line: 1043, col: 5, offset: 30042},
+				pos: position{line: 1043, col: 5, offset: 29572},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 30042},
+						pos: position{line: 1043, col: 5, offset: 29572},
 						run: (*parser).callonKeyWordStart2,
 						expr: &charClassMatcher{
-							pos:        position{line: 1043, col: 5, offset: 30042},
+							pos:        position{line: 1043, col: 5, offset: 29572},
 							val:        "[a-zA-Z_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -7652,7 +7652,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 30094},
+						pos:  position{line: 1044, col: 5, offset: 29624},
 						name: "KeyWordEsc",
 					},
 				},
@@ -7660,16 +7660,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1046, col: 1, offset: 30106},
+			pos:  position{line: 1046, col: 1, offset: 29636},
 			expr: &choiceExpr{
-				pos: position{line: 1047, col: 5, offset: 30122},
+				pos: position{line: 1047, col: 5, offset: 29652},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 5, offset: 30122},
+						pos:  position{line: 1047, col: 5, offset: 29652},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1048, col: 5, offset: 30139},
+						pos:        position{line: 1048, col: 5, offset: 29669},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7680,30 +7680,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1050, col: 1, offset: 30146},
+			pos:  position{line: 1050, col: 1, offset: 29676},
 			expr: &actionExpr{
-				pos: position{line: 1050, col: 14, offset: 30159},
+				pos: position{line: 1050, col: 14, offset: 29689},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1050, col: 14, offset: 30159},
+					pos: position{line: 1050, col: 14, offset: 29689},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1050, col: 14, offset: 30159},
+							pos:        position{line: 1050, col: 14, offset: 29689},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1050, col: 19, offset: 30164},
+							pos:   position{line: 1050, col: 19, offset: 29694},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1050, col: 22, offset: 30167},
+								pos: position{line: 1050, col: 22, offset: 29697},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1050, col: 22, offset: 30167},
+										pos:  position{line: 1050, col: 22, offset: 29697},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1050, col: 38, offset: 30183},
+										pos:  position{line: 1050, col: 38, offset: 29713},
 										name: "EscapeSequence",
 									},
 								},
@@ -7715,55 +7715,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1052, col: 1, offset: 30219},
+			pos:  position{line: 1052, col: 1, offset: 29749},
 			expr: &choiceExpr{
-				pos: position{line: 1053, col: 5, offset: 30240},
+				pos: position{line: 1053, col: 5, offset: 29770},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1053, col: 5, offset: 30240},
+						pos: position{line: 1053, col: 5, offset: 29770},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1053, col: 5, offset: 30240},
+							pos: position{line: 1053, col: 5, offset: 29770},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1053, col: 5, offset: 30240},
+									pos: position{line: 1053, col: 5, offset: 29770},
 									expr: &choiceExpr{
-										pos: position{line: 1053, col: 7, offset: 30242},
+										pos: position{line: 1053, col: 7, offset: 29772},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1053, col: 7, offset: 30242},
+												pos:        position{line: 1053, col: 7, offset: 29772},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1053, col: 13, offset: 30248},
+												pos:  position{line: 1053, col: 13, offset: 29778},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1053, col: 26, offset: 30261,
+									line: 1053, col: 26, offset: 29791,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1054, col: 5, offset: 30298},
+						pos: position{line: 1054, col: 5, offset: 29828},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1054, col: 5, offset: 30298},
+							pos: position{line: 1054, col: 5, offset: 29828},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1054, col: 5, offset: 30298},
+									pos:        position{line: 1054, col: 5, offset: 29828},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1054, col: 10, offset: 30303},
+									pos:   position{line: 1054, col: 10, offset: 29833},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1054, col: 12, offset: 30305},
+										pos:  position{line: 1054, col: 12, offset: 29835},
 										name: "EscapeSequence",
 									},
 								},
@@ -7775,38 +7775,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1056, col: 1, offset: 30339},
+			pos:  position{line: 1056, col: 1, offset: 29869},
 			expr: &choiceExpr{
-				pos: position{line: 1057, col: 5, offset: 30358},
+				pos: position{line: 1057, col: 5, offset: 29888},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 30358},
+						pos: position{line: 1057, col: 5, offset: 29888},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 30358},
+							pos: position{line: 1057, col: 5, offset: 29888},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1057, col: 5, offset: 30358},
+									pos:        position{line: 1057, col: 5, offset: 29888},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 9, offset: 30362},
+									pos:  position{line: 1057, col: 9, offset: 29892},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 18, offset: 30371},
+									pos:  position{line: 1057, col: 18, offset: 29901},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1058, col: 5, offset: 30422},
+						pos:  position{line: 1058, col: 5, offset: 29952},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1059, col: 5, offset: 30443},
+						pos:  position{line: 1059, col: 5, offset: 29973},
 						name: "UnicodeEscape",
 					},
 				},
@@ -7814,75 +7814,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1061, col: 1, offset: 30458},
+			pos:  position{line: 1061, col: 1, offset: 29988},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 5, offset: 30479},
+				pos: position{line: 1062, col: 5, offset: 30009},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1062, col: 5, offset: 30479},
+						pos:        position{line: 1062, col: 5, offset: 30009},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1063, col: 5, offset: 30487},
+						pos:        position{line: 1063, col: 5, offset: 30017},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1064, col: 5, offset: 30496},
+						pos:        position{line: 1064, col: 5, offset: 30026},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 30505},
+						pos: position{line: 1065, col: 5, offset: 30035},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 1065, col: 5, offset: 30505},
+							pos:        position{line: 1065, col: 5, offset: 30035},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 30534},
+						pos: position{line: 1066, col: 5, offset: 30064},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 1066, col: 5, offset: 30534},
+							pos:        position{line: 1066, col: 5, offset: 30064},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30563},
+						pos: position{line: 1067, col: 5, offset: 30093},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 1067, col: 5, offset: 30563},
+							pos:        position{line: 1067, col: 5, offset: 30093},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 30592},
+						pos: position{line: 1068, col: 5, offset: 30122},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 1068, col: 5, offset: 30592},
+							pos:        position{line: 1068, col: 5, offset: 30122},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 30621},
+						pos: position{line: 1069, col: 5, offset: 30151},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 1069, col: 5, offset: 30621},
+							pos:        position{line: 1069, col: 5, offset: 30151},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 30650},
+						pos: position{line: 1070, col: 5, offset: 30180},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 1070, col: 5, offset: 30650},
+							pos:        position{line: 1070, col: 5, offset: 30180},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -7892,30 +7892,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1072, col: 1, offset: 30676},
+			pos:  position{line: 1072, col: 1, offset: 30206},
 			expr: &choiceExpr{
-				pos: position{line: 1073, col: 5, offset: 30694},
+				pos: position{line: 1073, col: 5, offset: 30224},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 30694},
+						pos: position{line: 1073, col: 5, offset: 30224},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1073, col: 5, offset: 30694},
+							pos:        position{line: 1073, col: 5, offset: 30224},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 30722},
+						pos: position{line: 1074, col: 5, offset: 30252},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1074, col: 5, offset: 30722},
+							pos:        position{line: 1074, col: 5, offset: 30252},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1075, col: 5, offset: 30752},
+						pos:        position{line: 1075, col: 5, offset: 30282},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -7926,41 +7926,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1077, col: 1, offset: 30758},
+			pos:  position{line: 1077, col: 1, offset: 30288},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 30776},
+				pos: position{line: 1078, col: 5, offset: 30306},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 30776},
+						pos: position{line: 1078, col: 5, offset: 30306},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 30776},
+							pos: position{line: 1078, col: 5, offset: 30306},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1078, col: 5, offset: 30776},
+									pos:        position{line: 1078, col: 5, offset: 30306},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 9, offset: 30780},
+									pos:   position{line: 1078, col: 9, offset: 30310},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1078, col: 16, offset: 30787},
+										pos: position{line: 1078, col: 16, offset: 30317},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 16, offset: 30787},
+												pos:  position{line: 1078, col: 16, offset: 30317},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 25, offset: 30796},
+												pos:  position{line: 1078, col: 25, offset: 30326},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 34, offset: 30805},
+												pos:  position{line: 1078, col: 34, offset: 30335},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 43, offset: 30814},
+												pos:  position{line: 1078, col: 43, offset: 30344},
 												name: "HexDigit",
 											},
 										},
@@ -7970,63 +7970,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 30877},
+						pos: position{line: 1081, col: 5, offset: 30407},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1081, col: 5, offset: 30877},
+							pos: position{line: 1081, col: 5, offset: 30407},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1081, col: 5, offset: 30877},
+									pos:        position{line: 1081, col: 5, offset: 30407},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 9, offset: 30881},
+									pos:        position{line: 1081, col: 9, offset: 30411},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1081, col: 13, offset: 30885},
+									pos:   position{line: 1081, col: 13, offset: 30415},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1081, col: 20, offset: 30892},
+										pos: position{line: 1081, col: 20, offset: 30422},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1081, col: 20, offset: 30892},
+												pos:  position{line: 1081, col: 20, offset: 30422},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 29, offset: 30901},
+												pos: position{line: 1081, col: 29, offset: 30431},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 29, offset: 30901},
+													pos:  position{line: 1081, col: 29, offset: 30431},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 39, offset: 30911},
+												pos: position{line: 1081, col: 39, offset: 30441},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 39, offset: 30911},
+													pos:  position{line: 1081, col: 39, offset: 30441},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 49, offset: 30921},
+												pos: position{line: 1081, col: 49, offset: 30451},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 49, offset: 30921},
+													pos:  position{line: 1081, col: 49, offset: 30451},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 59, offset: 30931},
+												pos: position{line: 1081, col: 59, offset: 30461},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 59, offset: 30931},
+													pos:  position{line: 1081, col: 59, offset: 30461},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 69, offset: 30941},
+												pos: position{line: 1081, col: 69, offset: 30471},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 69, offset: 30941},
+													pos:  position{line: 1081, col: 69, offset: 30471},
 													name: "HexDigit",
 												},
 											},
@@ -8034,7 +8034,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 80, offset: 30952},
+									pos:        position{line: 1081, col: 80, offset: 30482},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8046,28 +8046,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1085, col: 1, offset: 31006},
+			pos:  position{line: 1085, col: 1, offset: 30536},
 			expr: &actionExpr{
-				pos: position{line: 1086, col: 5, offset: 31017},
+				pos: position{line: 1086, col: 5, offset: 30547},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1086, col: 5, offset: 31017},
+					pos: position{line: 1086, col: 5, offset: 30547},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1086, col: 5, offset: 31017},
+							pos:        position{line: 1086, col: 5, offset: 30547},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1086, col: 9, offset: 31021},
+							pos:   position{line: 1086, col: 9, offset: 30551},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1086, col: 14, offset: 31026},
+								pos:  position{line: 1086, col: 14, offset: 30556},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 25, offset: 31037},
+							pos:        position{line: 1086, col: 25, offset: 30567},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -8077,24 +8077,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1088, col: 1, offset: 31063},
+			pos:  position{line: 1088, col: 1, offset: 30593},
 			expr: &actionExpr{
-				pos: position{line: 1089, col: 5, offset: 31078},
+				pos: position{line: 1089, col: 5, offset: 30608},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1089, col: 5, offset: 31078},
+					pos: position{line: 1089, col: 5, offset: 30608},
 					expr: &choiceExpr{
-						pos: position{line: 1089, col: 6, offset: 31079},
+						pos: position{line: 1089, col: 6, offset: 30609},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1089, col: 6, offset: 31079},
+								pos:        position{line: 1089, col: 6, offset: 30609},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1089, col: 13, offset: 31086},
+								pos:        position{line: 1089, col: 13, offset: 30616},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -8105,9 +8105,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1091, col: 1, offset: 31126},
+			pos:  position{line: 1091, col: 1, offset: 30656},
 			expr: &charClassMatcher{
-				pos:        position{line: 1092, col: 5, offset: 31142},
+				pos:        position{line: 1092, col: 5, offset: 30672},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -8117,42 +8117,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1094, col: 1, offset: 31157},
+			pos:  position{line: 1094, col: 1, offset: 30687},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1094, col: 6, offset: 31162},
+				pos: position{line: 1094, col: 6, offset: 30692},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1094, col: 6, offset: 31162},
+					pos:  position{line: 1094, col: 6, offset: 30692},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1096, col: 1, offset: 31173},
+			pos:  position{line: 1096, col: 1, offset: 30703},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1096, col: 6, offset: 31178},
+				pos: position{line: 1096, col: 6, offset: 30708},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1096, col: 6, offset: 31178},
+					pos:  position{line: 1096, col: 6, offset: 30708},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1098, col: 1, offset: 31189},
+			pos:  position{line: 1098, col: 1, offset: 30719},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 31202},
+				pos: position{line: 1099, col: 5, offset: 30732},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 31202},
+						pos:  position{line: 1099, col: 5, offset: 30732},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 31217},
+						pos:  position{line: 1100, col: 5, offset: 30747},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 31236},
+						pos:  position{line: 1101, col: 5, offset: 30766},
 						name: "Comment",
 					},
 				},
@@ -8160,45 +8160,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1103, col: 1, offset: 31245},
+			pos:  position{line: 1103, col: 1, offset: 30775},
 			expr: &anyMatcher{
-				line: 1104, col: 5, offset: 31265,
+				line: 1104, col: 5, offset: 30795,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1106, col: 1, offset: 31268},
+			pos:         position{line: 1106, col: 1, offset: 30798},
 			expr: &choiceExpr{
-				pos: position{line: 1107, col: 5, offset: 31296},
+				pos: position{line: 1107, col: 5, offset: 30826},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1107, col: 5, offset: 31296},
+						pos:        position{line: 1107, col: 5, offset: 30826},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1108, col: 5, offset: 31305},
+						pos:        position{line: 1108, col: 5, offset: 30835},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1109, col: 5, offset: 31314},
+						pos:        position{line: 1109, col: 5, offset: 30844},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1110, col: 5, offset: 31323},
+						pos:        position{line: 1110, col: 5, offset: 30853},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1111, col: 5, offset: 31331},
+						pos:        position{line: 1111, col: 5, offset: 30861},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1112, col: 5, offset: 31344},
+						pos:        position{line: 1112, col: 5, offset: 30874},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -8207,9 +8207,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1114, col: 1, offset: 31354},
+			pos:  position{line: 1114, col: 1, offset: 30884},
 			expr: &charClassMatcher{
-				pos:        position{line: 1115, col: 5, offset: 31373},
+				pos:        position{line: 1115, col: 5, offset: 30903},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -8219,45 +8219,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1121, col: 1, offset: 31703},
+			pos:         position{line: 1121, col: 1, offset: 31233},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1124, col: 5, offset: 31774},
+				pos:  position{line: 1124, col: 5, offset: 31304},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1126, col: 1, offset: 31793},
+			pos:  position{line: 1126, col: 1, offset: 31323},
 			expr: &seqExpr{
-				pos: position{line: 1127, col: 5, offset: 31814},
+				pos: position{line: 1127, col: 5, offset: 31344},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1127, col: 5, offset: 31814},
+						pos:        position{line: 1127, col: 5, offset: 31344},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1127, col: 10, offset: 31819},
+						pos: position{line: 1127, col: 10, offset: 31349},
 						expr: &seqExpr{
-							pos: position{line: 1127, col: 11, offset: 31820},
+							pos: position{line: 1127, col: 11, offset: 31350},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1127, col: 11, offset: 31820},
+									pos: position{line: 1127, col: 11, offset: 31350},
 									expr: &litMatcher{
-										pos:        position{line: 1127, col: 12, offset: 31821},
+										pos:        position{line: 1127, col: 12, offset: 31351},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1127, col: 17, offset: 31826},
+									pos:  position{line: 1127, col: 17, offset: 31356},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1127, col: 35, offset: 31844},
+						pos:        position{line: 1127, col: 35, offset: 31374},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -8266,29 +8266,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1129, col: 1, offset: 31850},
+			pos:  position{line: 1129, col: 1, offset: 31380},
 			expr: &seqExpr{
-				pos: position{line: 1130, col: 5, offset: 31872},
+				pos: position{line: 1130, col: 5, offset: 31402},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1130, col: 5, offset: 31872},
+						pos:        position{line: 1130, col: 5, offset: 31402},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1130, col: 10, offset: 31877},
+						pos: position{line: 1130, col: 10, offset: 31407},
 						expr: &seqExpr{
-							pos: position{line: 1130, col: 11, offset: 31878},
+							pos: position{line: 1130, col: 11, offset: 31408},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1130, col: 11, offset: 31878},
+									pos: position{line: 1130, col: 11, offset: 31408},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1130, col: 12, offset: 31879},
+										pos:  position{line: 1130, col: 12, offset: 31409},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1130, col: 27, offset: 31894},
+									pos:  position{line: 1130, col: 27, offset: 31424},
 									name: "SourceCharacter",
 								},
 							},
@@ -8299,19 +8299,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1132, col: 1, offset: 31913},
+			pos:  position{line: 1132, col: 1, offset: 31443},
 			expr: &seqExpr{
-				pos: position{line: 1132, col: 7, offset: 31919},
+				pos: position{line: 1132, col: 7, offset: 31449},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1132, col: 7, offset: 31919},
+						pos: position{line: 1132, col: 7, offset: 31449},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1132, col: 7, offset: 31919},
+							pos:  position{line: 1132, col: 7, offset: 31449},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 19, offset: 31931},
+						pos:  position{line: 1132, col: 19, offset: 31461},
 						name: "LineTerminator",
 					},
 				},
@@ -8319,16 +8319,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1134, col: 1, offset: 31947},
+			pos:  position{line: 1134, col: 1, offset: 31477},
 			expr: &choiceExpr{
-				pos: position{line: 1134, col: 7, offset: 31953},
+				pos: position{line: 1134, col: 7, offset: 31483},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 7, offset: 31953},
+						pos:  position{line: 1134, col: 7, offset: 31483},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 11, offset: 31957},
+						pos:  position{line: 1134, col: 11, offset: 31487},
 						name: "EOF",
 					},
 				},
@@ -8336,11 +8336,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1136, col: 1, offset: 31962},
+			pos:  position{line: 1136, col: 1, offset: 31492},
 			expr: &notExpr{
-				pos: position{line: 1136, col: 7, offset: 31968},
+				pos: position{line: 1136, col: 7, offset: 31498},
 				expr: &anyMatcher{
-					line: 1136, col: 8, offset: 31969,
+					line: 1136, col: 8, offset: 31499,
 				},
 			},
 		},
@@ -8363,7 +8363,7 @@ func (c *current) onZ2(consts, first, rest interface{}) (interface{}, error) {
 	for _, p := range rest.([]interface{}) {
 		procs = append(procs, p)
 	}
-	return map[string]interface{}{"op": "SequentialProc", "procs": procs}, nil
+	return map[string]interface{}{"op": "Sequential", "procs": procs}, nil
 
 }
 
@@ -8384,7 +8384,7 @@ func (p *parser) callonConst1() (interface{}, error) {
 }
 
 func (c *current) onAnyConst2(id, expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "ConstProc", "name": id, "expr": expr}, nil
+	return map[string]interface{}{"op": "Const", "name": id, "expr": expr}, nil
 
 }
 
@@ -8406,7 +8406,7 @@ func (p *parser) callonAnyConst18() (interface{}, error) {
 }
 
 func (c *current) onSequential2(first, rest interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SequentialProc", "procs": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
+	return map[string]interface{}{"op": "Sequential", "procs": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
 
 }
 
@@ -8417,7 +8417,7 @@ func (p *parser) callonSequential2() (interface{}, error) {
 }
 
 func (c *current) onSequential9(op interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SequentialProc", "procs": []interface{}{op}}, nil
+	return map[string]interface{}{"op": "Sequential", "procs": []interface{}{op}}, nil
 
 }
 
@@ -8469,19 +8469,19 @@ func (p *parser) callonParallelTail1() (interface{}, error) {
 	return p.cur.onParallelTail1(stack["ch"])
 }
 
-func (c *current) onSwitchBranch2(filter, proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"filter": filter, "proc": proc}, nil
+func (c *current) onSwitchBranch2(e, proc interface{}) (interface{}, error) {
+	return map[string]interface{}{"expr": e, "proc": proc}, nil
 
 }
 
 func (p *parser) callonSwitchBranch2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSwitchBranch2(stack["filter"], stack["proc"])
+	return p.cur.onSwitchBranch2(stack["e"], stack["proc"])
 }
 
 func (c *current) onSwitchBranch14(proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"filter": map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}, nil
+	return map[string]interface{}{"expr": map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}, nil
 
 }
 
@@ -8514,7 +8514,7 @@ func (p *parser) callonSwitch9() (interface{}, error) {
 }
 
 func (c *current) onOperation2(procArray interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "ParallelProc", "procs": procArray}, nil
+	return map[string]interface{}{"op": "Parallel", "procs": procArray}, nil
 
 }
 
@@ -8525,7 +8525,7 @@ func (p *parser) callonOperation2() (interface{}, error) {
 }
 
 func (c *current) onOperation14(caseArray interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SwitchProc", "cases": caseArray}, nil
+	return map[string]interface{}{"op": "Switch", "cases": caseArray}, nil
 
 }
 
@@ -8556,7 +8556,7 @@ func (p *parser) callonOperation31() (interface{}, error) {
 }
 
 func (c *current) onOperation37(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
+	return map[string]interface{}{"op": "Filter", "expr": expr}, nil
 
 }
 
@@ -8609,7 +8609,7 @@ func (p *parser) callonSearchAnd1() (interface{}, error) {
 }
 
 func (c *current) onSearchFactor2(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "UnaryExpr", "operator": "!", "operand": e}, nil
+	return map[string]interface{}{"op": "UnaryExpr", "kind": "!", "operand": e}, nil
 
 }
 
@@ -8630,21 +8630,21 @@ func (p *parser) callonSearchFactor15() (interface{}, error) {
 }
 
 func (c *current) onShortCut2(compareOp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FunctionCall", "function": "or",
+	return map[string]interface{}{"op": "Call", "name": "or",
 
 		"args": []interface{}{
 
 			map[string]interface{}{"op": "SelectExpr",
 
-				"selectors": []interface{}{map[string]interface{}{"op": "RootRecord"}},
+				"selectors": []interface{}{map[string]interface{}{"op": "Root"}},
 
 				"methods": []interface{}{
 
-					map[string]interface{}{"op": "FunctionCall", "function": "map",
+					map[string]interface{}{"op": "Call", "name": "map",
 
-						"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "operator": "=",
+						"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "kind": "=",
 
-							"lhs": map[string]interface{}{"op": "Identifier", "name": "$"},
+							"lhs": map[string]interface{}{"op": "Id", "name": "$"},
 
 							"rhs": v}}}}}}}, nil
 
@@ -8657,7 +8657,7 @@ func (p *parser) callonShortCut2() (interface{}, error) {
 }
 
 func (c *current) onShortCut11(f, comp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "operator": comp, "lhs": f, "rhs": v}, nil
+	return map[string]interface{}{"op": "BinaryExpr", "kind": comp, "lhs": f, "rhs": v}, nil
 
 }
 
@@ -8668,21 +8668,21 @@ func (p *parser) callonShortCut11() (interface{}, error) {
 }
 
 func (c *current) onShortCut23(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FunctionCall", "function": "or",
+	return map[string]interface{}{"op": "Call", "name": "or",
 
 		"args": []interface{}{
 
 			map[string]interface{}{"op": "SelectExpr",
 
-				"selectors": []interface{}{map[string]interface{}{"op": "RootRecord"}},
+				"selectors": []interface{}{map[string]interface{}{"op": "Root"}},
 
 				"methods": []interface{}{
 
-					map[string]interface{}{"op": "FunctionCall", "function": "map",
+					map[string]interface{}{"op": "Call", "name": "map",
 
-						"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "operator": "in",
+						"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "kind": "in",
 
-							"rhs": map[string]interface{}{"op": "Identifier", "name": "$"},
+							"rhs": map[string]interface{}{"op": "Id", "name": "$"},
 
 							"lhs": v}}}}}}}, nil
 
@@ -8849,7 +8849,7 @@ func (p *parser) callonSearchExprMul1() (interface{}, error) {
 }
 
 func (c *current) onSearchExprCast2(e, typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CastExpr", "expr": e, "type": typ}, nil
+	return map[string]interface{}{"op": "Cast", "expr": e, "type": typ}, nil
 
 }
 
@@ -8871,7 +8871,7 @@ func (p *parser) callonSearchExprFunc4() (interface{}, error) {
 }
 
 func (c *current) onAggregation2(every, keys, limit interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "GroupByProc", "keys": keys, "reducers": nil, "duration": every, "limit": limit}, nil
+	return map[string]interface{}{"op": "Summarize", "keys": keys, "aggs": nil, "duration": every, "limit": limit}, nil
 
 }
 
@@ -8881,8 +8881,8 @@ func (p *parser) callonAggregation2() (interface{}, error) {
 	return p.cur.onAggregation2(stack["every"], stack["keys"], stack["limit"])
 }
 
-func (c *current) onAggregation11(every, reducers, keys, limit interface{}) (interface{}, error) {
-	var p = map[string]interface{}{"op": "GroupByProc", "keys": nil, "reducers": reducers, "duration": every, "limit": limit}
+func (c *current) onAggregation11(every, aggs, keys, limit interface{}) (interface{}, error) {
+	var p = map[string]interface{}{"op": "Summarize", "keys": nil, "aggs": aggs, "duration": every, "limit": limit}
 	if keys != nil {
 		p["keys"] = keys.([]interface{})[1]
 	}
@@ -8893,7 +8893,7 @@ func (c *current) onAggregation11(every, reducers, keys, limit interface{}) (int
 func (p *parser) callonAggregation11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAggregation11(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
+	return p.cur.onAggregation11(stack["every"], stack["aggs"], stack["keys"], stack["limit"])
 }
 
 func (c *current) onEveryDur2(dur interface{}) (interface{}, error) {
@@ -8977,30 +8977,30 @@ func (p *parser) callonFlexAssignments1() (interface{}, error) {
 	return p.cur.onFlexAssignments1(stack["first"], stack["rest"])
 }
 
-func (c *current) onReducerAssignment2(lval, reducer interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "lhs": lval, "rhs": reducer}, nil
+func (c *current) onAggAssignment2(lval, agg interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Assignment", "lhs": lval, "rhs": agg}, nil
 
 }
 
-func (p *parser) callonReducerAssignment2() (interface{}, error) {
+func (p *parser) callonAggAssignment2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onReducerAssignment2(stack["lval"], stack["reducer"])
+	return p.cur.onAggAssignment2(stack["lval"], stack["agg"])
 }
 
-func (c *current) onReducerAssignment11(reducer interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "lhs": nil, "rhs": reducer}, nil
+func (c *current) onAggAssignment11(agg interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Assignment", "lhs": nil, "rhs": agg}, nil
 
 }
 
-func (p *parser) callonReducerAssignment11() (interface{}, error) {
+func (p *parser) callonAggAssignment11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onReducerAssignment11(stack["reducer"])
+	return p.cur.onAggAssignment11(stack["agg"])
 }
 
-func (c *current) onReducer1(op, expr, where interface{}) (interface{}, error) {
-	var r = map[string]interface{}{"op": "Reducer", "operator": op, "expr": nil, "where": where}
+func (c *current) onAgg1(op, expr, where interface{}) (interface{}, error) {
+	var r = map[string]interface{}{"op": "Agg", "name": op, "expr": nil, "where": where}
 	if expr != nil {
 		r["expr"] = expr
 	}
@@ -9008,10 +9008,10 @@ func (c *current) onReducer1(op, expr, where interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonReducer1() (interface{}, error) {
+func (p *parser) callonAgg1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onReducer1(stack["op"], stack["expr"], stack["where"])
+	return p.cur.onAgg1(stack["op"], stack["expr"], stack["where"])
 }
 
 func (c *current) onWhereClause1(expr interface{}) (interface{}, error) {
@@ -9024,7 +9024,7 @@ func (p *parser) callonWhereClause1() (interface{}, error) {
 	return p.cur.onWhereClause1(stack["expr"])
 }
 
-func (c *current) onReducers1(first, rest interface{}) (interface{}, error) {
+func (c *current) onAggAssignments1(first, rest interface{}) (interface{}, error) {
 	var result = []interface{}{first}
 	for _, r := range rest.([]interface{}) {
 		result = append(result, r.([]interface{})[3])
@@ -9033,10 +9033,10 @@ func (c *current) onReducers1(first, rest interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonReducers1() (interface{}, error) {
+func (p *parser) callonAggAssignments1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onReducers1(stack["first"], stack["rest"])
+	return p.cur.onAggAssignments1(stack["first"], stack["rest"])
 }
 
 func (c *current) onSortProc8(l interface{}) (interface{}, error) {
@@ -9051,7 +9051,7 @@ func (p *parser) callonSortProc8() (interface{}, error) {
 
 func (c *current) onSortProc1(args, list interface{}) (interface{}, error) {
 	var argm = args.(map[string]interface{})
-	var proc = map[string]interface{}{"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
+	var proc = map[string]interface{}{"op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false}
 	if _, ok := argm["r"]; ok {
 		proc["sortdir"] = -1
 	}
@@ -9141,12 +9141,12 @@ func (p *parser) callonTopProc18() (interface{}, error) {
 }
 
 func (c *current) onTopProc1(limit, flush, fields interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "TopProc", "limit": 0, "fields": nil, "flush": false}
+	var proc = map[string]interface{}{"op": "Top", "limit": 0, "args": nil, "flush": false}
 	if limit != nil {
 		proc["limit"] = limit
 	}
 	if fields != nil {
-		proc["fields"] = fields
+		proc["args"] = fields
 	}
 	if flush != nil {
 		proc["flush"] = true
@@ -9161,41 +9161,41 @@ func (p *parser) callonTopProc1() (interface{}, error) {
 	return p.cur.onTopProc1(stack["limit"], stack["flush"], stack["fields"])
 }
 
-func (c *current) onCutProc1(columns interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CutProc", "fields": columns}, nil
+func (c *current) onCutProc1(args interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Cut", "args": args}, nil
 
 }
 
 func (p *parser) callonCutProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onCutProc1(stack["columns"])
+	return p.cur.onCutProc1(stack["args"])
 }
 
-func (c *current) onPickProc1(columns interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "PickProc", "fields": columns}, nil
+func (c *current) onPickProc1(args interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Pick", "args": args}, nil
 
 }
 
 func (p *parser) callonPickProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPickProc1(stack["columns"])
+	return p.cur.onPickProc1(stack["args"])
 }
 
-func (c *current) onDropProc1(columns interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "DropProc", "fields": columns}, nil
+func (c *current) onDropProc1(args interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Drop", "args": args}, nil
 
 }
 
 func (p *parser) callonDropProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDropProc1(stack["columns"])
+	return p.cur.onDropProc1(stack["args"])
 }
 
 func (c *current) onHeadProc2(count interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "HeadProc", "count": count}, nil
+	return map[string]interface{}{"op": "Head", "count": count}, nil
 }
 
 func (p *parser) callonHeadProc2() (interface{}, error) {
@@ -9205,7 +9205,7 @@ func (p *parser) callonHeadProc2() (interface{}, error) {
 }
 
 func (c *current) onHeadProc8() (interface{}, error) {
-	return map[string]interface{}{"op": "HeadProc", "count": 1}, nil
+	return map[string]interface{}{"op": "Head", "count": 1}, nil
 }
 
 func (p *parser) callonHeadProc8() (interface{}, error) {
@@ -9215,7 +9215,7 @@ func (p *parser) callonHeadProc8() (interface{}, error) {
 }
 
 func (c *current) onTailProc2(count interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TailProc", "count": count}, nil
+	return map[string]interface{}{"op": "Tail", "count": count}, nil
 }
 
 func (p *parser) callonTailProc2() (interface{}, error) {
@@ -9225,7 +9225,7 @@ func (p *parser) callonTailProc2() (interface{}, error) {
 }
 
 func (c *current) onTailProc8() (interface{}, error) {
-	return map[string]interface{}{"op": "TailProc", "count": 1}, nil
+	return map[string]interface{}{"op": "Tail", "count": 1}, nil
 }
 
 func (p *parser) callonTailProc8() (interface{}, error) {
@@ -9246,7 +9246,7 @@ func (p *parser) callonFilterProc1() (interface{}, error) {
 }
 
 func (c *current) onFilter1(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
+	return map[string]interface{}{"op": "Filter", "expr": expr}, nil
 
 }
 
@@ -9257,7 +9257,7 @@ func (p *parser) callonFilter1() (interface{}, error) {
 }
 
 func (c *current) onUniqProc2() (interface{}, error) {
-	return map[string]interface{}{"op": "UniqProc", "cflag": true}, nil
+	return map[string]interface{}{"op": "Uniq", "cflag": true}, nil
 
 }
 
@@ -9268,7 +9268,7 @@ func (p *parser) callonUniqProc2() (interface{}, error) {
 }
 
 func (c *current) onUniqProc7() (interface{}, error) {
-	return map[string]interface{}{"op": "UniqProc", "cflag": false}, nil
+	return map[string]interface{}{"op": "Uniq", "cflag": false}, nil
 
 }
 
@@ -9278,15 +9278,15 @@ func (p *parser) callonUniqProc7() (interface{}, error) {
 	return p.cur.onUniqProc7()
 }
 
-func (c *current) onPutProc1(columns interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "PutProc", "clauses": columns}, nil
+func (c *current) onPutProc1(args interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Put", "args": args}, nil
 
 }
 
 func (p *parser) callonPutProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPutProc1(stack["columns"])
+	return p.cur.onPutProc1(stack["args"])
 }
 
 func (c *current) onRenameProc9(cl interface{}) (interface{}, error) {
@@ -9300,7 +9300,7 @@ func (p *parser) callonRenameProc9() (interface{}, error) {
 }
 
 func (c *current) onRenameProc1(first, rest interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "RenameProc", "fields": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
+	return map[string]interface{}{"op": "Rename", "args": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
 
 }
 
@@ -9311,7 +9311,7 @@ func (p *parser) callonRenameProc1() (interface{}, error) {
 }
 
 func (c *current) onFuseProc1() (interface{}, error) {
-	return map[string]interface{}{"op": "FuseProc"}, nil
+	return map[string]interface{}{"op": "Fuse"}, nil
 
 }
 
@@ -9322,7 +9322,7 @@ func (p *parser) callonFuseProc1() (interface{}, error) {
 }
 
 func (c *current) onShapeProc1() (interface{}, error) {
-	return map[string]interface{}{"op": "ShapeProc"}, nil
+	return map[string]interface{}{"op": "Shape"}, nil
 
 }
 
@@ -9333,9 +9333,9 @@ func (p *parser) callonShapeProc1() (interface{}, error) {
 }
 
 func (c *current) onJoinProc2(kind, leftKey, rightKey, columns interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "JoinProc", "kind": kind, "left_key": leftKey, "right_key": rightKey, "clauses": nil}
+	var proc = map[string]interface{}{"op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": nil}
 	if columns != nil {
-		proc["clauses"] = columns.([]interface{})[1]
+		proc["args"] = columns.([]interface{})[1]
 	}
 	return proc, nil
 
@@ -9348,9 +9348,9 @@ func (p *parser) callonJoinProc2() (interface{}, error) {
 }
 
 func (c *current) onJoinProc20(kind, key, columns interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "JoinProc", "kind": kind, "left_key": key, "right_key": key, "clauses": nil}
+	var proc = map[string]interface{}{"op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": nil}
 	if columns != nil {
-		proc["clauses"] = columns.([]interface{})[1]
+		proc["args"] = columns.([]interface{})[1]
 	}
 	return proc, nil
 
@@ -9413,25 +9413,25 @@ func (p *parser) callonJoinKey3() (interface{}, error) {
 }
 
 func (c *current) onTasteProc1(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SequentialProc", "procs": []interface{}{
+	return map[string]interface{}{"op": "Sequential", "procs": []interface{}{
 
-		map[string]interface{}{"op": "GroupByProc",
+		map[string]interface{}{"op": "Summarize",
 
 			"keys": []interface{}{map[string]interface{}{"op": "Assignment",
 
-				"lhs": map[string]interface{}{"op": "Identifier", "name": "shape"},
+				"lhs": map[string]interface{}{"op": "Id", "name": "shape"},
 
-				"rhs": map[string]interface{}{"op": "FunctionCall", "function": "typeof",
+				"rhs": map[string]interface{}{"op": "Call", "name": "typeof",
 
 					"args": []interface{}{e}}}},
 
-			"reducers": []interface{}{map[string]interface{}{"op": "Assignment",
+			"aggs": []interface{}{map[string]interface{}{"op": "Assignment",
 
-				"lhs": map[string]interface{}{"op": "Identifier", "name": "taste"},
+				"lhs": map[string]interface{}{"op": "Id", "name": "taste"},
 
-				"rhs": map[string]interface{}{"op": "Reducer",
+				"rhs": map[string]interface{}{"op": "Agg",
 
-					"operator": "any",
+					"name": "any",
 
 					"expr": e,
 
@@ -9439,13 +9439,13 @@ func (c *current) onTasteProc1(e interface{}) (interface{}, error) {
 
 			"duration": nil, "limit": 0},
 
-		map[string]interface{}{"op": "CutProc",
+		map[string]interface{}{"op": "Cut",
 
-			"fields": []interface{}{map[string]interface{}{"op": "Assignment",
+			"args": []interface{}{map[string]interface{}{"op": "Assignment",
 
 				"lhs": nil,
 
-				"rhs": map[string]interface{}{"op": "Identifier", "name": "taste"}}}}}}, nil
+				"rhs": map[string]interface{}{"op": "Id", "name": "taste"}}}}}}, nil
 
 }
 
@@ -9466,7 +9466,7 @@ func (p *parser) callonTasteExpr2() (interface{}, error) {
 }
 
 func (c *current) onTasteExpr7() (interface{}, error) {
-	return map[string]interface{}{"op": "RootRecord"}, nil
+	return map[string]interface{}{"op": "Root"}, nil
 }
 
 func (p *parser) callonTasteExpr7() (interface{}, error) {
@@ -9520,7 +9520,7 @@ func (p *parser) callonAssignment1() (interface{}, error) {
 }
 
 func (c *current) onConditionalExpr2(condition, thenClause, elseClause interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}, nil
+	return map[string]interface{}{"op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}, nil
 
 }
 
@@ -9707,7 +9707,7 @@ func (p *parser) callonMultiplicativeOperator1() (interface{}, error) {
 }
 
 func (c *current) onNotExpr2(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "UnaryExpr", "operator": "!", "operand": e}, nil
+	return map[string]interface{}{"op": "UnaryExpr", "kind": "!", "operand": e}, nil
 
 }
 
@@ -9718,7 +9718,7 @@ func (p *parser) callonNotExpr2() (interface{}, error) {
 }
 
 func (c *current) onCastExpr2(e, typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CastExpr", "expr": e, "type": typ}, nil
+	return map[string]interface{}{"op": "Cast", "expr": e, "type": typ}, nil
 
 }
 
@@ -9791,7 +9791,7 @@ func (p *parser) callonMethod1() (interface{}, error) {
 }
 
 func (c *current) onFunction1(fn, args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FunctionCall", "function": fn, "args": args}, nil
+	return map[string]interface{}{"op": "Call", "name": fn, "args": args}, nil
 
 }
 
@@ -9855,7 +9855,7 @@ func (p *parser) callonDerefExpr9() (interface{}, error) {
 }
 
 func (c *current) onDerefExpr16() (interface{}, error) {
-	return map[string]interface{}{"op": "RootRecord"}, nil
+	return map[string]interface{}{"op": "Root"}, nil
 
 }
 
@@ -9866,9 +9866,9 @@ func (p *parser) callonDerefExpr16() (interface{}, error) {
 }
 
 func (c *current) onDotId2(field interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "operator": ".",
+	return map[string]interface{}{"op": "BinaryExpr", "kind": ".",
 
-		"lhs": map[string]interface{}{"op": "RootRecord"},
+		"lhs": map[string]interface{}{"op": "Root"},
 
 		"rhs": field}, nil
 
@@ -9881,9 +9881,9 @@ func (p *parser) callonDotId2() (interface{}, error) {
 }
 
 func (c *current) onDotId7(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "operator": "[",
+	return map[string]interface{}{"op": "BinaryExpr", "kind": "[",
 
-		"lhs": map[string]interface{}{"op": "RootRecord"},
+		"lhs": map[string]interface{}{"op": "Root"},
 
 		"rhs": expr}, nil
 
@@ -9896,7 +9896,7 @@ func (p *parser) callonDotId7() (interface{}, error) {
 }
 
 func (c *current) onDeref2(from, to interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "operator": ":",
+	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "kind": ":",
 
 		"lhs": from, "rhs": to}}, nil
 
@@ -9909,7 +9909,7 @@ func (p *parser) callonDeref2() (interface{}, error) {
 }
 
 func (c *current) onDeref13(to interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "operator": ":",
+	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "kind": ":",
 
 		"lhs": nil, "rhs": to}}, nil
 
@@ -9922,7 +9922,7 @@ func (p *parser) callonDeref13() (interface{}, error) {
 }
 
 func (c *current) onDeref22(from interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "operator": ":",
+	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "kind": ":",
 
 		"lhs": from, "rhs": nil}}, nil
 
@@ -10083,7 +10083,7 @@ func (p *parser) callonNullLiteral1() (interface{}, error) {
 }
 
 func (c *current) onTypeLiteral1(typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeExpr", "type": typ}, nil
+	return map[string]interface{}{"op": "TypeValue", "value": typ}, nil
 
 }
 
@@ -10347,7 +10347,7 @@ func (p *parser) callonByToken1() (interface{}, error) {
 }
 
 func (c *current) onIdentifier1(id interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Identifier", "name": id}, nil
+	return map[string]interface{}{"op": "Id", "name": id}, nil
 }
 
 func (p *parser) callonIdentifier1() (interface{}, error) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -104,7 +104,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 22, col: 5, offset: 739},
+						pos:  position{line: 22, col: 5, offset: 741},
 						name: "Sequential",
 					},
 				},
@@ -112,22 +112,22 @@ var g = &grammar{
 		},
 		{
 			name: "Const",
-			pos:  position{line: 24, col: 1, offset: 751},
+			pos:  position{line: 24, col: 1, offset: 753},
 			expr: &actionExpr{
-				pos: position{line: 24, col: 9, offset: 759},
+				pos: position{line: 24, col: 9, offset: 761},
 				run: (*parser).callonConst1,
 				expr: &seqExpr{
-					pos: position{line: 24, col: 9, offset: 759},
+					pos: position{line: 24, col: 9, offset: 761},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 24, col: 9, offset: 759},
+							pos:  position{line: 24, col: 9, offset: 761},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 24, col: 12, offset: 762},
+							pos:   position{line: 24, col: 12, offset: 764},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 24, col: 14, offset: 764},
+								pos:  position{line: 24, col: 14, offset: 766},
 								name: "AnyConst",
 							},
 						},
@@ -137,73 +137,73 @@ var g = &grammar{
 		},
 		{
 			name: "AnyConst",
-			pos:  position{line: 26, col: 1, offset: 792},
+			pos:  position{line: 26, col: 1, offset: 794},
 			expr: &choiceExpr{
-				pos: position{line: 27, col: 5, offset: 805},
+				pos: position{line: 27, col: 5, offset: 807},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 27, col: 5, offset: 805},
+						pos: position{line: 27, col: 5, offset: 807},
 						run: (*parser).callonAnyConst2,
 						expr: &seqExpr{
-							pos: position{line: 27, col: 5, offset: 805},
+							pos: position{line: 27, col: 5, offset: 807},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 27, col: 5, offset: 805},
+									pos:        position{line: 27, col: 5, offset: 807},
 									val:        "const",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 13, offset: 813},
+									pos:  position{line: 27, col: 13, offset: 815},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 27, col: 15, offset: 815},
+									pos:   position{line: 27, col: 15, offset: 817},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 27, col: 18, offset: 818},
+										pos:  position{line: 27, col: 18, offset: 820},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 33, offset: 833},
+									pos:  position{line: 27, col: 33, offset: 835},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 27, col: 36, offset: 836},
+									pos:        position{line: 27, col: 36, offset: 838},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 27, col: 40, offset: 840},
+									pos:  position{line: 27, col: 40, offset: 842},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 27, col: 43, offset: 843},
+									pos:   position{line: 27, col: 43, offset: 845},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 27, col: 48, offset: 848},
+										pos:  position{line: 27, col: 48, offset: 850},
 										name: "Expr",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 27, col: 55, offset: 855},
+									pos: position{line: 27, col: 55, offset: 857},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 27, col: 55, offset: 855},
+											pos: position{line: 27, col: 55, offset: 857},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 55, offset: 855},
+													pos:  position{line: 27, col: 55, offset: 857},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 27, col: 58, offset: 858},
+													pos:        position{line: 27, col: 58, offset: 860},
 													val:        ";",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 27, col: 64, offset: 864},
+											pos:  position{line: 27, col: 64, offset: 866},
 											name: "EOL",
 										},
 									},
@@ -212,68 +212,68 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 30, col: 5, offset: 960},
+						pos: position{line: 30, col: 5, offset: 964},
 						run: (*parser).callonAnyConst18,
 						expr: &seqExpr{
-							pos: position{line: 30, col: 5, offset: 960},
+							pos: position{line: 30, col: 5, offset: 964},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 30, col: 5, offset: 960},
+									pos:        position{line: 30, col: 5, offset: 964},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 12, offset: 967},
+									pos:  position{line: 30, col: 12, offset: 971},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 30, col: 14, offset: 969},
+									pos:   position{line: 30, col: 14, offset: 973},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 30, col: 17, offset: 972},
+										pos:  position{line: 30, col: 17, offset: 976},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 32, offset: 987},
+									pos:  position{line: 30, col: 32, offset: 991},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 30, col: 35, offset: 990},
+									pos:        position{line: 30, col: 35, offset: 994},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 30, col: 39, offset: 994},
+									pos:  position{line: 30, col: 39, offset: 998},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 30, col: 42, offset: 997},
+									pos:   position{line: 30, col: 42, offset: 1001},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 30, col: 46, offset: 1001},
+										pos:  position{line: 30, col: 46, offset: 1005},
 										name: "Type",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 30, col: 53, offset: 1008},
+									pos: position{line: 30, col: 53, offset: 1012},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 30, col: 53, offset: 1008},
+											pos: position{line: 30, col: 53, offset: 1012},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 30, col: 53, offset: 1008},
+													pos:  position{line: 30, col: 53, offset: 1012},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 30, col: 56, offset: 1011},
+													pos:        position{line: 30, col: 56, offset: 1015},
 													val:        ";",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 30, col: 62, offset: 1017},
+											pos:  position{line: 30, col: 62, offset: 1021},
 											name: "EOL",
 										},
 									},
@@ -286,31 +286,31 @@ var g = &grammar{
 		},
 		{
 			name: "Sequential",
-			pos:  position{line: 34, col: 1, offset: 1112},
+			pos:  position{line: 34, col: 1, offset: 1118},
 			expr: &choiceExpr{
-				pos: position{line: 35, col: 5, offset: 1127},
+				pos: position{line: 35, col: 5, offset: 1133},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 35, col: 5, offset: 1127},
+						pos: position{line: 35, col: 5, offset: 1133},
 						run: (*parser).callonSequential2,
 						expr: &seqExpr{
-							pos: position{line: 35, col: 5, offset: 1127},
+							pos: position{line: 35, col: 5, offset: 1133},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 35, col: 5, offset: 1127},
+									pos:   position{line: 35, col: 5, offset: 1133},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 35, col: 11, offset: 1133},
+										pos:  position{line: 35, col: 11, offset: 1139},
 										name: "Operation",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 35, col: 21, offset: 1143},
+									pos:   position{line: 35, col: 21, offset: 1149},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 35, col: 26, offset: 1148},
+										pos: position{line: 35, col: 26, offset: 1154},
 										expr: &ruleRefExpr{
-											pos:  position{line: 35, col: 26, offset: 1148},
+											pos:  position{line: 35, col: 26, offset: 1154},
 											name: "SequentialTail",
 										},
 									},
@@ -319,13 +319,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 38, col: 5, offset: 1304},
+						pos: position{line: 38, col: 5, offset: 1312},
 						run: (*parser).callonSequential9,
 						expr: &labeledExpr{
-							pos:   position{line: 38, col: 5, offset: 1304},
+							pos:   position{line: 38, col: 5, offset: 1312},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 38, col: 8, offset: 1307},
+								pos:  position{line: 38, col: 8, offset: 1315},
 								name: "Operation",
 							},
 						},
@@ -335,31 +335,31 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialTail",
-			pos:  position{line: 42, col: 1, offset: 1415},
+			pos:  position{line: 42, col: 1, offset: 1425},
 			expr: &actionExpr{
-				pos: position{line: 42, col: 18, offset: 1432},
+				pos: position{line: 42, col: 18, offset: 1442},
 				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 42, col: 18, offset: 1432},
+					pos: position{line: 42, col: 18, offset: 1442},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 18, offset: 1432},
+							pos:  position{line: 42, col: 18, offset: 1442},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 42, col: 21, offset: 1435},
+							pos:        position{line: 42, col: 21, offset: 1445},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 42, col: 25, offset: 1439},
+							pos:  position{line: 42, col: 25, offset: 1449},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 42, col: 28, offset: 1442},
+							pos:   position{line: 42, col: 28, offset: 1452},
 							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 42, col: 30, offset: 1444},
+								pos:  position{line: 42, col: 30, offset: 1454},
 								name: "Operation",
 							},
 						},
@@ -369,31 +369,31 @@ var g = &grammar{
 		},
 		{
 			name: "Parallel",
-			pos:  position{line: 44, col: 1, offset: 1473},
+			pos:  position{line: 44, col: 1, offset: 1483},
 			expr: &choiceExpr{
-				pos: position{line: 45, col: 5, offset: 1486},
+				pos: position{line: 45, col: 5, offset: 1496},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 45, col: 5, offset: 1486},
+						pos: position{line: 45, col: 5, offset: 1496},
 						run: (*parser).callonParallel2,
 						expr: &seqExpr{
-							pos: position{line: 45, col: 5, offset: 1486},
+							pos: position{line: 45, col: 5, offset: 1496},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 45, col: 5, offset: 1486},
+									pos:   position{line: 45, col: 5, offset: 1496},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 45, col: 11, offset: 1492},
+										pos:  position{line: 45, col: 11, offset: 1502},
 										name: "Sequential",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 45, col: 22, offset: 1503},
+									pos:   position{line: 45, col: 22, offset: 1513},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 45, col: 27, offset: 1508},
+										pos: position{line: 45, col: 27, offset: 1518},
 										expr: &ruleRefExpr{
-											pos:  position{line: 45, col: 27, offset: 1508},
+											pos:  position{line: 45, col: 27, offset: 1518},
 											name: "ParallelTail",
 										},
 									},
@@ -402,13 +402,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 48, col: 5, offset: 1609},
+						pos: position{line: 48, col: 5, offset: 1619},
 						run: (*parser).callonParallel9,
 						expr: &labeledExpr{
-							pos:   position{line: 48, col: 5, offset: 1609},
+							pos:   position{line: 48, col: 5, offset: 1619},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 48, col: 11, offset: 1615},
+								pos:  position{line: 48, col: 11, offset: 1625},
 								name: "Sequential",
 							},
 						},
@@ -418,31 +418,31 @@ var g = &grammar{
 		},
 		{
 			name: "ParallelTail",
-			pos:  position{line: 52, col: 1, offset: 1674},
+			pos:  position{line: 52, col: 1, offset: 1684},
 			expr: &actionExpr{
-				pos: position{line: 53, col: 5, offset: 1691},
+				pos: position{line: 53, col: 5, offset: 1701},
 				run: (*parser).callonParallelTail1,
 				expr: &seqExpr{
-					pos: position{line: 53, col: 5, offset: 1691},
+					pos: position{line: 53, col: 5, offset: 1701},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 53, col: 5, offset: 1691},
+							pos:  position{line: 53, col: 5, offset: 1701},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 53, col: 8, offset: 1694},
+							pos:        position{line: 53, col: 8, offset: 1704},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 53, col: 13, offset: 1699},
+							pos:  position{line: 53, col: 13, offset: 1709},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 53, col: 16, offset: 1702},
+							pos:   position{line: 53, col: 16, offset: 1712},
 							label: "ch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 53, col: 19, offset: 1705},
+								pos:  position{line: 53, col: 19, offset: 1715},
 								name: "Sequential",
 							},
 						},
@@ -452,54 +452,54 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchBranch",
-			pos:  position{line: 55, col: 1, offset: 1736},
+			pos:  position{line: 55, col: 1, offset: 1746},
 			expr: &choiceExpr{
-				pos: position{line: 56, col: 5, offset: 1753},
+				pos: position{line: 56, col: 5, offset: 1763},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 56, col: 5, offset: 1753},
+						pos: position{line: 56, col: 5, offset: 1763},
 						run: (*parser).callonSwitchBranch2,
 						expr: &seqExpr{
-							pos: position{line: 56, col: 5, offset: 1753},
+							pos: position{line: 56, col: 5, offset: 1763},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 5, offset: 1753},
+									pos:  position{line: 56, col: 5, offset: 1763},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 8, offset: 1756},
+									pos:  position{line: 56, col: 8, offset: 1766},
 									name: "CaseToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 18, offset: 1766},
+									pos:  position{line: 56, col: 18, offset: 1776},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 20, offset: 1768},
+									pos:   position{line: 56, col: 20, offset: 1778},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 22, offset: 1770},
+										pos:  position{line: 56, col: 22, offset: 1780},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 36, offset: 1784},
+									pos:  position{line: 56, col: 36, offset: 1794},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 56, col: 39, offset: 1787},
+									pos:        position{line: 56, col: 39, offset: 1797},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 44, offset: 1792},
+									pos:  position{line: 56, col: 44, offset: 1802},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 47, offset: 1795},
+									pos:   position{line: 56, col: 47, offset: 1805},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 52, offset: 1800},
+										pos:  position{line: 56, col: 52, offset: 1810},
 										name: "Sequential",
 									},
 								},
@@ -507,37 +507,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 59, col: 5, offset: 1889},
+						pos: position{line: 59, col: 5, offset: 1899},
 						run: (*parser).callonSwitchBranch14,
 						expr: &seqExpr{
-							pos: position{line: 59, col: 5, offset: 1889},
+							pos: position{line: 59, col: 5, offset: 1899},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 5, offset: 1889},
+									pos:  position{line: 59, col: 5, offset: 1899},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 8, offset: 1892},
+									pos:  position{line: 59, col: 8, offset: 1902},
 									name: "DefaultToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 21, offset: 1905},
+									pos:  position{line: 59, col: 21, offset: 1915},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 59, col: 24, offset: 1908},
+									pos:        position{line: 59, col: 24, offset: 1918},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 29, offset: 1913},
+									pos:  position{line: 59, col: 29, offset: 1923},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 59, col: 32, offset: 1916},
+									pos:   position{line: 59, col: 32, offset: 1926},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 59, col: 37, offset: 1921},
+										pos:  position{line: 59, col: 37, offset: 1931},
 										name: "Sequential",
 									},
 								},
@@ -549,31 +549,31 @@ var g = &grammar{
 		},
 		{
 			name: "Switch",
-			pos:  position{line: 63, col: 1, offset: 2078},
+			pos:  position{line: 63, col: 1, offset: 2090},
 			expr: &choiceExpr{
-				pos: position{line: 64, col: 5, offset: 2089},
+				pos: position{line: 64, col: 5, offset: 2101},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 64, col: 5, offset: 2089},
+						pos: position{line: 64, col: 5, offset: 2101},
 						run: (*parser).callonSwitch2,
 						expr: &seqExpr{
-							pos: position{line: 64, col: 5, offset: 2089},
+							pos: position{line: 64, col: 5, offset: 2101},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 64, col: 5, offset: 2089},
+									pos:   position{line: 64, col: 5, offset: 2101},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 64, col: 11, offset: 2095},
+										pos:  position{line: 64, col: 11, offset: 2107},
 										name: "SwitchBranch",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 64, col: 24, offset: 2108},
+									pos:   position{line: 64, col: 24, offset: 2120},
 									label: "rest",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 64, col: 29, offset: 2113},
+										pos: position{line: 64, col: 29, offset: 2125},
 										expr: &ruleRefExpr{
-											pos:  position{line: 64, col: 29, offset: 2113},
+											pos:  position{line: 64, col: 29, offset: 2125},
 											name: "SwitchBranch",
 										},
 									},
@@ -582,13 +582,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 67, col: 5, offset: 2214},
+						pos: position{line: 67, col: 5, offset: 2226},
 						run: (*parser).callonSwitch9,
 						expr: &labeledExpr{
-							pos:   position{line: 67, col: 5, offset: 2214},
+							pos:   position{line: 67, col: 5, offset: 2226},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 67, col: 11, offset: 2220},
+								pos:  position{line: 67, col: 11, offset: 2232},
 								name: "SwitchBranch",
 							},
 						},
@@ -598,75 +598,75 @@ var g = &grammar{
 		},
 		{
 			name: "CaseToken",
-			pos:  position{line: 71, col: 1, offset: 2281},
+			pos:  position{line: 71, col: 1, offset: 2293},
 			expr: &litMatcher{
-				pos:        position{line: 71, col: 13, offset: 2293},
+				pos:        position{line: 71, col: 13, offset: 2305},
 				val:        "case",
 				ignoreCase: true,
 			},
 		},
 		{
 			name: "DefaultToken",
-			pos:  position{line: 72, col: 1, offset: 2301},
+			pos:  position{line: 72, col: 1, offset: 2313},
 			expr: &litMatcher{
-				pos:        position{line: 72, col: 16, offset: 2316},
+				pos:        position{line: 72, col: 16, offset: 2328},
 				val:        "default",
 				ignoreCase: true,
 			},
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 74, col: 1, offset: 2328},
+			pos:  position{line: 74, col: 1, offset: 2340},
 			expr: &choiceExpr{
-				pos: position{line: 75, col: 5, offset: 2342},
+				pos: position{line: 75, col: 5, offset: 2354},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 75, col: 5, offset: 2342},
+						pos: position{line: 75, col: 5, offset: 2354},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 75, col: 5, offset: 2342},
+							pos: position{line: 75, col: 5, offset: 2354},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 75, col: 5, offset: 2342},
+									pos:        position{line: 75, col: 5, offset: 2354},
 									val:        "split",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 13, offset: 2350},
+									pos:  position{line: 75, col: 13, offset: 2362},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 16, offset: 2353},
+									pos:        position{line: 75, col: 16, offset: 2365},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 20, offset: 2357},
+									pos:  position{line: 75, col: 20, offset: 2369},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 23, offset: 2360},
+									pos:        position{line: 75, col: 23, offset: 2372},
 									val:        "=>",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 28, offset: 2365},
+									pos:  position{line: 75, col: 28, offset: 2377},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 75, col: 31, offset: 2368},
+									pos:   position{line: 75, col: 31, offset: 2380},
 									label: "procArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 75, col: 41, offset: 2378},
+										pos:  position{line: 75, col: 41, offset: 2390},
 										name: "Parallel",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 50, offset: 2387},
+									pos:  position{line: 75, col: 50, offset: 2399},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 75, col: 53, offset: 2390},
+									pos:        position{line: 75, col: 53, offset: 2402},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -674,43 +674,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 78, col: 5, offset: 2485},
+						pos: position{line: 78, col: 5, offset: 2499},
 						run: (*parser).callonOperation14,
 						expr: &seqExpr{
-							pos: position{line: 78, col: 5, offset: 2485},
+							pos: position{line: 78, col: 5, offset: 2499},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 78, col: 5, offset: 2485},
+									pos:        position{line: 78, col: 5, offset: 2499},
 									val:        "switch",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 14, offset: 2494},
+									pos:  position{line: 78, col: 14, offset: 2508},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 78, col: 17, offset: 2497},
+									pos:        position{line: 78, col: 17, offset: 2511},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 21, offset: 2501},
+									pos:  position{line: 78, col: 21, offset: 2515},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 78, col: 24, offset: 2504},
+									pos:   position{line: 78, col: 24, offset: 2518},
 									label: "caseArray",
 									expr: &ruleRefExpr{
-										pos:  position{line: 78, col: 34, offset: 2514},
+										pos:  position{line: 78, col: 34, offset: 2528},
 										name: "Switch",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 78, col: 41, offset: 2521},
+									pos:  position{line: 78, col: 41, offset: 2535},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 78, col: 44, offset: 2524},
+									pos:        position{line: 78, col: 44, offset: 2538},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -718,27 +718,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 81, col: 5, offset: 2617},
+						pos:  position{line: 81, col: 5, offset: 2633},
 						name: "Operator",
 					},
 					&actionExpr{
-						pos: position{line: 82, col: 5, offset: 2630},
+						pos: position{line: 82, col: 5, offset: 2646},
 						run: (*parser).callonOperation25,
 						expr: &seqExpr{
-							pos: position{line: 82, col: 5, offset: 2630},
+							pos: position{line: 82, col: 5, offset: 2646},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 82, col: 5, offset: 2630},
+									pos:   position{line: 82, col: 5, offset: 2646},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 7, offset: 2632},
+										pos:  position{line: 82, col: 7, offset: 2648},
 										name: "Function",
 									},
 								},
 								&andExpr{
-									pos: position{line: 82, col: 16, offset: 2641},
+									pos: position{line: 82, col: 16, offset: 2657},
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 17, offset: 2642},
+										pos:  position{line: 82, col: 17, offset: 2658},
 										name: "EndOfOp",
 									},
 								},
@@ -746,23 +746,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 83, col: 5, offset: 2672},
+						pos: position{line: 83, col: 5, offset: 2688},
 						run: (*parser).callonOperation31,
 						expr: &seqExpr{
-							pos: position{line: 83, col: 5, offset: 2672},
+							pos: position{line: 83, col: 5, offset: 2688},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 83, col: 5, offset: 2672},
+									pos:   position{line: 83, col: 5, offset: 2688},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 7, offset: 2674},
+										pos:  position{line: 83, col: 7, offset: 2690},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 83, col: 19, offset: 2686},
+									pos: position{line: 83, col: 19, offset: 2702},
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 20, offset: 2687},
+										pos:  position{line: 83, col: 20, offset: 2703},
 										name: "EndOfOp",
 									},
 								},
@@ -770,23 +770,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 84, col: 5, offset: 2718},
+						pos: position{line: 84, col: 5, offset: 2734},
 						run: (*parser).callonOperation37,
 						expr: &seqExpr{
-							pos: position{line: 84, col: 5, offset: 2718},
+							pos: position{line: 84, col: 5, offset: 2734},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 84, col: 5, offset: 2718},
+									pos:   position{line: 84, col: 5, offset: 2734},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 10, offset: 2723},
+										pos:  position{line: 84, col: 10, offset: 2739},
 										name: "SearchBoolean",
 									},
 								},
 								&notExpr{
-									pos: position{line: 84, col: 24, offset: 2737},
+									pos: position{line: 84, col: 24, offset: 2753},
 									expr: &ruleRefExpr{
-										pos:  position{line: 84, col: 25, offset: 2738},
+										pos:  position{line: 84, col: 25, offset: 2754},
 										name: "AggGuard",
 									},
 								},
@@ -798,34 +798,34 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 88, col: 1, offset: 2827},
+			pos:  position{line: 88, col: 1, offset: 2845},
 			expr: &seqExpr{
-				pos: position{line: 88, col: 11, offset: 2837},
+				pos: position{line: 88, col: 11, offset: 2855},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 88, col: 11, offset: 2837},
+						pos:  position{line: 88, col: 11, offset: 2855},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 88, col: 15, offset: 2841},
+						pos: position{line: 88, col: 15, offset: 2859},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 88, col: 15, offset: 2841},
+								pos:        position{line: 88, col: 15, offset: 2859},
 								val:        "|",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 88, col: 21, offset: 2847},
+								pos:        position{line: 88, col: 21, offset: 2865},
 								val:        "=>",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 88, col: 28, offset: 2854},
+								pos:        position{line: 88, col: 28, offset: 2872},
 								val:        ")",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 88, col: 34, offset: 2860},
+								pos:  position{line: 88, col: 34, offset: 2878},
 								name: "EOF",
 							},
 						},
@@ -835,49 +835,49 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 90, col: 1, offset: 2866},
+			pos:  position{line: 90, col: 1, offset: 2884},
 			expr: &seqExpr{
-				pos: position{line: 90, col: 13, offset: 2878},
+				pos: position{line: 90, col: 13, offset: 2896},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 90, col: 13, offset: 2878},
+						pos:  position{line: 90, col: 13, offset: 2896},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 90, col: 17, offset: 2882},
+						pos: position{line: 90, col: 17, offset: 2900},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 90, col: 18, offset: 2883},
+								pos: position{line: 90, col: 18, offset: 2901},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 90, col: 18, offset: 2883},
+										pos: position{line: 90, col: 18, offset: 2901},
 										expr: &litMatcher{
-											pos:        position{line: 90, col: 19, offset: 2884},
+											pos:        position{line: 90, col: 19, offset: 2902},
 											val:        "=>",
 											ignoreCase: false,
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 90, col: 24, offset: 2889},
+										pos:  position{line: 90, col: 24, offset: 2907},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 90, col: 38, offset: 2903},
+								pos:  position{line: 90, col: 38, offset: 2921},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 90, col: 57, offset: 2922},
+								pos:  position{line: 90, col: 57, offset: 2940},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 90, col: 82, offset: 2947},
+								pos:        position{line: 90, col: 82, offset: 2965},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 90, col: 88, offset: 2953},
+								pos:        position{line: 90, col: 88, offset: 2971},
 								val:        "(",
 								ignoreCase: false,
 							},
@@ -888,46 +888,46 @@ var g = &grammar{
 		},
 		{
 			name: "AggGuard",
-			pos:  position{line: 92, col: 1, offset: 2959},
+			pos:  position{line: 92, col: 1, offset: 2977},
 			expr: &choiceExpr{
-				pos: position{line: 92, col: 12, offset: 2970},
+				pos: position{line: 92, col: 12, offset: 2988},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 92, col: 13, offset: 2971},
+						pos: position{line: 92, col: 13, offset: 2989},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 13, offset: 2971},
+								pos:  position{line: 92, col: 13, offset: 2989},
 								name: "_",
 							},
 							&choiceExpr{
-								pos: position{line: 92, col: 16, offset: 2974},
+								pos: position{line: 92, col: 16, offset: 2992},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 92, col: 16, offset: 2974},
+										pos:  position{line: 92, col: 16, offset: 2992},
 										name: "ByToken",
 									},
 									&litMatcher{
-										pos:        position{line: 92, col: 26, offset: 2984},
+										pos:        position{line: 92, col: 26, offset: 3002},
 										val:        "-with",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 35, offset: 2993},
+								pos:  position{line: 92, col: 35, offset: 3011},
 								name: "EOT",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 92, col: 43, offset: 3001},
+						pos: position{line: 92, col: 43, offset: 3019},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 92, col: 43, offset: 3001},
+								pos:  position{line: 92, col: 43, offset: 3019},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 92, col: 46, offset: 3004},
+								pos:        position{line: 92, col: 46, offset: 3022},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -938,28 +938,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 94, col: 1, offset: 3010},
+			pos:  position{line: 94, col: 1, offset: 3028},
 			expr: &actionExpr{
-				pos: position{line: 95, col: 5, offset: 3028},
+				pos: position{line: 95, col: 5, offset: 3046},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 95, col: 5, offset: 3028},
+					pos: position{line: 95, col: 5, offset: 3046},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 95, col: 5, offset: 3028},
+							pos:   position{line: 95, col: 5, offset: 3046},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 95, col: 11, offset: 3034},
+								pos:  position{line: 95, col: 11, offset: 3052},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 95, col: 21, offset: 3044},
+							pos:   position{line: 95, col: 21, offset: 3062},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 95, col: 26, offset: 3049},
+								pos: position{line: 95, col: 26, offset: 3067},
 								expr: &ruleRefExpr{
-									pos:  position{line: 95, col: 26, offset: 3049},
+									pos:  position{line: 95, col: 26, offset: 3067},
 									name: "SearchOrTerm",
 								},
 							},
@@ -970,30 +970,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 99, col: 1, offset: 3123},
+			pos:  position{line: 99, col: 1, offset: 3141},
 			expr: &actionExpr{
-				pos: position{line: 99, col: 16, offset: 3138},
+				pos: position{line: 99, col: 16, offset: 3156},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 99, col: 16, offset: 3138},
+					pos: position{line: 99, col: 16, offset: 3156},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 16, offset: 3138},
+							pos:  position{line: 99, col: 16, offset: 3156},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 18, offset: 3140},
+							pos:  position{line: 99, col: 18, offset: 3158},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 99, col: 26, offset: 3148},
+							pos:  position{line: 99, col: 26, offset: 3166},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 99, col: 28, offset: 3150},
+							pos:   position{line: 99, col: 28, offset: 3168},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 99, col: 30, offset: 3152},
+								pos:  position{line: 99, col: 30, offset: 3170},
 								name: "SearchAnd",
 							},
 						},
@@ -1003,61 +1003,61 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 101, col: 1, offset: 3202},
+			pos:  position{line: 101, col: 1, offset: 3220},
 			expr: &actionExpr{
-				pos: position{line: 102, col: 5, offset: 3216},
+				pos: position{line: 102, col: 5, offset: 3234},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 102, col: 5, offset: 3216},
+					pos: position{line: 102, col: 5, offset: 3234},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 102, col: 5, offset: 3216},
+							pos:   position{line: 102, col: 5, offset: 3234},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 102, col: 11, offset: 3222},
+								pos:  position{line: 102, col: 11, offset: 3240},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 103, col: 5, offset: 3239},
+							pos:   position{line: 103, col: 5, offset: 3257},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 103, col: 10, offset: 3244},
+								pos: position{line: 103, col: 10, offset: 3262},
 								expr: &actionExpr{
-									pos: position{line: 103, col: 11, offset: 3245},
+									pos: position{line: 103, col: 11, offset: 3263},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 103, col: 11, offset: 3245},
+										pos: position{line: 103, col: 11, offset: 3263},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 103, col: 11, offset: 3245},
+												pos:  position{line: 103, col: 11, offset: 3263},
 												name: "__",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 103, col: 14, offset: 3248},
+												pos: position{line: 103, col: 14, offset: 3266},
 												expr: &seqExpr{
-													pos: position{line: 103, col: 15, offset: 3249},
+													pos: position{line: 103, col: 15, offset: 3267},
 													exprs: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 103, col: 15, offset: 3249},
+															pos:  position{line: 103, col: 15, offset: 3267},
 															name: "AndToken",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 103, col: 24, offset: 3258},
+															pos:  position{line: 103, col: 24, offset: 3276},
 															name: "_",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 103, col: 28, offset: 3262},
+												pos:  position{line: 103, col: 28, offset: 3280},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 103, col: 31, offset: 3265},
+												pos:   position{line: 103, col: 31, offset: 3283},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 103, col: 36, offset: 3270},
+													pos:  position{line: 103, col: 36, offset: 3288},
 													name: "SearchFactor",
 												},
 											},
@@ -1072,42 +1072,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 107, col: 1, offset: 3386},
+			pos:  position{line: 107, col: 1, offset: 3404},
 			expr: &choiceExpr{
-				pos: position{line: 108, col: 5, offset: 3403},
+				pos: position{line: 108, col: 5, offset: 3421},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 108, col: 5, offset: 3403},
+						pos: position{line: 108, col: 5, offset: 3421},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 108, col: 5, offset: 3403},
+							pos: position{line: 108, col: 5, offset: 3421},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 108, col: 6, offset: 3404},
+									pos: position{line: 108, col: 6, offset: 3422},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 108, col: 6, offset: 3404},
+											pos: position{line: 108, col: 6, offset: 3422},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 6, offset: 3404},
+													pos:  position{line: 108, col: 6, offset: 3422},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 15, offset: 3413},
+													pos:  position{line: 108, col: 15, offset: 3431},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 108, col: 19, offset: 3417},
+											pos: position{line: 108, col: 19, offset: 3435},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 108, col: 19, offset: 3417},
+													pos:        position{line: 108, col: 19, offset: 3435},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 108, col: 23, offset: 3421},
+													pos:  position{line: 108, col: 23, offset: 3439},
 													name: "__",
 												},
 											},
@@ -1115,10 +1115,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 108, col: 27, offset: 3425},
+									pos:   position{line: 108, col: 27, offset: 3443},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 108, col: 29, offset: 3427},
+										pos:  position{line: 108, col: 29, offset: 3445},
 										name: "SearchFactor",
 									},
 								},
@@ -1126,42 +1126,42 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 111, col: 5, offset: 3539},
+						pos:  position{line: 111, col: 5, offset: 3557},
 						name: "ShortCut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 112, col: 5, offset: 3552},
+						pos:  position{line: 112, col: 5, offset: 3570},
 						name: "SearchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 113, col: 5, offset: 3567},
+						pos: position{line: 113, col: 5, offset: 3585},
 						run: (*parser).callonSearchFactor15,
 						expr: &seqExpr{
-							pos: position{line: 113, col: 5, offset: 3567},
+							pos: position{line: 113, col: 5, offset: 3585},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 113, col: 5, offset: 3567},
+									pos:        position{line: 113, col: 5, offset: 3585},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 113, col: 9, offset: 3571},
+									pos:  position{line: 113, col: 9, offset: 3589},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 113, col: 12, offset: 3574},
+									pos:   position{line: 113, col: 12, offset: 3592},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 17, offset: 3579},
+										pos:  position{line: 113, col: 17, offset: 3597},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 113, col: 31, offset: 3593},
+									pos:  position{line: 113, col: 31, offset: 3611},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 113, col: 34, offset: 3596},
+									pos:        position{line: 113, col: 34, offset: 3614},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1173,42 +1173,42 @@ var g = &grammar{
 		},
 		{
 			name: "ShortCut",
-			pos:  position{line: 115, col: 1, offset: 3622},
+			pos:  position{line: 115, col: 1, offset: 3640},
 			expr: &choiceExpr{
-				pos: position{line: 116, col: 5, offset: 3635},
+				pos: position{line: 116, col: 5, offset: 3653},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 116, col: 5, offset: 3635},
+						pos: position{line: 116, col: 5, offset: 3653},
 						run: (*parser).callonShortCut2,
 						expr: &seqExpr{
-							pos: position{line: 116, col: 5, offset: 3635},
+							pos: position{line: 116, col: 5, offset: 3653},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 116, col: 5, offset: 3635},
+									pos:        position{line: 116, col: 5, offset: 3653},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 116, col: 9, offset: 3639},
+									pos:  position{line: 116, col: 9, offset: 3657},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 12, offset: 3642},
+									pos:   position{line: 116, col: 12, offset: 3660},
 									label: "compareOp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 22, offset: 3652},
+										pos:  position{line: 116, col: 22, offset: 3670},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 116, col: 36, offset: 3666},
+									pos:  position{line: 116, col: 36, offset: 3684},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 39, offset: 3669},
+									pos:   position{line: 116, col: 39, offset: 3687},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 41, offset: 3671},
+										pos:  position{line: 116, col: 41, offset: 3689},
 										name: "SearchValue",
 									},
 								},
@@ -1216,47 +1216,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 143, col: 5, offset: 4350},
+						pos: position{line: 143, col: 5, offset: 4378},
 						run: (*parser).callonShortCut11,
 						expr: &seqExpr{
-							pos: position{line: 143, col: 5, offset: 4350},
+							pos: position{line: 143, col: 5, offset: 4378},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 143, col: 5, offset: 4350},
+									pos:   position{line: 143, col: 5, offset: 4378},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 7, offset: 4352},
+										pos:  position{line: 143, col: 7, offset: 4380},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 12, offset: 4357},
+									pos:  position{line: 143, col: 12, offset: 4385},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 15, offset: 4360},
+									pos:   position{line: 143, col: 15, offset: 4388},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 20, offset: 4365},
+										pos:  position{line: 143, col: 20, offset: 4393},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 143, col: 34, offset: 4379},
+									pos:  position{line: 143, col: 34, offset: 4407},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 143, col: 37, offset: 4382},
+									pos:   position{line: 143, col: 37, offset: 4410},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 39, offset: 4384},
+										pos:  position{line: 143, col: 39, offset: 4412},
 										name: "GlobbySearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 143, col: 57, offset: 4402},
+									pos: position{line: 143, col: 57, offset: 4430},
 									expr: &ruleRefExpr{
-										pos:  position{line: 143, col: 58, offset: 4403},
+										pos:  position{line: 143, col: 58, offset: 4431},
 										name: "ExprGuard",
 									},
 								},
@@ -1264,33 +1264,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 146, col: 5, offset: 4517},
+						pos: position{line: 146, col: 5, offset: 4545},
 						run: (*parser).callonShortCut23,
 						expr: &seqExpr{
-							pos: position{line: 146, col: 5, offset: 4517},
+							pos: position{line: 146, col: 5, offset: 4545},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 146, col: 5, offset: 4517},
+									pos:   position{line: 146, col: 5, offset: 4545},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 7, offset: 4519},
+										pos:  position{line: 146, col: 7, offset: 4547},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 19, offset: 4531},
+									pos:  position{line: 146, col: 19, offset: 4559},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 21, offset: 4533},
+									pos:  position{line: 146, col: 21, offset: 4561},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 29, offset: 4541},
+									pos:  position{line: 146, col: 29, offset: 4569},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 146, col: 31, offset: 4543},
+									pos:        position{line: 146, col: 31, offset: 4571},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1298,39 +1298,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 173, col: 5, offset: 5215},
+						pos: position{line: 173, col: 5, offset: 5253},
 						run: (*parser).callonShortCut31,
 						expr: &seqExpr{
-							pos: position{line: 173, col: 5, offset: 5215},
+							pos: position{line: 173, col: 5, offset: 5253},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 173, col: 5, offset: 5215},
+									pos: position{line: 173, col: 5, offset: 5253},
 									expr: &seqExpr{
-										pos: position{line: 173, col: 7, offset: 5217},
+										pos: position{line: 173, col: 7, offset: 5255},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 173, col: 7, offset: 5217},
+												pos:  position{line: 173, col: 7, offset: 5255},
 												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 173, col: 19, offset: 5229},
+												pos:  position{line: 173, col: 19, offset: 5267},
 												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 173, col: 24, offset: 5234},
+									pos:   position{line: 173, col: 24, offset: 5272},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 173, col: 26, offset: 5236},
+										pos:  position{line: 173, col: 26, offset: 5274},
 										name: "GlobbySearchValue",
 									},
 								},
 								&notExpr{
-									pos: position{line: 173, col: 44, offset: 5254},
+									pos: position{line: 173, col: 44, offset: 5292},
 									expr: &ruleRefExpr{
-										pos:  position{line: 173, col: 45, offset: 5255},
+										pos:  position{line: 173, col: 45, offset: 5293},
 										name: "ExprGuard",
 									},
 								},
@@ -1338,20 +1338,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 5370},
+						pos: position{line: 176, col: 5, offset: 5410},
 						run: (*parser).callonShortCut41,
 						expr: &seqExpr{
-							pos: position{line: 176, col: 5, offset: 5370},
+							pos: position{line: 176, col: 5, offset: 5410},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 176, col: 5, offset: 5370},
+									pos:        position{line: 176, col: 5, offset: 5410},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 176, col: 9, offset: 5374},
+									pos: position{line: 176, col: 9, offset: 5414},
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 10, offset: 5375},
+										pos:  position{line: 176, col: 10, offset: 5415},
 										name: "ExprGuard",
 									},
 								},
@@ -1363,22 +1363,22 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 180, col: 1, offset: 5485},
+			pos:  position{line: 180, col: 1, offset: 5527},
 			expr: &choiceExpr{
-				pos: position{line: 181, col: 5, offset: 5501},
+				pos: position{line: 181, col: 5, offset: 5543},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 181, col: 5, offset: 5501},
+						pos:  position{line: 181, col: 5, offset: 5543},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 182, col: 5, offset: 5513},
+						pos: position{line: 182, col: 5, offset: 5555},
 						run: (*parser).callonSearchValue3,
 						expr: &labeledExpr{
-							pos:   position{line: 182, col: 5, offset: 5513},
+							pos:   position{line: 182, col: 5, offset: 5555},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 182, col: 7, offset: 5515},
+								pos:  position{line: 182, col: 7, offset: 5557},
 								name: "KeyWord",
 							},
 						},
@@ -1388,22 +1388,22 @@ var g = &grammar{
 		},
 		{
 			name: "GlobbySearchValue",
-			pos:  position{line: 186, col: 1, offset: 5620},
+			pos:  position{line: 186, col: 1, offset: 5664},
 			expr: &choiceExpr{
-				pos: position{line: 187, col: 5, offset: 5642},
+				pos: position{line: 187, col: 5, offset: 5686},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 187, col: 5, offset: 5642},
+						pos:  position{line: 187, col: 5, offset: 5686},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 188, col: 5, offset: 5654},
+						pos: position{line: 188, col: 5, offset: 5698},
 						run: (*parser).callonGlobbySearchValue3,
 						expr: &labeledExpr{
-							pos:   position{line: 188, col: 5, offset: 5654},
+							pos:   position{line: 188, col: 5, offset: 5698},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 7, offset: 5656},
+								pos:  position{line: 188, col: 7, offset: 5700},
 								name: "SearchGlob",
 							},
 						},
@@ -1413,31 +1413,31 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGlob",
-			pos:  position{line: 198, col: 1, offset: 5942},
+			pos:  position{line: 198, col: 1, offset: 5988},
 			expr: &actionExpr{
-				pos: position{line: 199, col: 5, offset: 5957},
+				pos: position{line: 199, col: 5, offset: 6003},
 				run: (*parser).callonSearchGlob1,
 				expr: &seqExpr{
-					pos: position{line: 199, col: 5, offset: 5957},
+					pos: position{line: 199, col: 5, offset: 6003},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 199, col: 5, offset: 5957},
+							pos:   position{line: 199, col: 5, offset: 6003},
 							label: "head",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 199, col: 10, offset: 5962},
+								pos: position{line: 199, col: 10, offset: 6008},
 								expr: &ruleRefExpr{
-									pos:  position{line: 199, col: 10, offset: 5962},
+									pos:  position{line: 199, col: 10, offset: 6008},
 									name: "GlobPart",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 199, col: 20, offset: 5972},
+							pos:   position{line: 199, col: 20, offset: 6018},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 199, col: 25, offset: 5977},
+								pos: position{line: 199, col: 25, offset: 6023},
 								expr: &litMatcher{
-									pos:        position{line: 199, col: 26, offset: 5978},
+									pos:        position{line: 199, col: 26, offset: 6024},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -1449,29 +1449,29 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPart",
-			pos:  position{line: 203, col: 1, offset: 6045},
+			pos:  position{line: 203, col: 1, offset: 6091},
 			expr: &choiceExpr{
-				pos: position{line: 204, col: 5, offset: 6058},
+				pos: position{line: 204, col: 5, offset: 6104},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 204, col: 5, offset: 6058},
+						pos: position{line: 204, col: 5, offset: 6104},
 						run: (*parser).callonGlobPart2,
 						expr: &seqExpr{
-							pos: position{line: 204, col: 5, offset: 6058},
+							pos: position{line: 204, col: 5, offset: 6104},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 204, col: 5, offset: 6058},
+									pos:   position{line: 204, col: 5, offset: 6104},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 204, col: 7, offset: 6060},
+										pos:  position{line: 204, col: 7, offset: 6106},
 										name: "Stars",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 204, col: 13, offset: 6066},
+									pos:   position{line: 204, col: 13, offset: 6112},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 204, col: 15, offset: 6068},
+										pos:  position{line: 204, col: 15, offset: 6114},
 										name: "KeyWord",
 									},
 								},
@@ -1479,7 +1479,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 5, offset: 6118},
+						pos:  position{line: 205, col: 5, offset: 6164},
 						name: "KeyWord",
 					},
 				},
@@ -1487,14 +1487,14 @@ var g = &grammar{
 		},
 		{
 			name: "Stars",
-			pos:  position{line: 207, col: 1, offset: 6127},
+			pos:  position{line: 207, col: 1, offset: 6173},
 			expr: &actionExpr{
-				pos: position{line: 207, col: 9, offset: 6135},
+				pos: position{line: 207, col: 9, offset: 6181},
 				run: (*parser).callonStars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 207, col: 9, offset: 6135},
+					pos: position{line: 207, col: 9, offset: 6181},
 					expr: &litMatcher{
-						pos:        position{line: 207, col: 9, offset: 6135},
+						pos:        position{line: 207, col: 9, offset: 6181},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -1503,40 +1503,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchGuard",
-			pos:  position{line: 209, col: 1, offset: 6172},
+			pos:  position{line: 209, col: 1, offset: 6218},
 			expr: &choiceExpr{
-				pos: position{line: 210, col: 5, offset: 6188},
+				pos: position{line: 210, col: 5, offset: 6234},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 210, col: 5, offset: 6188},
+						pos:  position{line: 210, col: 5, offset: 6234},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 211, col: 5, offset: 6201},
+						pos:  position{line: 211, col: 5, offset: 6247},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 212, col: 5, offset: 6213},
+						pos:  position{line: 212, col: 5, offset: 6259},
 						name: "NotToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 213, col: 5, offset: 6226},
+						pos:  position{line: 213, col: 5, offset: 6272},
 						name: "InToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 214, col: 5, offset: 6238},
+						pos:  position{line: 214, col: 5, offset: 6284},
 						name: "ByToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 215, col: 5, offset: 6250},
+						pos:  position{line: 215, col: 5, offset: 6296},
 						name: "CaseToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 216, col: 5, offset: 6264},
+						pos:  position{line: 216, col: 5, offset: 6310},
 						name: "DefaultToken",
 					},
 					&litMatcher{
-						pos:        position{line: 217, col: 5, offset: 6281},
+						pos:        position{line: 217, col: 5, offset: 6327},
 						val:        "type(",
 						ignoreCase: false,
 					},
@@ -1545,53 +1545,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 221, col: 1, offset: 6338},
+			pos:  position{line: 221, col: 1, offset: 6384},
 			expr: &ruleRefExpr{
-				pos:  position{line: 221, col: 14, offset: 6351},
+				pos:  position{line: 221, col: 14, offset: 6397},
 				name: "SearchExprRelative",
 			},
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 223, col: 1, offset: 6371},
+			pos:  position{line: 223, col: 1, offset: 6417},
 			expr: &actionExpr{
-				pos: position{line: 223, col: 14, offset: 6384},
+				pos: position{line: 223, col: 14, offset: 6430},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 223, col: 15, offset: 6385},
+					pos: position{line: 223, col: 15, offset: 6431},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 223, col: 15, offset: 6385},
+							pos:        position{line: 223, col: 15, offset: 6431},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 21, offset: 6391},
+							pos:        position{line: 223, col: 21, offset: 6437},
 							val:        "!=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 28, offset: 6398},
+							pos:        position{line: 223, col: 28, offset: 6444},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 35, offset: 6405},
+							pos:        position{line: 223, col: 35, offset: 6451},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 42, offset: 6412},
+							pos:        position{line: 223, col: 42, offset: 6458},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 48, offset: 6418},
+							pos:        position{line: 223, col: 48, offset: 6464},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 55, offset: 6425},
+							pos:        position{line: 223, col: 55, offset: 6471},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1601,53 +1601,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprRelative",
-			pos:  position{line: 225, col: 1, offset: 6462},
+			pos:  position{line: 225, col: 1, offset: 6508},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 6485},
+				pos: position{line: 226, col: 5, offset: 6531},
 				run: (*parser).callonSearchExprRelative1,
 				expr: &seqExpr{
-					pos: position{line: 226, col: 5, offset: 6485},
+					pos: position{line: 226, col: 5, offset: 6531},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 6485},
+							pos:   position{line: 226, col: 5, offset: 6531},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 226, col: 11, offset: 6491},
+								pos:  position{line: 226, col: 11, offset: 6537},
 								name: "SearchExprAdd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 227, col: 5, offset: 6509},
+							pos:   position{line: 227, col: 5, offset: 6555},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 227, col: 10, offset: 6514},
+								pos: position{line: 227, col: 10, offset: 6560},
 								expr: &actionExpr{
-									pos: position{line: 227, col: 11, offset: 6515},
+									pos: position{line: 227, col: 11, offset: 6561},
 									run: (*parser).callonSearchExprRelative7,
 									expr: &seqExpr{
-										pos: position{line: 227, col: 11, offset: 6515},
+										pos: position{line: 227, col: 11, offset: 6561},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 227, col: 11, offset: 6515},
+												pos:  position{line: 227, col: 11, offset: 6561},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 227, col: 14, offset: 6518},
+												pos:   position{line: 227, col: 14, offset: 6564},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 227, col: 17, offset: 6521},
+													pos:  position{line: 227, col: 17, offset: 6567},
 													name: "Comparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 227, col: 28, offset: 6532},
+												pos:  position{line: 227, col: 28, offset: 6578},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 227, col: 31, offset: 6535},
+												pos:   position{line: 227, col: 31, offset: 6581},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 227, col: 36, offset: 6540},
+													pos:  position{line: 227, col: 36, offset: 6586},
 													name: "SearchExprAdd",
 												},
 											},
@@ -1662,53 +1662,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprAdd",
-			pos:  position{line: 231, col: 1, offset: 6657},
+			pos:  position{line: 231, col: 1, offset: 6703},
 			expr: &actionExpr{
-				pos: position{line: 232, col: 5, offset: 6675},
+				pos: position{line: 232, col: 5, offset: 6721},
 				run: (*parser).callonSearchExprAdd1,
 				expr: &seqExpr{
-					pos: position{line: 232, col: 5, offset: 6675},
+					pos: position{line: 232, col: 5, offset: 6721},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 232, col: 5, offset: 6675},
+							pos:   position{line: 232, col: 5, offset: 6721},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 11, offset: 6681},
+								pos:  position{line: 232, col: 11, offset: 6727},
 								name: "SearchExprMul",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 5, offset: 6699},
+							pos:   position{line: 233, col: 5, offset: 6745},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 233, col: 10, offset: 6704},
+								pos: position{line: 233, col: 10, offset: 6750},
 								expr: &actionExpr{
-									pos: position{line: 233, col: 11, offset: 6705},
+									pos: position{line: 233, col: 11, offset: 6751},
 									run: (*parser).callonSearchExprAdd7,
 									expr: &seqExpr{
-										pos: position{line: 233, col: 11, offset: 6705},
+										pos: position{line: 233, col: 11, offset: 6751},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 233, col: 11, offset: 6705},
+												pos:  position{line: 233, col: 11, offset: 6751},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 233, col: 14, offset: 6708},
+												pos:   position{line: 233, col: 14, offset: 6754},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 233, col: 17, offset: 6711},
+													pos:  position{line: 233, col: 17, offset: 6757},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 233, col: 34, offset: 6728},
+												pos:  position{line: 233, col: 34, offset: 6774},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 233, col: 37, offset: 6731},
+												pos:   position{line: 233, col: 37, offset: 6777},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 233, col: 42, offset: 6736},
+													pos:  position{line: 233, col: 42, offset: 6782},
 													name: "SearchExprMul",
 												},
 											},
@@ -1723,53 +1723,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprMul",
-			pos:  position{line: 237, col: 1, offset: 6853},
+			pos:  position{line: 237, col: 1, offset: 6899},
 			expr: &actionExpr{
-				pos: position{line: 238, col: 5, offset: 6871},
+				pos: position{line: 238, col: 5, offset: 6917},
 				run: (*parser).callonSearchExprMul1,
 				expr: &seqExpr{
-					pos: position{line: 238, col: 5, offset: 6871},
+					pos: position{line: 238, col: 5, offset: 6917},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 238, col: 5, offset: 6871},
+							pos:   position{line: 238, col: 5, offset: 6917},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 238, col: 11, offset: 6877},
+								pos:  position{line: 238, col: 11, offset: 6923},
 								name: "SearchExprCast",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 5, offset: 6896},
+							pos:   position{line: 239, col: 5, offset: 6942},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 239, col: 10, offset: 6901},
+								pos: position{line: 239, col: 10, offset: 6947},
 								expr: &actionExpr{
-									pos: position{line: 239, col: 11, offset: 6902},
+									pos: position{line: 239, col: 11, offset: 6948},
 									run: (*parser).callonSearchExprMul7,
 									expr: &seqExpr{
-										pos: position{line: 239, col: 11, offset: 6902},
+										pos: position{line: 239, col: 11, offset: 6948},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 239, col: 11, offset: 6902},
+												pos:  position{line: 239, col: 11, offset: 6948},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 239, col: 14, offset: 6905},
+												pos:   position{line: 239, col: 14, offset: 6951},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 239, col: 17, offset: 6908},
+													pos:  position{line: 239, col: 17, offset: 6954},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 239, col: 40, offset: 6931},
+												pos:  position{line: 239, col: 40, offset: 6977},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 239, col: 43, offset: 6934},
+												pos:   position{line: 239, col: 43, offset: 6980},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 239, col: 48, offset: 6939},
+													pos:  position{line: 239, col: 48, offset: 6985},
 													name: "SearchExprCast",
 												},
 											},
@@ -1784,42 +1784,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprCast",
-			pos:  position{line: 243, col: 1, offset: 7057},
+			pos:  position{line: 243, col: 1, offset: 7103},
 			expr: &choiceExpr{
-				pos: position{line: 244, col: 5, offset: 7076},
+				pos: position{line: 244, col: 5, offset: 7122},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 244, col: 5, offset: 7076},
+						pos: position{line: 244, col: 5, offset: 7122},
 						run: (*parser).callonSearchExprCast2,
 						expr: &seqExpr{
-							pos: position{line: 244, col: 5, offset: 7076},
+							pos: position{line: 244, col: 5, offset: 7122},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 244, col: 5, offset: 7076},
+									pos:   position{line: 244, col: 5, offset: 7122},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 244, col: 7, offset: 7078},
+										pos:  position{line: 244, col: 7, offset: 7124},
 										name: "SearchExprFunc",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 244, col: 22, offset: 7093},
+									pos:  position{line: 244, col: 22, offset: 7139},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 244, col: 25, offset: 7096},
+									pos:        position{line: 244, col: 25, offset: 7142},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 244, col: 29, offset: 7100},
+									pos:  position{line: 244, col: 29, offset: 7146},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 244, col: 32, offset: 7103},
+									pos:   position{line: 244, col: 32, offset: 7149},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 244, col: 36, offset: 7107},
+										pos:  position{line: 244, col: 36, offset: 7153},
 										name: "CastType",
 									},
 								},
@@ -1827,7 +1827,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 5, offset: 7207},
+						pos:  position{line: 247, col: 5, offset: 7255},
 						name: "SearchExprFunc",
 					},
 				},
@@ -1835,39 +1835,39 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExprFunc",
-			pos:  position{line: 249, col: 1, offset: 7223},
+			pos:  position{line: 249, col: 1, offset: 7271},
 			expr: &choiceExpr{
-				pos: position{line: 250, col: 5, offset: 7242},
+				pos: position{line: 250, col: 5, offset: 7290},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 250, col: 5, offset: 7242},
+						pos:  position{line: 250, col: 5, offset: 7290},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 7256},
+						pos:  position{line: 251, col: 5, offset: 7304},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 252, col: 5, offset: 7272},
+						pos: position{line: 252, col: 5, offset: 7320},
 						run: (*parser).callonSearchExprFunc4,
 						expr: &seqExpr{
-							pos: position{line: 252, col: 5, offset: 7272},
+							pos: position{line: 252, col: 5, offset: 7320},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 252, col: 5, offset: 7272},
+									pos:   position{line: 252, col: 5, offset: 7320},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 252, col: 11, offset: 7278},
+										pos:  position{line: 252, col: 11, offset: 7326},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 252, col: 20, offset: 7287},
+									pos:   position{line: 252, col: 20, offset: 7335},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 252, col: 25, offset: 7292},
+										pos: position{line: 252, col: 25, offset: 7340},
 										expr: &ruleRefExpr{
-											pos:  position{line: 252, col: 26, offset: 7293},
+											pos:  position{line: 252, col: 26, offset: 7341},
 											name: "Deref",
 										},
 									},
@@ -1876,11 +1876,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 7365},
+						pos:  position{line: 255, col: 5, offset: 7413},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 7377},
+						pos:  position{line: 256, col: 5, offset: 7425},
 						name: "DerefExpr",
 					},
 				},
@@ -1888,41 +1888,41 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 260, col: 1, offset: 7414},
+			pos:  position{line: 260, col: 1, offset: 7462},
 			expr: &choiceExpr{
-				pos: position{line: 261, col: 5, offset: 7430},
+				pos: position{line: 261, col: 5, offset: 7478},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 7430},
+						pos: position{line: 261, col: 5, offset: 7478},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 261, col: 5, offset: 7430},
+							pos: position{line: 261, col: 5, offset: 7478},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 261, col: 5, offset: 7430},
+									pos:  position{line: 261, col: 5, offset: 7478},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 15, offset: 7440},
+									pos:   position{line: 261, col: 15, offset: 7488},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 21, offset: 7446},
+										pos:  position{line: 261, col: 21, offset: 7494},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 30, offset: 7455},
+									pos:   position{line: 261, col: 30, offset: 7503},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 35, offset: 7460},
+										pos:  position{line: 261, col: 35, offset: 7508},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 47, offset: 7472},
+									pos:   position{line: 261, col: 47, offset: 7520},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 53, offset: 7478},
+										pos:  position{line: 261, col: 53, offset: 7526},
 										name: "LimitArg",
 									},
 								},
@@ -1930,45 +1930,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 7621},
+						pos: position{line: 264, col: 5, offset: 7671},
 						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 264, col: 5, offset: 7621},
+							pos: position{line: 264, col: 5, offset: 7671},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 264, col: 5, offset: 7621},
+									pos:  position{line: 264, col: 5, offset: 7671},
 									name: "Summarize",
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 15, offset: 7631},
+									pos:   position{line: 264, col: 15, offset: 7681},
 									label: "every",
 									expr: &ruleRefExpr{
-										pos:  position{line: 264, col: 21, offset: 7637},
+										pos:  position{line: 264, col: 21, offset: 7687},
 										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 30, offset: 7646},
+									pos:   position{line: 264, col: 30, offset: 7696},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 264, col: 35, offset: 7651},
+										pos:  position{line: 264, col: 35, offset: 7701},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 50, offset: 7666},
+									pos:   position{line: 264, col: 50, offset: 7716},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 264, col: 55, offset: 7671},
+										pos: position{line: 264, col: 55, offset: 7721},
 										expr: &seqExpr{
-											pos: position{line: 264, col: 56, offset: 7672},
+											pos: position{line: 264, col: 56, offset: 7722},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 264, col: 56, offset: 7672},
+													pos:  position{line: 264, col: 56, offset: 7722},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 264, col: 58, offset: 7674},
+													pos:  position{line: 264, col: 58, offset: 7724},
 													name: "GroupByKeys",
 												},
 											},
@@ -1976,10 +1976,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 264, col: 72, offset: 7688},
+									pos:   position{line: 264, col: 72, offset: 7738},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 264, col: 78, offset: 7694},
+										pos:  position{line: 264, col: 78, offset: 7744},
 										name: "LimitArg",
 									},
 								},
@@ -1991,26 +1991,26 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 272, col: 1, offset: 7925},
+			pos:  position{line: 272, col: 1, offset: 7977},
 			expr: &choiceExpr{
-				pos: position{line: 272, col: 13, offset: 7937},
+				pos: position{line: 272, col: 13, offset: 7989},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 272, col: 13, offset: 7937},
+						pos: position{line: 272, col: 13, offset: 7989},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 272, col: 13, offset: 7937},
+								pos:        position{line: 272, col: 13, offset: 7989},
 								val:        "summarize",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 272, col: 25, offset: 7949},
+								pos:  position{line: 272, col: 25, offset: 8001},
 								name: "_",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 272, col: 29, offset: 7953},
+						pos:        position{line: 272, col: 29, offset: 8005},
 						val:        "",
 						ignoreCase: false,
 					},
@@ -2019,45 +2019,45 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 274, col: 1, offset: 7957},
+			pos:  position{line: 274, col: 1, offset: 8009},
 			expr: &choiceExpr{
-				pos: position{line: 275, col: 5, offset: 7970},
+				pos: position{line: 275, col: 5, offset: 8022},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 275, col: 5, offset: 7970},
+						pos: position{line: 275, col: 5, offset: 8022},
 						run: (*parser).callonEveryDur2,
 						expr: &seqExpr{
-							pos: position{line: 275, col: 5, offset: 7970},
+							pos: position{line: 275, col: 5, offset: 8022},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 275, col: 5, offset: 7970},
+									pos:        position{line: 275, col: 5, offset: 8022},
 									val:        "every",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 275, col: 14, offset: 7979},
+									pos:  position{line: 275, col: 14, offset: 8031},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 275, col: 16, offset: 7981},
+									pos:   position{line: 275, col: 16, offset: 8033},
 									label: "dur",
 									expr: &ruleRefExpr{
-										pos:  position{line: 275, col: 20, offset: 7985},
+										pos:  position{line: 275, col: 20, offset: 8037},
 										name: "Duration",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 275, col: 29, offset: 7994},
+									pos:  position{line: 275, col: 29, offset: 8046},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 276, col: 5, offset: 8020},
+						pos: position{line: 276, col: 5, offset: 8072},
 						run: (*parser).callonEveryDur9,
 						expr: &litMatcher{
-							pos:        position{line: 276, col: 5, offset: 8020},
+							pos:        position{line: 276, col: 5, offset: 8072},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2067,26 +2067,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 278, col: 1, offset: 8045},
+			pos:  position{line: 278, col: 1, offset: 8097},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 5, offset: 8061},
+				pos: position{line: 279, col: 5, offset: 8113},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 5, offset: 8061},
+					pos: position{line: 279, col: 5, offset: 8113},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 279, col: 5, offset: 8061},
+							pos:  position{line: 279, col: 5, offset: 8113},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 279, col: 13, offset: 8069},
+							pos:  position{line: 279, col: 13, offset: 8121},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 15, offset: 8071},
+							pos:   position{line: 279, col: 15, offset: 8123},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 23, offset: 8079},
+								pos:  position{line: 279, col: 23, offset: 8131},
 								name: "FlexAssignments",
 							},
 						},
@@ -2096,43 +2096,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 281, col: 1, offset: 8120},
+			pos:  position{line: 281, col: 1, offset: 8172},
 			expr: &choiceExpr{
-				pos: position{line: 282, col: 5, offset: 8133},
+				pos: position{line: 282, col: 5, offset: 8185},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 282, col: 5, offset: 8133},
+						pos: position{line: 282, col: 5, offset: 8185},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 282, col: 5, offset: 8133},
+							pos: position{line: 282, col: 5, offset: 8185},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 282, col: 5, offset: 8133},
+									pos:  position{line: 282, col: 5, offset: 8185},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 282, col: 7, offset: 8135},
+									pos:        position{line: 282, col: 7, offset: 8187},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 282, col: 14, offset: 8142},
+									pos:  position{line: 282, col: 14, offset: 8194},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 282, col: 16, offset: 8144},
+									pos:        position{line: 282, col: 16, offset: 8196},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 282, col: 25, offset: 8153},
+									pos:  position{line: 282, col: 25, offset: 8205},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 282, col: 27, offset: 8155},
+									pos:   position{line: 282, col: 27, offset: 8207},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 282, col: 33, offset: 8161},
+										pos:  position{line: 282, col: 33, offset: 8213},
 										name: "UInt",
 									},
 								},
@@ -2140,10 +2140,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 8192},
+						pos: position{line: 283, col: 5, offset: 8244},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 283, col: 5, offset: 8192},
+							pos:        position{line: 283, col: 5, offset: 8244},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2153,22 +2153,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 288, col: 1, offset: 8452},
+			pos:  position{line: 288, col: 1, offset: 8504},
 			expr: &choiceExpr{
-				pos: position{line: 289, col: 5, offset: 8471},
+				pos: position{line: 289, col: 5, offset: 8523},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 289, col: 5, offset: 8471},
+						pos:  position{line: 289, col: 5, offset: 8523},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 290, col: 5, offset: 8486},
+						pos: position{line: 290, col: 5, offset: 8538},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 290, col: 5, offset: 8486},
+							pos:   position{line: 290, col: 5, offset: 8538},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 10, offset: 8491},
+								pos:  position{line: 290, col: 10, offset: 8543},
 								name: "Expr",
 							},
 						},
@@ -2178,50 +2178,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 292, col: 1, offset: 8581},
+			pos:  position{line: 292, col: 1, offset: 8635},
 			expr: &actionExpr{
-				pos: position{line: 293, col: 5, offset: 8601},
+				pos: position{line: 293, col: 5, offset: 8655},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 293, col: 5, offset: 8601},
+					pos: position{line: 293, col: 5, offset: 8655},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 293, col: 5, offset: 8601},
+							pos:   position{line: 293, col: 5, offset: 8655},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 11, offset: 8607},
+								pos:  position{line: 293, col: 11, offset: 8661},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 26, offset: 8622},
+							pos:   position{line: 293, col: 26, offset: 8676},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 293, col: 31, offset: 8627},
+								pos: position{line: 293, col: 31, offset: 8681},
 								expr: &actionExpr{
-									pos: position{line: 293, col: 32, offset: 8628},
+									pos: position{line: 293, col: 32, offset: 8682},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 293, col: 32, offset: 8628},
+										pos: position{line: 293, col: 32, offset: 8682},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 293, col: 32, offset: 8628},
+												pos:  position{line: 293, col: 32, offset: 8682},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 293, col: 35, offset: 8631},
+												pos:        position{line: 293, col: 35, offset: 8685},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 293, col: 39, offset: 8635},
+												pos:  position{line: 293, col: 39, offset: 8689},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 293, col: 42, offset: 8638},
+												pos:   position{line: 293, col: 42, offset: 8692},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 293, col: 47, offset: 8643},
+													pos:  position{line: 293, col: 47, offset: 8697},
 													name: "FlexAssignment",
 												},
 											},
@@ -2236,42 +2236,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 297, col: 1, offset: 8765},
+			pos:  position{line: 297, col: 1, offset: 8819},
 			expr: &choiceExpr{
-				pos: position{line: 298, col: 5, offset: 8783},
+				pos: position{line: 298, col: 5, offset: 8837},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 298, col: 5, offset: 8783},
+						pos: position{line: 298, col: 5, offset: 8837},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 298, col: 5, offset: 8783},
+							pos: position{line: 298, col: 5, offset: 8837},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 298, col: 5, offset: 8783},
+									pos:   position{line: 298, col: 5, offset: 8837},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 298, col: 10, offset: 8788},
+										pos:  position{line: 298, col: 10, offset: 8842},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 298, col: 15, offset: 8793},
+									pos:  position{line: 298, col: 15, offset: 8847},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 298, col: 18, offset: 8796},
+									pos:        position{line: 298, col: 18, offset: 8850},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 298, col: 22, offset: 8800},
+									pos:  position{line: 298, col: 22, offset: 8854},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 298, col: 25, offset: 8803},
+									pos:   position{line: 298, col: 25, offset: 8857},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 298, col: 29, offset: 8807},
+										pos:  position{line: 298, col: 29, offset: 8861},
 										name: "Agg",
 									},
 								},
@@ -2279,13 +2279,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 301, col: 5, offset: 8909},
+						pos: position{line: 301, col: 5, offset: 8965},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 301, col: 5, offset: 8909},
+							pos:   position{line: 301, col: 5, offset: 8965},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 301, col: 9, offset: 8913},
+								pos:  position{line: 301, col: 9, offset: 8969},
 								name: "Agg",
 							},
 						},
@@ -2295,72 +2295,72 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 305, col: 1, offset: 9011},
+			pos:  position{line: 305, col: 1, offset: 9069},
 			expr: &actionExpr{
-				pos: position{line: 306, col: 5, offset: 9019},
+				pos: position{line: 306, col: 5, offset: 9077},
 				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 306, col: 5, offset: 9019},
+					pos: position{line: 306, col: 5, offset: 9077},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 306, col: 5, offset: 9019},
+							pos: position{line: 306, col: 5, offset: 9077},
 							expr: &ruleRefExpr{
-								pos:  position{line: 306, col: 6, offset: 9020},
+								pos:  position{line: 306, col: 6, offset: 9078},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 16, offset: 9030},
+							pos:   position{line: 306, col: 16, offset: 9088},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 306, col: 19, offset: 9033},
+								pos:  position{line: 306, col: 19, offset: 9091},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 27, offset: 9041},
+							pos:  position{line: 306, col: 27, offset: 9099},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 306, col: 30, offset: 9044},
+							pos:        position{line: 306, col: 30, offset: 9102},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 34, offset: 9048},
+							pos:  position{line: 306, col: 34, offset: 9106},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 37, offset: 9051},
+							pos:   position{line: 306, col: 37, offset: 9109},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 306, col: 42, offset: 9056},
+								pos: position{line: 306, col: 42, offset: 9114},
 								expr: &ruleRefExpr{
-									pos:  position{line: 306, col: 42, offset: 9056},
+									pos:  position{line: 306, col: 42, offset: 9114},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 306, col: 49, offset: 9063},
+							pos:  position{line: 306, col: 49, offset: 9121},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 306, col: 52, offset: 9066},
+							pos:        position{line: 306, col: 52, offset: 9124},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 306, col: 56, offset: 9070},
+							pos: position{line: 306, col: 56, offset: 9128},
 							expr: &seqExpr{
-								pos: position{line: 306, col: 58, offset: 9072},
+								pos: position{line: 306, col: 58, offset: 9130},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 306, col: 58, offset: 9072},
+										pos:  position{line: 306, col: 58, offset: 9130},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 306, col: 61, offset: 9075},
+										pos:        position{line: 306, col: 61, offset: 9133},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2368,12 +2368,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 306, col: 66, offset: 9080},
+							pos:   position{line: 306, col: 66, offset: 9138},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 306, col: 72, offset: 9086},
+								pos: position{line: 306, col: 72, offset: 9144},
 								expr: &ruleRefExpr{
-									pos:  position{line: 306, col: 72, offset: 9086},
+									pos:  position{line: 306, col: 72, offset: 9144},
 									name: "WhereClause",
 								},
 							},
@@ -2384,20 +2384,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 314, col: 1, offset: 9274},
+			pos:  position{line: 314, col: 1, offset: 9334},
 			expr: &choiceExpr{
-				pos: position{line: 315, col: 5, offset: 9286},
+				pos: position{line: 315, col: 5, offset: 9346},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 315, col: 5, offset: 9286},
+						pos:  position{line: 315, col: 5, offset: 9346},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 316, col: 5, offset: 9305},
+						pos:  position{line: 316, col: 5, offset: 9365},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 9318},
+						pos:  position{line: 317, col: 5, offset: 9378},
 						name: "OrToken",
 					},
 				},
@@ -2405,31 +2405,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 319, col: 1, offset: 9327},
+			pos:  position{line: 319, col: 1, offset: 9387},
 			expr: &actionExpr{
-				pos: position{line: 319, col: 15, offset: 9341},
+				pos: position{line: 319, col: 15, offset: 9401},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 319, col: 15, offset: 9341},
+					pos: position{line: 319, col: 15, offset: 9401},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 319, col: 15, offset: 9341},
+							pos:  position{line: 319, col: 15, offset: 9401},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 319, col: 17, offset: 9343},
+							pos:        position{line: 319, col: 17, offset: 9403},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 319, col: 25, offset: 9351},
+							pos:  position{line: 319, col: 25, offset: 9411},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 319, col: 27, offset: 9353},
+							pos:   position{line: 319, col: 27, offset: 9413},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 319, col: 32, offset: 9358},
+								pos:  position{line: 319, col: 32, offset: 9418},
 								name: "SearchBoolean",
 							},
 						},
@@ -2439,44 +2439,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 321, col: 1, offset: 9394},
+			pos:  position{line: 321, col: 1, offset: 9454},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 5, offset: 9413},
+				pos: position{line: 322, col: 5, offset: 9473},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 5, offset: 9413},
+					pos: position{line: 322, col: 5, offset: 9473},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 322, col: 5, offset: 9413},
+							pos:   position{line: 322, col: 5, offset: 9473},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 322, col: 11, offset: 9419},
+								pos:  position{line: 322, col: 11, offset: 9479},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 25, offset: 9433},
+							pos:   position{line: 322, col: 25, offset: 9493},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 322, col: 30, offset: 9438},
+								pos: position{line: 322, col: 30, offset: 9498},
 								expr: &seqExpr{
-									pos: position{line: 322, col: 31, offset: 9439},
+									pos: position{line: 322, col: 31, offset: 9499},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 31, offset: 9439},
+											pos:  position{line: 322, col: 31, offset: 9499},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 322, col: 34, offset: 9442},
+											pos:        position{line: 322, col: 34, offset: 9502},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 38, offset: 9446},
+											pos:  position{line: 322, col: 38, offset: 9506},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 41, offset: 9449},
+											pos:  position{line: 322, col: 41, offset: 9509},
 											name: "AggAssignment",
 										},
 									},
@@ -2489,68 +2489,68 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 330, col: 1, offset: 9650},
+			pos:  position{line: 330, col: 1, offset: 9710},
 			expr: &choiceExpr{
-				pos: position{line: 331, col: 5, offset: 9663},
+				pos: position{line: 331, col: 5, offset: 9723},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 9663},
+						pos:  position{line: 331, col: 5, offset: 9723},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 332, col: 5, offset: 9676},
+						pos:  position{line: 332, col: 5, offset: 9736},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 9688},
+						pos:  position{line: 333, col: 5, offset: 9748},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 9700},
+						pos:  position{line: 334, col: 5, offset: 9760},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 9713},
+						pos:  position{line: 335, col: 5, offset: 9773},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 9726},
+						pos:  position{line: 336, col: 5, offset: 9786},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 9739},
+						pos:  position{line: 337, col: 5, offset: 9799},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 9752},
+						pos:  position{line: 338, col: 5, offset: 9812},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 9767},
+						pos:  position{line: 339, col: 5, offset: 9827},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 9780},
+						pos:  position{line: 340, col: 5, offset: 9840},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 341, col: 5, offset: 9792},
+						pos:  position{line: 341, col: 5, offset: 9852},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 342, col: 5, offset: 9807},
+						pos:  position{line: 342, col: 5, offset: 9867},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 343, col: 5, offset: 9820},
+						pos:  position{line: 343, col: 5, offset: 9880},
 						name: "ShapeProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 344, col: 5, offset: 9834},
+						pos:  position{line: 344, col: 5, offset: 9894},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 345, col: 5, offset: 9847},
+						pos:  position{line: 345, col: 5, offset: 9907},
 						name: "TasteProc",
 					},
 				},
@@ -2558,46 +2558,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 347, col: 1, offset: 9858},
+			pos:  position{line: 347, col: 1, offset: 9918},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 9871},
+				pos: position{line: 348, col: 5, offset: 9931},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 5, offset: 9871},
+					pos: position{line: 348, col: 5, offset: 9931},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 5, offset: 9871},
+							pos:        position{line: 348, col: 5, offset: 9931},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 13, offset: 9879},
+							pos:   position{line: 348, col: 13, offset: 9939},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 18, offset: 9884},
+								pos:  position{line: 348, col: 18, offset: 9944},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 27, offset: 9893},
+							pos:   position{line: 348, col: 27, offset: 9953},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 348, col: 32, offset: 9898},
+								pos: position{line: 348, col: 32, offset: 9958},
 								expr: &actionExpr{
-									pos: position{line: 348, col: 33, offset: 9899},
+									pos: position{line: 348, col: 33, offset: 9959},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 348, col: 33, offset: 9899},
+										pos: position{line: 348, col: 33, offset: 9959},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 348, col: 33, offset: 9899},
+												pos:  position{line: 348, col: 33, offset: 9959},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 348, col: 35, offset: 9901},
+												pos:   position{line: 348, col: 35, offset: 9961},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 348, col: 37, offset: 9903},
+													pos:  position{line: 348, col: 37, offset: 9963},
 													name: "Exprs",
 												},
 											},
@@ -2612,30 +2612,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 362, col: 1, offset: 10316},
+			pos:  position{line: 362, col: 1, offset: 10378},
 			expr: &actionExpr{
-				pos: position{line: 362, col: 12, offset: 10327},
+				pos: position{line: 362, col: 12, offset: 10389},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 362, col: 12, offset: 10327},
+					pos:   position{line: 362, col: 12, offset: 10389},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 362, col: 17, offset: 10332},
+						pos: position{line: 362, col: 17, offset: 10394},
 						expr: &actionExpr{
-							pos: position{line: 362, col: 18, offset: 10333},
+							pos: position{line: 362, col: 18, offset: 10395},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 362, col: 18, offset: 10333},
+								pos: position{line: 362, col: 18, offset: 10395},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 362, col: 18, offset: 10333},
+										pos:  position{line: 362, col: 18, offset: 10395},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 362, col: 20, offset: 10335},
+										pos:   position{line: 362, col: 20, offset: 10397},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 362, col: 22, offset: 10337},
+											pos:  position{line: 362, col: 22, offset: 10399},
 											name: "SortArg",
 										},
 									},
@@ -2648,50 +2648,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 364, col: 1, offset: 10393},
+			pos:  position{line: 364, col: 1, offset: 10455},
 			expr: &choiceExpr{
-				pos: position{line: 365, col: 5, offset: 10405},
+				pos: position{line: 365, col: 5, offset: 10467},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 365, col: 5, offset: 10405},
+						pos: position{line: 365, col: 5, offset: 10467},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 365, col: 5, offset: 10405},
+							pos:        position{line: 365, col: 5, offset: 10467},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 366, col: 5, offset: 10480},
+						pos: position{line: 366, col: 5, offset: 10542},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 366, col: 5, offset: 10480},
+							pos: position{line: 366, col: 5, offset: 10542},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 366, col: 5, offset: 10480},
+									pos:        position{line: 366, col: 5, offset: 10542},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 366, col: 14, offset: 10489},
+									pos:  position{line: 366, col: 14, offset: 10551},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 366, col: 16, offset: 10491},
+									pos:   position{line: 366, col: 16, offset: 10553},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 366, col: 23, offset: 10498},
+										pos: position{line: 366, col: 23, offset: 10560},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 366, col: 24, offset: 10499},
+											pos: position{line: 366, col: 24, offset: 10561},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 366, col: 24, offset: 10499},
+													pos:        position{line: 366, col: 24, offset: 10561},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 366, col: 34, offset: 10509},
+													pos:        position{line: 366, col: 34, offset: 10571},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2707,38 +2707,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 368, col: 1, offset: 10623},
+			pos:  position{line: 368, col: 1, offset: 10685},
 			expr: &actionExpr{
-				pos: position{line: 369, col: 5, offset: 10635},
+				pos: position{line: 369, col: 5, offset: 10697},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 369, col: 5, offset: 10635},
+					pos: position{line: 369, col: 5, offset: 10697},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 369, col: 5, offset: 10635},
+							pos:        position{line: 369, col: 5, offset: 10697},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 12, offset: 10642},
+							pos:   position{line: 369, col: 12, offset: 10704},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 18, offset: 10648},
+								pos: position{line: 369, col: 18, offset: 10710},
 								expr: &actionExpr{
-									pos: position{line: 369, col: 19, offset: 10649},
+									pos: position{line: 369, col: 19, offset: 10711},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 369, col: 19, offset: 10649},
+										pos: position{line: 369, col: 19, offset: 10711},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 369, col: 19, offset: 10649},
+												pos:  position{line: 369, col: 19, offset: 10711},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 369, col: 21, offset: 10651},
+												pos:   position{line: 369, col: 21, offset: 10713},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 369, col: 23, offset: 10653},
+													pos:  position{line: 369, col: 23, offset: 10715},
 													name: "UInt",
 												},
 											},
@@ -2748,19 +2748,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 47, offset: 10677},
+							pos:   position{line: 369, col: 47, offset: 10739},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 53, offset: 10683},
+								pos: position{line: 369, col: 53, offset: 10745},
 								expr: &seqExpr{
-									pos: position{line: 369, col: 54, offset: 10684},
+									pos: position{line: 369, col: 54, offset: 10746},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 369, col: 54, offset: 10684},
+											pos:  position{line: 369, col: 54, offset: 10746},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 369, col: 56, offset: 10686},
+											pos:        position{line: 369, col: 56, offset: 10748},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2769,25 +2769,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 67, offset: 10697},
+							pos:   position{line: 369, col: 67, offset: 10759},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 74, offset: 10704},
+								pos: position{line: 369, col: 74, offset: 10766},
 								expr: &actionExpr{
-									pos: position{line: 369, col: 75, offset: 10705},
+									pos: position{line: 369, col: 75, offset: 10767},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 369, col: 75, offset: 10705},
+										pos: position{line: 369, col: 75, offset: 10767},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 369, col: 75, offset: 10705},
+												pos:  position{line: 369, col: 75, offset: 10767},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 369, col: 77, offset: 10707},
+												pos:   position{line: 369, col: 77, offset: 10769},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 369, col: 79, offset: 10709},
+													pos:  position{line: 369, col: 79, offset: 10771},
 													name: "FieldExprs",
 												},
 											},
@@ -2802,27 +2802,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 383, col: 1, offset: 11052},
+			pos:  position{line: 383, col: 1, offset: 11116},
 			expr: &actionExpr{
-				pos: position{line: 384, col: 5, offset: 11064},
+				pos: position{line: 384, col: 5, offset: 11128},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 384, col: 5, offset: 11064},
+					pos: position{line: 384, col: 5, offset: 11128},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 384, col: 5, offset: 11064},
+							pos:        position{line: 384, col: 5, offset: 11128},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 384, col: 12, offset: 11071},
+							pos:  position{line: 384, col: 12, offset: 11135},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 384, col: 14, offset: 11073},
+							pos:   position{line: 384, col: 14, offset: 11137},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 384, col: 19, offset: 11078},
+								pos:  position{line: 384, col: 19, offset: 11142},
 								name: "FlexAssignments",
 							},
 						},
@@ -2832,27 +2832,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 388, col: 1, offset: 11171},
+			pos:  position{line: 388, col: 1, offset: 11237},
 			expr: &actionExpr{
-				pos: position{line: 389, col: 5, offset: 11184},
+				pos: position{line: 389, col: 5, offset: 11250},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 389, col: 5, offset: 11184},
+					pos: position{line: 389, col: 5, offset: 11250},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 389, col: 5, offset: 11184},
+							pos:        position{line: 389, col: 5, offset: 11250},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 389, col: 13, offset: 11192},
+							pos:  position{line: 389, col: 13, offset: 11258},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 389, col: 15, offset: 11194},
+							pos:   position{line: 389, col: 15, offset: 11260},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 389, col: 20, offset: 11199},
+								pos:  position{line: 389, col: 20, offset: 11265},
 								name: "FlexAssignments",
 							},
 						},
@@ -2862,27 +2862,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 393, col: 1, offset: 11293},
+			pos:  position{line: 393, col: 1, offset: 11361},
 			expr: &actionExpr{
-				pos: position{line: 394, col: 5, offset: 11306},
+				pos: position{line: 394, col: 5, offset: 11374},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 394, col: 5, offset: 11306},
+					pos: position{line: 394, col: 5, offset: 11374},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 394, col: 5, offset: 11306},
+							pos:        position{line: 394, col: 5, offset: 11374},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 13, offset: 11314},
+							pos:  position{line: 394, col: 13, offset: 11382},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 15, offset: 11316},
+							pos:   position{line: 394, col: 15, offset: 11384},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 20, offset: 11321},
+								pos:  position{line: 394, col: 20, offset: 11389},
 								name: "FieldExprs",
 							},
 						},
@@ -2892,30 +2892,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 398, col: 1, offset: 11410},
+			pos:  position{line: 398, col: 1, offset: 11480},
 			expr: &choiceExpr{
-				pos: position{line: 399, col: 5, offset: 11423},
+				pos: position{line: 399, col: 5, offset: 11493},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 399, col: 5, offset: 11423},
+						pos: position{line: 399, col: 5, offset: 11493},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 399, col: 5, offset: 11423},
+							pos: position{line: 399, col: 5, offset: 11493},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 399, col: 5, offset: 11423},
+									pos:        position{line: 399, col: 5, offset: 11493},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 399, col: 13, offset: 11431},
+									pos:  position{line: 399, col: 13, offset: 11501},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 399, col: 15, offset: 11433},
+									pos:   position{line: 399, col: 15, offset: 11503},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 399, col: 21, offset: 11439},
+										pos:  position{line: 399, col: 21, offset: 11509},
 										name: "UInt",
 									},
 								},
@@ -2923,10 +2923,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 400, col: 5, offset: 11517},
+						pos: position{line: 400, col: 5, offset: 11589},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 400, col: 5, offset: 11517},
+							pos:        position{line: 400, col: 5, offset: 11589},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2936,30 +2936,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 402, col: 1, offset: 11591},
+			pos:  position{line: 402, col: 1, offset: 11665},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 5, offset: 11604},
+				pos: position{line: 403, col: 5, offset: 11678},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 403, col: 5, offset: 11604},
+						pos: position{line: 403, col: 5, offset: 11678},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 403, col: 5, offset: 11604},
+							pos: position{line: 403, col: 5, offset: 11678},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 403, col: 5, offset: 11604},
+									pos:        position{line: 403, col: 5, offset: 11678},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 403, col: 13, offset: 11612},
+									pos:  position{line: 403, col: 13, offset: 11686},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 403, col: 15, offset: 11614},
+									pos:   position{line: 403, col: 15, offset: 11688},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 403, col: 21, offset: 11620},
+										pos:  position{line: 403, col: 21, offset: 11694},
 										name: "UInt",
 									},
 								},
@@ -2967,10 +2967,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 404, col: 5, offset: 11698},
+						pos: position{line: 404, col: 5, offset: 11774},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 404, col: 5, offset: 11698},
+							pos:        position{line: 404, col: 5, offset: 11774},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2980,27 +2980,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 406, col: 1, offset: 11772},
+			pos:  position{line: 406, col: 1, offset: 11850},
 			expr: &actionExpr{
-				pos: position{line: 407, col: 5, offset: 11787},
+				pos: position{line: 407, col: 5, offset: 11865},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 407, col: 5, offset: 11787},
+					pos: position{line: 407, col: 5, offset: 11865},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 407, col: 5, offset: 11787},
+							pos:        position{line: 407, col: 5, offset: 11865},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 407, col: 15, offset: 11797},
+							pos:  position{line: 407, col: 15, offset: 11875},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 407, col: 17, offset: 11799},
+							pos:   position{line: 407, col: 17, offset: 11877},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 407, col: 20, offset: 11802},
+								pos:  position{line: 407, col: 20, offset: 11880},
 								name: "Filter",
 							},
 						},
@@ -3010,15 +3010,15 @@ var g = &grammar{
 		},
 		{
 			name: "Filter",
-			pos:  position{line: 411, col: 1, offset: 11839},
+			pos:  position{line: 411, col: 1, offset: 11917},
 			expr: &actionExpr{
-				pos: position{line: 412, col: 5, offset: 11850},
+				pos: position{line: 412, col: 5, offset: 11928},
 				run: (*parser).callonFilter1,
 				expr: &labeledExpr{
-					pos:   position{line: 412, col: 5, offset: 11850},
+					pos:   position{line: 412, col: 5, offset: 11928},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 412, col: 10, offset: 11855},
+						pos:  position{line: 412, col: 10, offset: 11933},
 						name: "SearchBoolean",
 					},
 				},
@@ -3026,27 +3026,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 416, col: 1, offset: 11949},
+			pos:  position{line: 416, col: 1, offset: 12029},
 			expr: &choiceExpr{
-				pos: position{line: 417, col: 5, offset: 11962},
+				pos: position{line: 417, col: 5, offset: 12042},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 417, col: 5, offset: 11962},
+						pos: position{line: 417, col: 5, offset: 12042},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 417, col: 5, offset: 11962},
+							pos: position{line: 417, col: 5, offset: 12042},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 417, col: 5, offset: 11962},
+									pos:        position{line: 417, col: 5, offset: 12042},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 417, col: 13, offset: 11970},
+									pos:  position{line: 417, col: 13, offset: 12050},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 417, col: 15, offset: 11972},
+									pos:        position{line: 417, col: 15, offset: 12052},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -3054,10 +3054,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 420, col: 5, offset: 12059},
+						pos: position{line: 420, col: 5, offset: 12141},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 420, col: 5, offset: 12059},
+							pos:        position{line: 420, col: 5, offset: 12141},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -3067,27 +3067,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 424, col: 1, offset: 12147},
+			pos:  position{line: 424, col: 1, offset: 12231},
 			expr: &actionExpr{
-				pos: position{line: 425, col: 5, offset: 12159},
+				pos: position{line: 425, col: 5, offset: 12243},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 425, col: 5, offset: 12159},
+					pos: position{line: 425, col: 5, offset: 12243},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 425, col: 5, offset: 12159},
+							pos:        position{line: 425, col: 5, offset: 12243},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 425, col: 12, offset: 12166},
+							pos:  position{line: 425, col: 12, offset: 12250},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 425, col: 14, offset: 12168},
+							pos:   position{line: 425, col: 14, offset: 12252},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 425, col: 19, offset: 12173},
+								pos:  position{line: 425, col: 19, offset: 12257},
 								name: "FlexAssignments",
 							},
 						},
@@ -3097,59 +3097,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 429, col: 1, offset: 12266},
+			pos:  position{line: 429, col: 1, offset: 12352},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 12281},
+				pos: position{line: 430, col: 5, offset: 12367},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 12281},
+					pos: position{line: 430, col: 5, offset: 12367},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 430, col: 5, offset: 12281},
+							pos:        position{line: 430, col: 5, offset: 12367},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 430, col: 15, offset: 12291},
+							pos:  position{line: 430, col: 15, offset: 12377},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 17, offset: 12293},
+							pos:   position{line: 430, col: 17, offset: 12379},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 23, offset: 12299},
+								pos:  position{line: 430, col: 23, offset: 12385},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 34, offset: 12310},
+							pos:   position{line: 430, col: 34, offset: 12396},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 430, col: 39, offset: 12315},
+								pos: position{line: 430, col: 39, offset: 12401},
 								expr: &actionExpr{
-									pos: position{line: 430, col: 40, offset: 12316},
+									pos: position{line: 430, col: 40, offset: 12402},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 430, col: 40, offset: 12316},
+										pos: position{line: 430, col: 40, offset: 12402},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 430, col: 40, offset: 12316},
+												pos:  position{line: 430, col: 40, offset: 12402},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 430, col: 43, offset: 12319},
+												pos:        position{line: 430, col: 43, offset: 12405},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 430, col: 47, offset: 12323},
+												pos:  position{line: 430, col: 47, offset: 12409},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 430, col: 50, offset: 12326},
+												pos:   position{line: 430, col: 50, offset: 12412},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 430, col: 53, offset: 12329},
+													pos:  position{line: 430, col: 53, offset: 12415},
 													name: "Assignment",
 												},
 											},
@@ -3164,29 +3164,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 438, col: 1, offset: 12734},
+			pos:  position{line: 438, col: 1, offset: 12822},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 12747},
+				pos: position{line: 439, col: 5, offset: 12835},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 12747},
+					pos: position{line: 439, col: 5, offset: 12835},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 439, col: 5, offset: 12747},
+							pos:        position{line: 439, col: 5, offset: 12835},
 							val:        "fuse",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 439, col: 13, offset: 12755},
+							pos: position{line: 439, col: 13, offset: 12843},
 							expr: &seqExpr{
-								pos: position{line: 439, col: 15, offset: 12757},
+								pos: position{line: 439, col: 15, offset: 12845},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 439, col: 15, offset: 12757},
+										pos:  position{line: 439, col: 15, offset: 12845},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 439, col: 18, offset: 12760},
+										pos:        position{line: 439, col: 18, offset: 12848},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -3199,12 +3199,12 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeProc",
-			pos:  position{line: 443, col: 1, offset: 12829},
+			pos:  position{line: 443, col: 1, offset: 12919},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 5, offset: 12843},
+				pos: position{line: 444, col: 5, offset: 12933},
 				run: (*parser).callonShapeProc1,
 				expr: &litMatcher{
-					pos:        position{line: 444, col: 5, offset: 12843},
+					pos:        position{line: 444, col: 5, offset: 12933},
 					val:        "shape",
 					ignoreCase: true,
 				},
@@ -3212,76 +3212,76 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 448, col: 1, offset: 12917},
+			pos:  position{line: 448, col: 1, offset: 13009},
 			expr: &choiceExpr{
-				pos: position{line: 449, col: 5, offset: 12930},
+				pos: position{line: 449, col: 5, offset: 13022},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 449, col: 5, offset: 12930},
+						pos: position{line: 449, col: 5, offset: 13022},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 449, col: 5, offset: 12930},
+							pos: position{line: 449, col: 5, offset: 13022},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 449, col: 5, offset: 12930},
-									label: "kind",
+									pos:   position{line: 449, col: 5, offset: 13022},
+									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 10, offset: 12935},
-										name: "JoinKind",
+										pos:  position{line: 449, col: 11, offset: 13028},
+										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 449, col: 19, offset: 12944},
+									pos:        position{line: 449, col: 21, offset: 13038},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 27, offset: 12952},
+									pos:  position{line: 449, col: 29, offset: 13046},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 29, offset: 12954},
+									pos:   position{line: 449, col: 31, offset: 13048},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 37, offset: 12962},
+										pos:  position{line: 449, col: 39, offset: 13056},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 45, offset: 12970},
+									pos:  position{line: 449, col: 47, offset: 13064},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 449, col: 48, offset: 12973},
+									pos:        position{line: 449, col: 50, offset: 13067},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 449, col: 52, offset: 12977},
+									pos:  position{line: 449, col: 54, offset: 13071},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 55, offset: 12980},
+									pos:   position{line: 449, col: 57, offset: 13074},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 449, col: 64, offset: 12989},
+										pos:  position{line: 449, col: 66, offset: 13083},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 449, col: 72, offset: 12997},
+									pos:   position{line: 449, col: 74, offset: 13091},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 449, col: 80, offset: 13005},
+										pos: position{line: 449, col: 82, offset: 13099},
 										expr: &seqExpr{
-											pos: position{line: 449, col: 81, offset: 13006},
+											pos: position{line: 449, col: 83, offset: 13100},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 449, col: 81, offset: 13006},
+													pos:  position{line: 449, col: 83, offset: 13100},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 449, col: 83, offset: 13008},
+													pos:  position{line: 449, col: 85, offset: 13102},
 													name: "FlexAssignments",
 												},
 											},
@@ -3292,50 +3292,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 456, col: 5, offset: 13270},
+						pos: position{line: 456, col: 5, offset: 13368},
 						run: (*parser).callonJoinProc20,
 						expr: &seqExpr{
-							pos: position{line: 456, col: 5, offset: 13270},
+							pos: position{line: 456, col: 5, offset: 13368},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 456, col: 5, offset: 13270},
-									label: "kind",
+									pos:   position{line: 456, col: 5, offset: 13368},
+									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 456, col: 10, offset: 13275},
-										name: "JoinKind",
+										pos:  position{line: 456, col: 11, offset: 13374},
+										name: "JoinStyle",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 456, col: 20, offset: 13285},
+									pos:        position{line: 456, col: 22, offset: 13385},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 456, col: 28, offset: 13293},
+									pos:  position{line: 456, col: 30, offset: 13393},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 456, col: 30, offset: 13295},
+									pos:   position{line: 456, col: 32, offset: 13395},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 456, col: 34, offset: 13299},
+										pos:  position{line: 456, col: 36, offset: 13399},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 456, col: 42, offset: 13307},
+									pos:   position{line: 456, col: 44, offset: 13407},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 456, col: 50, offset: 13315},
+										pos: position{line: 456, col: 52, offset: 13415},
 										expr: &seqExpr{
-											pos: position{line: 456, col: 51, offset: 13316},
+											pos: position{line: 456, col: 53, offset: 13416},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 456, col: 51, offset: 13316},
+													pos:  position{line: 456, col: 53, offset: 13416},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 456, col: 53, offset: 13318},
+													pos:  position{line: 456, col: 55, offset: 13418},
 													name: "FlexAssignments",
 												},
 											},
@@ -3349,70 +3349,70 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "JoinKind",
-			pos:  position{line: 464, col: 1, offset: 13568},
+			name: "JoinStyle",
+			pos:  position{line: 464, col: 1, offset: 13672},
 			expr: &choiceExpr{
-				pos: position{line: 465, col: 5, offset: 13581},
+				pos: position{line: 465, col: 5, offset: 13686},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 465, col: 5, offset: 13581},
-						run: (*parser).callonJoinKind2,
+						pos: position{line: 465, col: 5, offset: 13686},
+						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 465, col: 5, offset: 13581},
+							pos: position{line: 465, col: 5, offset: 13686},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 465, col: 5, offset: 13581},
+									pos:        position{line: 465, col: 5, offset: 13686},
 									val:        "inner",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 465, col: 14, offset: 13590},
+									pos:  position{line: 465, col: 14, offset: 13695},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 466, col: 5, offset: 13620},
-						run: (*parser).callonJoinKind6,
+						pos: position{line: 466, col: 5, offset: 13725},
+						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 466, col: 5, offset: 13620},
+							pos: position{line: 466, col: 5, offset: 13725},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 466, col: 5, offset: 13620},
+									pos:        position{line: 466, col: 5, offset: 13725},
 									val:        "left",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 466, col: 14, offset: 13629},
+									pos:  position{line: 466, col: 14, offset: 13734},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 467, col: 5, offset: 13658},
-						run: (*parser).callonJoinKind10,
+						pos: position{line: 467, col: 5, offset: 13763},
+						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 467, col: 5, offset: 13658},
+							pos: position{line: 467, col: 5, offset: 13763},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 467, col: 5, offset: 13658},
+									pos:        position{line: 467, col: 5, offset: 13763},
 									val:        "right",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 467, col: 14, offset: 13667},
+									pos:  position{line: 467, col: 14, offset: 13772},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 468, col: 5, offset: 13697},
-						run: (*parser).callonJoinKind14,
+						pos: position{line: 468, col: 5, offset: 13802},
+						run: (*parser).callonJoinStyle14,
 						expr: &litMatcher{
-							pos:        position{line: 468, col: 5, offset: 13697},
+							pos:        position{line: 468, col: 5, offset: 13802},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3422,35 +3422,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 470, col: 1, offset: 13733},
+			pos:  position{line: 470, col: 1, offset: 13838},
 			expr: &choiceExpr{
-				pos: position{line: 471, col: 5, offset: 13745},
+				pos: position{line: 471, col: 5, offset: 13850},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 471, col: 5, offset: 13745},
+						pos:  position{line: 471, col: 5, offset: 13850},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 13754},
+						pos: position{line: 472, col: 5, offset: 13859},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 472, col: 5, offset: 13754},
+							pos: position{line: 472, col: 5, offset: 13859},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 472, col: 5, offset: 13754},
+									pos:        position{line: 472, col: 5, offset: 13859},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 472, col: 9, offset: 13758},
+									pos:   position{line: 472, col: 9, offset: 13863},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 472, col: 14, offset: 13763},
+										pos:  position{line: 472, col: 14, offset: 13868},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 472, col: 19, offset: 13768},
+									pos:        position{line: 472, col: 19, offset: 13873},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3462,23 +3462,23 @@ var g = &grammar{
 		},
 		{
 			name: "TasteProc",
-			pos:  position{line: 474, col: 1, offset: 13794},
+			pos:  position{line: 474, col: 1, offset: 13899},
 			expr: &actionExpr{
-				pos: position{line: 475, col: 5, offset: 13808},
+				pos: position{line: 475, col: 5, offset: 13913},
 				run: (*parser).callonTasteProc1,
 				expr: &seqExpr{
-					pos: position{line: 475, col: 5, offset: 13808},
+					pos: position{line: 475, col: 5, offset: 13913},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 475, col: 5, offset: 13808},
+							pos:        position{line: 475, col: 5, offset: 13913},
 							val:        "taste",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 475, col: 14, offset: 13817},
+							pos:   position{line: 475, col: 14, offset: 13922},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 475, col: 16, offset: 13819},
+								pos:  position{line: 475, col: 16, offset: 13924},
 								name: "TasteExpr",
 							},
 						},
@@ -3488,25 +3488,25 @@ var g = &grammar{
 		},
 		{
 			name: "TasteExpr",
-			pos:  position{line: 512, col: 1, offset: 15089},
+			pos:  position{line: 512, col: 1, offset: 15216},
 			expr: &choiceExpr{
-				pos: position{line: 513, col: 5, offset: 15103},
+				pos: position{line: 513, col: 5, offset: 15230},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 15103},
+						pos: position{line: 513, col: 5, offset: 15230},
 						run: (*parser).callonTasteExpr2,
 						expr: &seqExpr{
-							pos: position{line: 513, col: 5, offset: 15103},
+							pos: position{line: 513, col: 5, offset: 15230},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 513, col: 5, offset: 15103},
+									pos:  position{line: 513, col: 5, offset: 15230},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 513, col: 7, offset: 15105},
+									pos:   position{line: 513, col: 7, offset: 15232},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 513, col: 12, offset: 15110},
+										pos:  position{line: 513, col: 12, offset: 15237},
 										name: "Lval",
 									},
 								},
@@ -3514,10 +3514,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 15139},
+						pos: position{line: 514, col: 5, offset: 15266},
 						run: (*parser).callonTasteExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 514, col: 5, offset: 15139},
+							pos:        position{line: 514, col: 5, offset: 15266},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3527,60 +3527,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 516, col: 1, offset: 15195},
+			pos:  position{line: 516, col: 1, offset: 15324},
 			expr: &ruleRefExpr{
-				pos:  position{line: 516, col: 8, offset: 15202},
+				pos:  position{line: 516, col: 8, offset: 15331},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 518, col: 1, offset: 15213},
+			pos:  position{line: 518, col: 1, offset: 15342},
 			expr: &ruleRefExpr{
-				pos:  position{line: 518, col: 13, offset: 15225},
+				pos:  position{line: 518, col: 13, offset: 15354},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 520, col: 1, offset: 15231},
+			pos:  position{line: 520, col: 1, offset: 15360},
 			expr: &actionExpr{
-				pos: position{line: 521, col: 5, offset: 15246},
+				pos: position{line: 521, col: 5, offset: 15375},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 521, col: 5, offset: 15246},
+					pos: position{line: 521, col: 5, offset: 15375},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 521, col: 5, offset: 15246},
+							pos:   position{line: 521, col: 5, offset: 15375},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 521, col: 11, offset: 15252},
+								pos:  position{line: 521, col: 11, offset: 15381},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 521, col: 21, offset: 15262},
+							pos:   position{line: 521, col: 21, offset: 15391},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 521, col: 26, offset: 15267},
+								pos: position{line: 521, col: 26, offset: 15396},
 								expr: &seqExpr{
-									pos: position{line: 521, col: 27, offset: 15268},
+									pos: position{line: 521, col: 27, offset: 15397},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 521, col: 27, offset: 15268},
+											pos:  position{line: 521, col: 27, offset: 15397},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 521, col: 30, offset: 15271},
+											pos:        position{line: 521, col: 30, offset: 15400},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 521, col: 34, offset: 15275},
+											pos:  position{line: 521, col: 34, offset: 15404},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 521, col: 37, offset: 15278},
+											pos:  position{line: 521, col: 37, offset: 15407},
 											name: "FieldExpr",
 										},
 									},
@@ -3593,44 +3593,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 531, col: 1, offset: 15477},
+			pos:  position{line: 531, col: 1, offset: 15606},
 			expr: &actionExpr{
-				pos: position{line: 532, col: 5, offset: 15487},
+				pos: position{line: 532, col: 5, offset: 15616},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 532, col: 5, offset: 15487},
+					pos: position{line: 532, col: 5, offset: 15616},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 532, col: 5, offset: 15487},
+							pos:   position{line: 532, col: 5, offset: 15616},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 532, col: 11, offset: 15493},
+								pos:  position{line: 532, col: 11, offset: 15622},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 532, col: 16, offset: 15498},
+							pos:   position{line: 532, col: 16, offset: 15627},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 532, col: 21, offset: 15503},
+								pos: position{line: 532, col: 21, offset: 15632},
 								expr: &seqExpr{
-									pos: position{line: 532, col: 22, offset: 15504},
+									pos: position{line: 532, col: 22, offset: 15633},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 532, col: 22, offset: 15504},
+											pos:  position{line: 532, col: 22, offset: 15633},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 532, col: 25, offset: 15507},
+											pos:        position{line: 532, col: 25, offset: 15636},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 532, col: 29, offset: 15511},
+											pos:  position{line: 532, col: 29, offset: 15640},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 532, col: 32, offset: 15514},
+											pos:  position{line: 532, col: 32, offset: 15643},
 											name: "Expr",
 										},
 									},
@@ -3643,39 +3643,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 542, col: 1, offset: 15708},
+			pos:  position{line: 542, col: 1, offset: 15837},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 5, offset: 15723},
+				pos: position{line: 543, col: 5, offset: 15852},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 5, offset: 15723},
+					pos: position{line: 543, col: 5, offset: 15852},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 543, col: 5, offset: 15723},
+							pos:   position{line: 543, col: 5, offset: 15852},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 9, offset: 15727},
+								pos:  position{line: 543, col: 9, offset: 15856},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 14, offset: 15732},
+							pos:  position{line: 543, col: 14, offset: 15861},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 543, col: 17, offset: 15735},
+							pos:        position{line: 543, col: 17, offset: 15864},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 21, offset: 15739},
+							pos:  position{line: 543, col: 21, offset: 15868},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 543, col: 24, offset: 15742},
+							pos:   position{line: 543, col: 24, offset: 15871},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 28, offset: 15746},
+								pos:  position{line: 543, col: 28, offset: 15875},
 								name: "Expr",
 							},
 						},
@@ -3685,71 +3685,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 545, col: 1, offset: 15835},
+			pos:  position{line: 545, col: 1, offset: 15966},
 			expr: &ruleRefExpr{
-				pos:  position{line: 545, col: 8, offset: 15842},
+				pos:  position{line: 545, col: 8, offset: 15973},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 547, col: 1, offset: 15859},
+			pos:  position{line: 547, col: 1, offset: 15990},
 			expr: &choiceExpr{
-				pos: position{line: 548, col: 5, offset: 15879},
+				pos: position{line: 548, col: 5, offset: 16010},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 15879},
+						pos: position{line: 548, col: 5, offset: 16010},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 15879},
+							pos: position{line: 548, col: 5, offset: 16010},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 548, col: 5, offset: 15879},
+									pos:   position{line: 548, col: 5, offset: 16010},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 15, offset: 15889},
+										pos:  position{line: 548, col: 15, offset: 16020},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 29, offset: 15903},
+									pos:  position{line: 548, col: 29, offset: 16034},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 548, col: 32, offset: 15906},
+									pos:        position{line: 548, col: 32, offset: 16037},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 36, offset: 15910},
+									pos:  position{line: 548, col: 36, offset: 16041},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 548, col: 39, offset: 15913},
+									pos:   position{line: 548, col: 39, offset: 16044},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 50, offset: 15924},
+										pos:  position{line: 548, col: 50, offset: 16055},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 55, offset: 15929},
+									pos:  position{line: 548, col: 55, offset: 16060},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 548, col: 58, offset: 15932},
+									pos:        position{line: 548, col: 58, offset: 16063},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 62, offset: 15936},
+									pos:  position{line: 548, col: 62, offset: 16067},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 548, col: 65, offset: 15939},
+									pos:   position{line: 548, col: 65, offset: 16070},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 76, offset: 15950},
+										pos:  position{line: 548, col: 76, offset: 16081},
 										name: "Expr",
 									},
 								},
@@ -3757,7 +3757,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 551, col: 5, offset: 16088},
+						pos:  position{line: 551, col: 5, offset: 16221},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -3765,53 +3765,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 553, col: 1, offset: 16103},
+			pos:  position{line: 553, col: 1, offset: 16236},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 5, offset: 16121},
+				pos: position{line: 554, col: 5, offset: 16254},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 5, offset: 16121},
+					pos: position{line: 554, col: 5, offset: 16254},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 554, col: 5, offset: 16121},
+							pos:   position{line: 554, col: 5, offset: 16254},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 554, col: 11, offset: 16127},
+								pos:  position{line: 554, col: 11, offset: 16260},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 5, offset: 16146},
+							pos:   position{line: 555, col: 5, offset: 16279},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 555, col: 10, offset: 16151},
+								pos: position{line: 555, col: 10, offset: 16284},
 								expr: &actionExpr{
-									pos: position{line: 555, col: 11, offset: 16152},
+									pos: position{line: 555, col: 11, offset: 16285},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 555, col: 11, offset: 16152},
+										pos: position{line: 555, col: 11, offset: 16285},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 555, col: 11, offset: 16152},
+												pos:  position{line: 555, col: 11, offset: 16285},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 555, col: 14, offset: 16155},
+												pos:   position{line: 555, col: 14, offset: 16288},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 555, col: 17, offset: 16158},
+													pos:  position{line: 555, col: 17, offset: 16291},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 555, col: 25, offset: 16166},
+												pos:  position{line: 555, col: 25, offset: 16299},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 555, col: 28, offset: 16169},
+												pos:   position{line: 555, col: 28, offset: 16302},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 555, col: 33, offset: 16174},
+													pos:  position{line: 555, col: 33, offset: 16307},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -3826,53 +3826,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 559, col: 1, offset: 16292},
+			pos:  position{line: 559, col: 1, offset: 16425},
 			expr: &actionExpr{
-				pos: position{line: 560, col: 5, offset: 16311},
+				pos: position{line: 560, col: 5, offset: 16444},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 560, col: 5, offset: 16311},
+					pos: position{line: 560, col: 5, offset: 16444},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 560, col: 5, offset: 16311},
+							pos:   position{line: 560, col: 5, offset: 16444},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 560, col: 11, offset: 16317},
+								pos:  position{line: 560, col: 11, offset: 16450},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 561, col: 5, offset: 16341},
+							pos:   position{line: 561, col: 5, offset: 16474},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 561, col: 10, offset: 16346},
+								pos: position{line: 561, col: 10, offset: 16479},
 								expr: &actionExpr{
-									pos: position{line: 561, col: 11, offset: 16347},
+									pos: position{line: 561, col: 11, offset: 16480},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 561, col: 11, offset: 16347},
+										pos: position{line: 561, col: 11, offset: 16480},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 561, col: 11, offset: 16347},
+												pos:  position{line: 561, col: 11, offset: 16480},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 561, col: 14, offset: 16350},
+												pos:   position{line: 561, col: 14, offset: 16483},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 561, col: 17, offset: 16353},
+													pos:  position{line: 561, col: 17, offset: 16486},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 561, col: 26, offset: 16362},
+												pos:  position{line: 561, col: 26, offset: 16495},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 561, col: 29, offset: 16365},
+												pos:   position{line: 561, col: 29, offset: 16498},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 561, col: 34, offset: 16370},
+													pos:  position{line: 561, col: 34, offset: 16503},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -3887,53 +3887,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 565, col: 1, offset: 16493},
+			pos:  position{line: 565, col: 1, offset: 16626},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 5, offset: 16517},
+				pos: position{line: 566, col: 5, offset: 16650},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 5, offset: 16517},
+					pos: position{line: 566, col: 5, offset: 16650},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 566, col: 5, offset: 16517},
+							pos:   position{line: 566, col: 5, offset: 16650},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 11, offset: 16523},
+								pos:  position{line: 566, col: 11, offset: 16656},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 567, col: 5, offset: 16540},
+							pos:   position{line: 567, col: 5, offset: 16673},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 567, col: 10, offset: 16545},
+								pos: position{line: 567, col: 10, offset: 16678},
 								expr: &actionExpr{
-									pos: position{line: 567, col: 11, offset: 16546},
+									pos: position{line: 567, col: 11, offset: 16679},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 567, col: 11, offset: 16546},
+										pos: position{line: 567, col: 11, offset: 16679},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 567, col: 11, offset: 16546},
+												pos:  position{line: 567, col: 11, offset: 16679},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 567, col: 14, offset: 16549},
+												pos:   position{line: 567, col: 14, offset: 16682},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 567, col: 19, offset: 16554},
+													pos:  position{line: 567, col: 19, offset: 16687},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 567, col: 38, offset: 16573},
+												pos:  position{line: 567, col: 38, offset: 16706},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 567, col: 41, offset: 16576},
+												pos:   position{line: 567, col: 41, offset: 16709},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 567, col: 46, offset: 16581},
+													pos:  position{line: 567, col: 46, offset: 16714},
 													name: "RelativeExpr",
 												},
 											},
@@ -3948,20 +3948,20 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 571, col: 1, offset: 16699},
+			pos:  position{line: 571, col: 1, offset: 16832},
 			expr: &actionExpr{
-				pos: position{line: 572, col: 5, offset: 16720},
+				pos: position{line: 572, col: 5, offset: 16853},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 572, col: 6, offset: 16721},
+					pos: position{line: 572, col: 6, offset: 16854},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 572, col: 6, offset: 16721},
+							pos:        position{line: 572, col: 6, offset: 16854},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 572, col: 12, offset: 16727},
+							pos:        position{line: 572, col: 12, offset: 16860},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3971,19 +3971,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 574, col: 1, offset: 16765},
+			pos:  position{line: 574, col: 1, offset: 16898},
 			expr: &choiceExpr{
-				pos: position{line: 575, col: 5, offset: 16788},
+				pos: position{line: 575, col: 5, offset: 16921},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 575, col: 5, offset: 16788},
+						pos:  position{line: 575, col: 5, offset: 16921},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 576, col: 5, offset: 16809},
+						pos: position{line: 576, col: 5, offset: 16942},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 576, col: 5, offset: 16809},
+							pos:        position{line: 576, col: 5, offset: 16942},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3993,53 +3993,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 578, col: 1, offset: 16846},
+			pos:  position{line: 578, col: 1, offset: 16979},
 			expr: &actionExpr{
-				pos: position{line: 579, col: 5, offset: 16863},
+				pos: position{line: 579, col: 5, offset: 16996},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 579, col: 5, offset: 16863},
+					pos: position{line: 579, col: 5, offset: 16996},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 579, col: 5, offset: 16863},
+							pos:   position{line: 579, col: 5, offset: 16996},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 579, col: 11, offset: 16869},
+								pos:  position{line: 579, col: 11, offset: 17002},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 580, col: 5, offset: 16886},
+							pos:   position{line: 580, col: 5, offset: 17019},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 580, col: 10, offset: 16891},
+								pos: position{line: 580, col: 10, offset: 17024},
 								expr: &actionExpr{
-									pos: position{line: 580, col: 11, offset: 16892},
+									pos: position{line: 580, col: 11, offset: 17025},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 580, col: 11, offset: 16892},
+										pos: position{line: 580, col: 11, offset: 17025},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 580, col: 11, offset: 16892},
+												pos:  position{line: 580, col: 11, offset: 17025},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 580, col: 14, offset: 16895},
+												pos:   position{line: 580, col: 14, offset: 17028},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 580, col: 17, offset: 16898},
+													pos:  position{line: 580, col: 17, offset: 17031},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 580, col: 34, offset: 16915},
+												pos:  position{line: 580, col: 34, offset: 17048},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 580, col: 37, offset: 16918},
+												pos:   position{line: 580, col: 37, offset: 17051},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 580, col: 42, offset: 16923},
+													pos:  position{line: 580, col: 42, offset: 17056},
 													name: "AdditiveExpr",
 												},
 											},
@@ -4054,30 +4054,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 584, col: 1, offset: 17039},
+			pos:  position{line: 584, col: 1, offset: 17172},
 			expr: &actionExpr{
-				pos: position{line: 584, col: 20, offset: 17058},
+				pos: position{line: 584, col: 20, offset: 17191},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 584, col: 21, offset: 17059},
+					pos: position{line: 584, col: 21, offset: 17192},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 584, col: 21, offset: 17059},
+							pos:        position{line: 584, col: 21, offset: 17192},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 584, col: 28, offset: 17066},
+							pos:        position{line: 584, col: 28, offset: 17199},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 584, col: 34, offset: 17072},
+							pos:        position{line: 584, col: 34, offset: 17205},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 584, col: 41, offset: 17079},
+							pos:        position{line: 584, col: 41, offset: 17212},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -4087,53 +4087,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 586, col: 1, offset: 17116},
+			pos:  position{line: 586, col: 1, offset: 17249},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 5, offset: 17133},
+				pos: position{line: 587, col: 5, offset: 17266},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 5, offset: 17133},
+					pos: position{line: 587, col: 5, offset: 17266},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 587, col: 5, offset: 17133},
+							pos:   position{line: 587, col: 5, offset: 17266},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 11, offset: 17139},
+								pos:  position{line: 587, col: 11, offset: 17272},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 588, col: 5, offset: 17162},
+							pos:   position{line: 588, col: 5, offset: 17295},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 588, col: 10, offset: 17167},
+								pos: position{line: 588, col: 10, offset: 17300},
 								expr: &actionExpr{
-									pos: position{line: 588, col: 11, offset: 17168},
+									pos: position{line: 588, col: 11, offset: 17301},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 588, col: 11, offset: 17168},
+										pos: position{line: 588, col: 11, offset: 17301},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 588, col: 11, offset: 17168},
+												pos:  position{line: 588, col: 11, offset: 17301},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 588, col: 14, offset: 17171},
+												pos:   position{line: 588, col: 14, offset: 17304},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 588, col: 17, offset: 17174},
+													pos:  position{line: 588, col: 17, offset: 17307},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 588, col: 34, offset: 17191},
+												pos:  position{line: 588, col: 34, offset: 17324},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 588, col: 37, offset: 17194},
+												pos:   position{line: 588, col: 37, offset: 17327},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 588, col: 42, offset: 17199},
+													pos:  position{line: 588, col: 42, offset: 17332},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -4148,20 +4148,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 592, col: 1, offset: 17321},
+			pos:  position{line: 592, col: 1, offset: 17454},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 20, offset: 17340},
+				pos: position{line: 592, col: 20, offset: 17473},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 592, col: 21, offset: 17341},
+					pos: position{line: 592, col: 21, offset: 17474},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 592, col: 21, offset: 17341},
+							pos:        position{line: 592, col: 21, offset: 17474},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 27, offset: 17347},
+							pos:        position{line: 592, col: 27, offset: 17480},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -4171,53 +4171,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 594, col: 1, offset: 17384},
+			pos:  position{line: 594, col: 1, offset: 17517},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 17407},
+				pos: position{line: 595, col: 5, offset: 17540},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 17407},
+					pos: position{line: 595, col: 5, offset: 17540},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 595, col: 5, offset: 17407},
+							pos:   position{line: 595, col: 5, offset: 17540},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 11, offset: 17413},
+								pos:  position{line: 595, col: 11, offset: 17546},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 596, col: 5, offset: 17425},
+							pos:   position{line: 596, col: 5, offset: 17558},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 596, col: 10, offset: 17430},
+								pos: position{line: 596, col: 10, offset: 17563},
 								expr: &actionExpr{
-									pos: position{line: 596, col: 11, offset: 17431},
+									pos: position{line: 596, col: 11, offset: 17564},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 596, col: 11, offset: 17431},
+										pos: position{line: 596, col: 11, offset: 17564},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 596, col: 11, offset: 17431},
+												pos:  position{line: 596, col: 11, offset: 17564},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 596, col: 14, offset: 17434},
+												pos:   position{line: 596, col: 14, offset: 17567},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 596, col: 17, offset: 17437},
+													pos:  position{line: 596, col: 17, offset: 17570},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 596, col: 40, offset: 17460},
+												pos:  position{line: 596, col: 40, offset: 17593},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 596, col: 43, offset: 17463},
+												pos:   position{line: 596, col: 43, offset: 17596},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 596, col: 48, offset: 17468},
+													pos:  position{line: 596, col: 48, offset: 17601},
 													name: "NotExpr",
 												},
 											},
@@ -4232,20 +4232,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 600, col: 1, offset: 17579},
+			pos:  position{line: 600, col: 1, offset: 17712},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 26, offset: 17604},
+				pos: position{line: 600, col: 26, offset: 17737},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 600, col: 27, offset: 17605},
+					pos: position{line: 600, col: 27, offset: 17738},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 600, col: 27, offset: 17605},
+							pos:        position{line: 600, col: 27, offset: 17738},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 600, col: 33, offset: 17611},
+							pos:        position{line: 600, col: 33, offset: 17744},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4255,30 +4255,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 602, col: 1, offset: 17648},
+			pos:  position{line: 602, col: 1, offset: 17781},
 			expr: &choiceExpr{
-				pos: position{line: 603, col: 5, offset: 17660},
+				pos: position{line: 603, col: 5, offset: 17793},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 603, col: 5, offset: 17660},
+						pos: position{line: 603, col: 5, offset: 17793},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 603, col: 5, offset: 17660},
+							pos: position{line: 603, col: 5, offset: 17793},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 603, col: 5, offset: 17660},
+									pos:        position{line: 603, col: 5, offset: 17793},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 603, col: 9, offset: 17664},
+									pos:  position{line: 603, col: 9, offset: 17797},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 603, col: 12, offset: 17667},
+									pos:   position{line: 603, col: 12, offset: 17800},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 603, col: 14, offset: 17669},
+										pos:  position{line: 603, col: 14, offset: 17802},
 										name: "NotExpr",
 									},
 								},
@@ -4286,7 +4286,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 606, col: 5, offset: 17778},
+						pos:  position{line: 606, col: 5, offset: 17911},
 						name: "CastExpr",
 					},
 				},
@@ -4294,42 +4294,42 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 608, col: 1, offset: 17788},
+			pos:  position{line: 608, col: 1, offset: 17921},
 			expr: &choiceExpr{
-				pos: position{line: 609, col: 5, offset: 17801},
+				pos: position{line: 609, col: 5, offset: 17934},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 609, col: 5, offset: 17801},
+						pos: position{line: 609, col: 5, offset: 17934},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 609, col: 5, offset: 17801},
+							pos: position{line: 609, col: 5, offset: 17934},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 609, col: 5, offset: 17801},
+									pos:   position{line: 609, col: 5, offset: 17934},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 7, offset: 17803},
+										pos:  position{line: 609, col: 7, offset: 17936},
 										name: "FuncExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 609, col: 16, offset: 17812},
+									pos:  position{line: 609, col: 16, offset: 17945},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 609, col: 19, offset: 17815},
+									pos:        position{line: 609, col: 19, offset: 17948},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 609, col: 23, offset: 17819},
+									pos:  position{line: 609, col: 23, offset: 17952},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 609, col: 26, offset: 17822},
+									pos:   position{line: 609, col: 26, offset: 17955},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 30, offset: 17826},
+										pos:  position{line: 609, col: 30, offset: 17959},
 										name: "CastType",
 									},
 								},
@@ -4337,7 +4337,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 612, col: 5, offset: 17926},
+						pos:  position{line: 612, col: 5, offset: 18061},
 						name: "FuncExpr",
 					},
 				},
@@ -4345,43 +4345,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 614, col: 1, offset: 17936},
+			pos:  position{line: 614, col: 1, offset: 18071},
 			expr: &choiceExpr{
-				pos: position{line: 615, col: 5, offset: 17949},
+				pos: position{line: 615, col: 5, offset: 18084},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 615, col: 5, offset: 17949},
+						pos:  position{line: 615, col: 5, offset: 18084},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 616, col: 5, offset: 17964},
+						pos:  position{line: 616, col: 5, offset: 18099},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 617, col: 5, offset: 17978},
+						pos:  position{line: 617, col: 5, offset: 18113},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 618, col: 5, offset: 17994},
+						pos: position{line: 618, col: 5, offset: 18129},
 						run: (*parser).callonFuncExpr5,
 						expr: &seqExpr{
-							pos: position{line: 618, col: 5, offset: 17994},
+							pos: position{line: 618, col: 5, offset: 18129},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 618, col: 5, offset: 17994},
+									pos:   position{line: 618, col: 5, offset: 18129},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 618, col: 11, offset: 18000},
+										pos:  position{line: 618, col: 11, offset: 18135},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 618, col: 20, offset: 18009},
+									pos:   position{line: 618, col: 20, offset: 18144},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 618, col: 25, offset: 18014},
+										pos: position{line: 618, col: 25, offset: 18149},
 										expr: &ruleRefExpr{
-											pos:  position{line: 618, col: 26, offset: 18015},
+											pos:  position{line: 618, col: 26, offset: 18150},
 											name: "Deref",
 										},
 									},
@@ -4390,11 +4390,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 621, col: 5, offset: 18086},
+						pos:  position{line: 621, col: 5, offset: 18221},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 622, col: 5, offset: 18100},
+						pos:  position{line: 622, col: 5, offset: 18235},
 						name: "Primary",
 					},
 				},
@@ -4402,20 +4402,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 624, col: 1, offset: 18109},
+			pos:  position{line: 624, col: 1, offset: 18244},
 			expr: &seqExpr{
-				pos: position{line: 624, col: 13, offset: 18121},
+				pos: position{line: 624, col: 13, offset: 18256},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 13, offset: 18121},
+						pos:  position{line: 624, col: 13, offset: 18256},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 22, offset: 18130},
+						pos:  position{line: 624, col: 22, offset: 18265},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 624, col: 25, offset: 18133},
+						pos:        position{line: 624, col: 25, offset: 18268},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -4424,27 +4424,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 626, col: 1, offset: 18138},
+			pos:  position{line: 626, col: 1, offset: 18273},
 			expr: &choiceExpr{
-				pos: position{line: 627, col: 5, offset: 18151},
+				pos: position{line: 627, col: 5, offset: 18286},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 627, col: 5, offset: 18151},
+						pos:        position{line: 627, col: 5, offset: 18286},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 628, col: 5, offset: 18161},
+						pos:        position{line: 628, col: 5, offset: 18296},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 629, col: 5, offset: 18173},
+						pos:        position{line: 629, col: 5, offset: 18308},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 630, col: 5, offset: 18186},
+						pos:        position{line: 630, col: 5, offset: 18321},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -4453,37 +4453,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 632, col: 1, offset: 18194},
+			pos:  position{line: 632, col: 1, offset: 18329},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 18208},
+				pos: position{line: 633, col: 5, offset: 18343},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 18208},
+					pos: position{line: 633, col: 5, offset: 18343},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 633, col: 5, offset: 18208},
+							pos:        position{line: 633, col: 5, offset: 18343},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 633, col: 13, offset: 18216},
+							pos:  position{line: 633, col: 13, offset: 18351},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 633, col: 16, offset: 18219},
+							pos:        position{line: 633, col: 16, offset: 18354},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 633, col: 20, offset: 18223},
+							pos:   position{line: 633, col: 20, offset: 18358},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 25, offset: 18228},
+								pos:  position{line: 633, col: 25, offset: 18363},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 633, col: 39, offset: 18242},
+							pos:        position{line: 633, col: 39, offset: 18377},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4493,53 +4493,53 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 635, col: 1, offset: 18268},
+			pos:  position{line: 635, col: 1, offset: 18403},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 5, offset: 18283},
+				pos: position{line: 636, col: 5, offset: 18418},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 636, col: 5, offset: 18283},
+					pos: position{line: 636, col: 5, offset: 18418},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 636, col: 5, offset: 18283},
+							pos:        position{line: 636, col: 5, offset: 18418},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 14, offset: 18292},
+							pos:  position{line: 636, col: 14, offset: 18427},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 17, offset: 18295},
+							pos:        position{line: 636, col: 17, offset: 18430},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 21, offset: 18299},
+							pos:  position{line: 636, col: 21, offset: 18434},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 24, offset: 18302},
+							pos:   position{line: 636, col: 24, offset: 18437},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 29, offset: 18307},
+								pos:  position{line: 636, col: 29, offset: 18442},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 42, offset: 18320},
+							pos:  position{line: 636, col: 42, offset: 18455},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 636, col: 45, offset: 18323},
+							pos:        position{line: 636, col: 45, offset: 18458},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 49, offset: 18327},
+							pos:   position{line: 636, col: 49, offset: 18462},
 							label: "methods",
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 57, offset: 18335},
+								pos:  position{line: 636, col: 57, offset: 18470},
 								name: "Methods",
 							},
 						},
@@ -4549,30 +4549,30 @@ var g = &grammar{
 		},
 		{
 			name: "Methods",
-			pos:  position{line: 644, col: 1, offset: 18731},
+			pos:  position{line: 644, col: 1, offset: 18868},
 			expr: &choiceExpr{
-				pos: position{line: 645, col: 5, offset: 18743},
+				pos: position{line: 645, col: 5, offset: 18880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 645, col: 5, offset: 18743},
+						pos: position{line: 645, col: 5, offset: 18880},
 						run: (*parser).callonMethods2,
 						expr: &labeledExpr{
-							pos:   position{line: 645, col: 5, offset: 18743},
+							pos:   position{line: 645, col: 5, offset: 18880},
 							label: "methods",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 645, col: 13, offset: 18751},
+								pos: position{line: 645, col: 13, offset: 18888},
 								expr: &ruleRefExpr{
-									pos:  position{line: 645, col: 13, offset: 18751},
+									pos:  position{line: 645, col: 13, offset: 18888},
 									name: "Method",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 646, col: 5, offset: 18787},
+						pos: position{line: 646, col: 5, offset: 18924},
 						run: (*parser).callonMethods6,
 						expr: &litMatcher{
-							pos:        position{line: 646, col: 5, offset: 18787},
+							pos:        position{line: 646, col: 5, offset: 18924},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4582,31 +4582,31 @@ var g = &grammar{
 		},
 		{
 			name: "Method",
-			pos:  position{line: 648, col: 1, offset: 18811},
+			pos:  position{line: 648, col: 1, offset: 18948},
 			expr: &actionExpr{
-				pos: position{line: 649, col: 5, offset: 18822},
+				pos: position{line: 649, col: 5, offset: 18959},
 				run: (*parser).callonMethod1,
 				expr: &seqExpr{
-					pos: position{line: 649, col: 5, offset: 18822},
+					pos: position{line: 649, col: 5, offset: 18959},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 5, offset: 18822},
+							pos:  position{line: 649, col: 5, offset: 18959},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 649, col: 8, offset: 18825},
+							pos:        position{line: 649, col: 8, offset: 18962},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 12, offset: 18829},
+							pos:  position{line: 649, col: 12, offset: 18966},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 15, offset: 18832},
+							pos:   position{line: 649, col: 15, offset: 18969},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 17, offset: 18834},
+								pos:  position{line: 649, col: 17, offset: 18971},
 								name: "Function",
 							},
 						},
@@ -4616,55 +4616,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 651, col: 1, offset: 18862},
+			pos:  position{line: 651, col: 1, offset: 18999},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 18875},
+				pos: position{line: 652, col: 5, offset: 19012},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 18875},
+					pos: position{line: 652, col: 5, offset: 19012},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 652, col: 5, offset: 18875},
+							pos: position{line: 652, col: 5, offset: 19012},
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 6, offset: 18876},
+								pos:  position{line: 652, col: 6, offset: 19013},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 16, offset: 18886},
+							pos:   position{line: 652, col: 16, offset: 19023},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 19, offset: 18889},
+								pos:  position{line: 652, col: 19, offset: 19026},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 34, offset: 18904},
+							pos:  position{line: 652, col: 34, offset: 19041},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 652, col: 37, offset: 18907},
+							pos:        position{line: 652, col: 37, offset: 19044},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 41, offset: 18911},
+							pos:  position{line: 652, col: 41, offset: 19048},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 44, offset: 18914},
+							pos:   position{line: 652, col: 44, offset: 19051},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 49, offset: 18919},
+								pos:  position{line: 652, col: 49, offset: 19056},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 62, offset: 18932},
+							pos:  position{line: 652, col: 62, offset: 19069},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 652, col: 65, offset: 18935},
+							pos:        position{line: 652, col: 65, offset: 19072},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4674,53 +4674,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 656, col: 1, offset: 19029},
+			pos:  position{line: 656, col: 1, offset: 19168},
 			expr: &choiceExpr{
-				pos: position{line: 657, col: 5, offset: 19046},
+				pos: position{line: 657, col: 5, offset: 19185},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 657, col: 5, offset: 19046},
+						pos: position{line: 657, col: 5, offset: 19185},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 657, col: 5, offset: 19046},
+							pos: position{line: 657, col: 5, offset: 19185},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 657, col: 5, offset: 19046},
+									pos:   position{line: 657, col: 5, offset: 19185},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 657, col: 11, offset: 19052},
+										pos:  position{line: 657, col: 11, offset: 19191},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 657, col: 16, offset: 19057},
+									pos:   position{line: 657, col: 16, offset: 19196},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 657, col: 21, offset: 19062},
+										pos: position{line: 657, col: 21, offset: 19201},
 										expr: &actionExpr{
-											pos: position{line: 657, col: 22, offset: 19063},
+											pos: position{line: 657, col: 22, offset: 19202},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 657, col: 22, offset: 19063},
+												pos: position{line: 657, col: 22, offset: 19202},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 657, col: 22, offset: 19063},
+														pos:  position{line: 657, col: 22, offset: 19202},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 657, col: 25, offset: 19066},
+														pos:        position{line: 657, col: 25, offset: 19205},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 657, col: 29, offset: 19070},
+														pos:  position{line: 657, col: 29, offset: 19209},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 657, col: 32, offset: 19073},
+														pos:   position{line: 657, col: 32, offset: 19212},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 657, col: 34, offset: 19075},
+															pos:  position{line: 657, col: 34, offset: 19214},
 															name: "Expr",
 														},
 													},
@@ -4733,10 +4733,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 19187},
+						pos: position{line: 660, col: 5, offset: 19326},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 660, col: 5, offset: 19187},
+							pos:  position{line: 660, col: 5, offset: 19326},
 							name: "__",
 						},
 					},
@@ -4745,31 +4745,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 662, col: 1, offset: 19223},
+			pos:  position{line: 662, col: 1, offset: 19362},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 19237},
+				pos: position{line: 663, col: 5, offset: 19376},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 19237},
+						pos: position{line: 663, col: 5, offset: 19376},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 19237},
+							pos: position{line: 663, col: 5, offset: 19376},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 663, col: 5, offset: 19237},
+									pos:   position{line: 663, col: 5, offset: 19376},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 663, col: 11, offset: 19243},
+										pos:  position{line: 663, col: 11, offset: 19382},
 										name: "DotId",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 17, offset: 19249},
+									pos:   position{line: 663, col: 17, offset: 19388},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 663, col: 22, offset: 19254},
+										pos: position{line: 663, col: 22, offset: 19393},
 										expr: &ruleRefExpr{
-											pos:  position{line: 663, col: 23, offset: 19255},
+											pos:  position{line: 663, col: 23, offset: 19394},
 											name: "Deref",
 										},
 									},
@@ -4778,26 +4778,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 666, col: 5, offset: 19326},
+						pos: position{line: 666, col: 5, offset: 19465},
 						run: (*parser).callonDerefExpr9,
 						expr: &seqExpr{
-							pos: position{line: 666, col: 5, offset: 19326},
+							pos: position{line: 666, col: 5, offset: 19465},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 666, col: 5, offset: 19326},
+									pos:   position{line: 666, col: 5, offset: 19465},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 666, col: 11, offset: 19332},
+										pos:  position{line: 666, col: 11, offset: 19471},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 666, col: 22, offset: 19343},
+									pos:   position{line: 666, col: 22, offset: 19482},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 666, col: 27, offset: 19348},
+										pos: position{line: 666, col: 27, offset: 19487},
 										expr: &ruleRefExpr{
-											pos:  position{line: 666, col: 28, offset: 19349},
+											pos:  position{line: 666, col: 28, offset: 19488},
 											name: "Deref",
 										},
 									},
@@ -4806,10 +4806,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 669, col: 5, offset: 19420},
+						pos: position{line: 669, col: 5, offset: 19559},
 						run: (*parser).callonDerefExpr16,
 						expr: &litMatcher{
-							pos:        position{line: 669, col: 5, offset: 19420},
+							pos:        position{line: 669, col: 5, offset: 19559},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -4819,26 +4819,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotId",
-			pos:  position{line: 673, col: 1, offset: 19487},
+			pos:  position{line: 673, col: 1, offset: 19628},
 			expr: &choiceExpr{
-				pos: position{line: 674, col: 5, offset: 19497},
+				pos: position{line: 674, col: 5, offset: 19638},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 19497},
+						pos: position{line: 674, col: 5, offset: 19638},
 						run: (*parser).callonDotId2,
 						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 19497},
+							pos: position{line: 674, col: 5, offset: 19638},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 674, col: 5, offset: 19497},
+									pos:        position{line: 674, col: 5, offset: 19638},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 674, col: 9, offset: 19501},
+									pos:   position{line: 674, col: 9, offset: 19642},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 674, col: 15, offset: 19507},
+										pos:  position{line: 674, col: 15, offset: 19648},
 										name: "Identifier",
 									},
 								},
@@ -4846,31 +4846,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 19721},
+						pos: position{line: 683, col: 5, offset: 19864},
 						run: (*parser).callonDotId7,
 						expr: &seqExpr{
-							pos: position{line: 683, col: 5, offset: 19721},
+							pos: position{line: 683, col: 5, offset: 19864},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 683, col: 5, offset: 19721},
+									pos:        position{line: 683, col: 5, offset: 19864},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 683, col: 9, offset: 19725},
+									pos:        position{line: 683, col: 9, offset: 19868},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 683, col: 13, offset: 19729},
+									pos:   position{line: 683, col: 13, offset: 19872},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 683, col: 18, offset: 19734},
+										pos:  position{line: 683, col: 18, offset: 19877},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 683, col: 23, offset: 19739},
+									pos:        position{line: 683, col: 23, offset: 19882},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4882,52 +4882,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 693, col: 1, offset: 19942},
+			pos:  position{line: 693, col: 1, offset: 20087},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 19952},
+				pos: position{line: 694, col: 5, offset: 20097},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 19952},
+						pos: position{line: 694, col: 5, offset: 20097},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 694, col: 5, offset: 19952},
+							pos: position{line: 694, col: 5, offset: 20097},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 694, col: 5, offset: 19952},
+									pos:        position{line: 694, col: 5, offset: 20097},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 9, offset: 19956},
+									pos:   position{line: 694, col: 9, offset: 20101},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 14, offset: 19961},
+										pos:  position{line: 694, col: 14, offset: 20106},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 694, col: 27, offset: 19974},
+									pos:  position{line: 694, col: 27, offset: 20119},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 694, col: 30, offset: 19977},
+									pos:        position{line: 694, col: 30, offset: 20122},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 694, col: 34, offset: 19981},
+									pos:  position{line: 694, col: 34, offset: 20126},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 37, offset: 19984},
+									pos:   position{line: 694, col: 37, offset: 20129},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 40, offset: 19987},
+										pos:  position{line: 694, col: 40, offset: 20132},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 694, col: 53, offset: 20000},
+									pos:        position{line: 694, col: 53, offset: 20145},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4935,39 +4935,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20171},
+						pos: position{line: 700, col: 5, offset: 20316},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 700, col: 5, offset: 20171},
+							pos: position{line: 700, col: 5, offset: 20316},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 700, col: 5, offset: 20171},
+									pos:        position{line: 700, col: 5, offset: 20316},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 9, offset: 20175},
+									pos:  position{line: 700, col: 9, offset: 20320},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 12, offset: 20178},
+									pos:        position{line: 700, col: 12, offset: 20323},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 16, offset: 20182},
+									pos:  position{line: 700, col: 16, offset: 20327},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 19, offset: 20185},
+									pos:   position{line: 700, col: 19, offset: 20330},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 22, offset: 20188},
+										pos:  position{line: 700, col: 22, offset: 20333},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 700, col: 35, offset: 20201},
+									pos:        position{line: 700, col: 35, offset: 20346},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4975,39 +4975,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20372},
+						pos: position{line: 706, col: 5, offset: 20517},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 706, col: 5, offset: 20372},
+							pos: position{line: 706, col: 5, offset: 20517},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 706, col: 5, offset: 20372},
+									pos:        position{line: 706, col: 5, offset: 20517},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 706, col: 9, offset: 20376},
+									pos:   position{line: 706, col: 9, offset: 20521},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 14, offset: 20381},
+										pos:  position{line: 706, col: 14, offset: 20526},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 27, offset: 20394},
+									pos:  position{line: 706, col: 27, offset: 20539},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 30, offset: 20397},
+									pos:        position{line: 706, col: 30, offset: 20542},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 34, offset: 20401},
+									pos:  position{line: 706, col: 34, offset: 20546},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 37, offset: 20404},
+									pos:        position{line: 706, col: 37, offset: 20549},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5015,26 +5015,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 20577},
+						pos: position{line: 712, col: 5, offset: 20722},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 20577},
+							pos: position{line: 712, col: 5, offset: 20722},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 712, col: 5, offset: 20577},
+									pos:        position{line: 712, col: 5, offset: 20722},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 9, offset: 20581},
+									pos:   position{line: 712, col: 9, offset: 20726},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 712, col: 14, offset: 20586},
+										pos:  position{line: 712, col: 14, offset: 20731},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 19, offset: 20591},
+									pos:        position{line: 712, col: 19, offset: 20736},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5042,29 +5042,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20640},
+						pos: position{line: 713, col: 5, offset: 20785},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 713, col: 5, offset: 20640},
+							pos: position{line: 713, col: 5, offset: 20785},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 713, col: 5, offset: 20640},
+									pos:        position{line: 713, col: 5, offset: 20785},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 713, col: 9, offset: 20644},
+									pos: position{line: 713, col: 9, offset: 20789},
 									expr: &litMatcher{
-										pos:        position{line: 713, col: 11, offset: 20646},
+										pos:        position{line: 713, col: 11, offset: 20791},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 713, col: 16, offset: 20651},
+									pos:   position{line: 713, col: 16, offset: 20796},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 713, col: 19, offset: 20654},
+										pos:  position{line: 713, col: 19, offset: 20799},
 										name: "Identifier",
 									},
 								},
@@ -5076,43 +5076,43 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 715, col: 1, offset: 20705},
+			pos:  position{line: 715, col: 1, offset: 20850},
 			expr: &choiceExpr{
-				pos: position{line: 716, col: 5, offset: 20717},
+				pos: position{line: 716, col: 5, offset: 20862},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 716, col: 5, offset: 20717},
+						pos:  position{line: 716, col: 5, offset: 20862},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 717, col: 5, offset: 20729},
+						pos: position{line: 717, col: 5, offset: 20874},
 						run: (*parser).callonPrimary3,
 						expr: &seqExpr{
-							pos: position{line: 717, col: 5, offset: 20729},
+							pos: position{line: 717, col: 5, offset: 20874},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 717, col: 5, offset: 20729},
+									pos:        position{line: 717, col: 5, offset: 20874},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 9, offset: 20733},
+									pos:  position{line: 717, col: 9, offset: 20878},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 717, col: 12, offset: 20736},
+									pos:   position{line: 717, col: 12, offset: 20881},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 717, col: 17, offset: 20741},
+										pos:  position{line: 717, col: 17, offset: 20886},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 22, offset: 20746},
+									pos:  position{line: 717, col: 22, offset: 20891},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 717, col: 25, offset: 20749},
+									pos:        position{line: 717, col: 25, offset: 20894},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5124,44 +5124,44 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 719, col: 1, offset: 20775},
+			pos:  position{line: 719, col: 1, offset: 20920},
 			expr: &choiceExpr{
-				pos: position{line: 720, col: 5, offset: 20787},
+				pos: position{line: 720, col: 5, offset: 20932},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 720, col: 5, offset: 20787},
+						pos:  position{line: 720, col: 5, offset: 20932},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 5, offset: 20803},
+						pos:  position{line: 721, col: 5, offset: 20948},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 722, col: 5, offset: 20821},
+						pos:  position{line: 722, col: 5, offset: 20966},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 723, col: 5, offset: 20839},
+						pos:  position{line: 723, col: 5, offset: 20984},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 724, col: 5, offset: 20857},
+						pos:  position{line: 724, col: 5, offset: 21002},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 725, col: 5, offset: 20876},
+						pos:  position{line: 725, col: 5, offset: 21021},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 726, col: 5, offset: 20893},
+						pos:  position{line: 726, col: 5, offset: 21038},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 727, col: 5, offset: 20912},
+						pos:  position{line: 727, col: 5, offset: 21057},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 728, col: 5, offset: 20931},
+						pos:  position{line: 728, col: 5, offset: 21076},
 						name: "NullLiteral",
 					},
 				},
@@ -5169,15 +5169,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 730, col: 1, offset: 20944},
+			pos:  position{line: 730, col: 1, offset: 21089},
 			expr: &actionExpr{
-				pos: position{line: 731, col: 5, offset: 20962},
+				pos: position{line: 731, col: 5, offset: 21107},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 731, col: 5, offset: 20962},
+					pos:   position{line: 731, col: 5, offset: 21107},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 731, col: 7, offset: 20964},
+						pos:  position{line: 731, col: 7, offset: 21109},
 						name: "QuotedString",
 					},
 				},
@@ -5185,25 +5185,25 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpLiteral",
-			pos:  position{line: 735, col: 1, offset: 21074},
+			pos:  position{line: 735, col: 1, offset: 21221},
 			expr: &actionExpr{
-				pos: position{line: 736, col: 5, offset: 21092},
+				pos: position{line: 736, col: 5, offset: 21239},
 				run: (*parser).callonRegexpLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 736, col: 5, offset: 21092},
+					pos: position{line: 736, col: 5, offset: 21239},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 736, col: 5, offset: 21092},
+							pos:   position{line: 736, col: 5, offset: 21239},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 736, col: 7, offset: 21094},
+								pos:  position{line: 736, col: 7, offset: 21241},
 								name: "Regexp",
 							},
 						},
 						&notExpr{
-							pos: position{line: 736, col: 14, offset: 21101},
+							pos: position{line: 736, col: 14, offset: 21248},
 							expr: &ruleRefExpr{
-								pos:  position{line: 736, col: 15, offset: 21102},
+								pos:  position{line: 736, col: 15, offset: 21249},
 								name: "KeyWordStart",
 							},
 						},
@@ -5213,28 +5213,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 740, col: 1, offset: 21212},
+			pos:  position{line: 740, col: 1, offset: 21361},
 			expr: &choiceExpr{
-				pos: position{line: 741, col: 5, offset: 21230},
+				pos: position{line: 741, col: 5, offset: 21379},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 741, col: 5, offset: 21230},
+						pos: position{line: 741, col: 5, offset: 21379},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 741, col: 5, offset: 21230},
+							pos: position{line: 741, col: 5, offset: 21379},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 741, col: 5, offset: 21230},
+									pos:   position{line: 741, col: 5, offset: 21379},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 741, col: 7, offset: 21232},
+										pos:  position{line: 741, col: 7, offset: 21381},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 741, col: 14, offset: 21239},
+									pos: position{line: 741, col: 14, offset: 21388},
 									expr: &ruleRefExpr{
-										pos:  position{line: 741, col: 15, offset: 21240},
+										pos:  position{line: 741, col: 15, offset: 21389},
 										name: "IdentifierRest",
 									},
 								},
@@ -5242,13 +5242,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 21352},
+						pos: position{line: 744, col: 5, offset: 21503},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 744, col: 5, offset: 21352},
+							pos:   position{line: 744, col: 5, offset: 21503},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 7, offset: 21354},
+								pos:  position{line: 744, col: 7, offset: 21505},
 								name: "IP4Net",
 							},
 						},
@@ -5258,28 +5258,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 748, col: 1, offset: 21455},
+			pos:  position{line: 748, col: 1, offset: 21608},
 			expr: &choiceExpr{
-				pos: position{line: 749, col: 5, offset: 21474},
+				pos: position{line: 749, col: 5, offset: 21627},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 749, col: 5, offset: 21474},
+						pos: position{line: 749, col: 5, offset: 21627},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 749, col: 5, offset: 21474},
+							pos: position{line: 749, col: 5, offset: 21627},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 749, col: 5, offset: 21474},
+									pos:   position{line: 749, col: 5, offset: 21627},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 7, offset: 21476},
+										pos:  position{line: 749, col: 7, offset: 21629},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 749, col: 11, offset: 21480},
+									pos: position{line: 749, col: 11, offset: 21633},
 									expr: &ruleRefExpr{
-										pos:  position{line: 749, col: 12, offset: 21481},
+										pos:  position{line: 749, col: 12, offset: 21634},
 										name: "IdentifierRest",
 									},
 								},
@@ -5287,13 +5287,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 21592},
+						pos: position{line: 752, col: 5, offset: 21747},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 752, col: 5, offset: 21592},
+							pos:   position{line: 752, col: 5, offset: 21747},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 7, offset: 21594},
+								pos:  position{line: 752, col: 7, offset: 21749},
 								name: "IP",
 							},
 						},
@@ -5303,15 +5303,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 756, col: 1, offset: 21690},
+			pos:  position{line: 756, col: 1, offset: 21847},
 			expr: &actionExpr{
-				pos: position{line: 757, col: 5, offset: 21707},
+				pos: position{line: 757, col: 5, offset: 21864},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 757, col: 5, offset: 21707},
+					pos:   position{line: 757, col: 5, offset: 21864},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 757, col: 7, offset: 21709},
+						pos:  position{line: 757, col: 7, offset: 21866},
 						name: "FloatString",
 					},
 				},
@@ -5319,15 +5319,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 761, col: 1, offset: 21819},
+			pos:  position{line: 761, col: 1, offset: 21978},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 5, offset: 21838},
+				pos: position{line: 762, col: 5, offset: 21997},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 762, col: 5, offset: 21838},
+					pos:   position{line: 762, col: 5, offset: 21997},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 762, col: 7, offset: 21840},
+						pos:  position{line: 762, col: 7, offset: 21999},
 						name: "IntString",
 					},
 				},
@@ -5335,24 +5335,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 766, col: 1, offset: 21946},
+			pos:  position{line: 766, col: 1, offset: 22107},
 			expr: &choiceExpr{
-				pos: position{line: 767, col: 5, offset: 21965},
+				pos: position{line: 767, col: 5, offset: 22126},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 767, col: 5, offset: 21965},
+						pos: position{line: 767, col: 5, offset: 22126},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 767, col: 5, offset: 21965},
+							pos:        position{line: 767, col: 5, offset: 22126},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 768, col: 5, offset: 22075},
+						pos: position{line: 768, col: 5, offset: 22238},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 768, col: 5, offset: 22075},
+							pos:        position{line: 768, col: 5, offset: 22238},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -5362,12 +5362,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 770, col: 1, offset: 22183},
+			pos:  position{line: 770, col: 1, offset: 22348},
 			expr: &actionExpr{
-				pos: position{line: 771, col: 5, offset: 22199},
+				pos: position{line: 771, col: 5, offset: 22364},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 771, col: 5, offset: 22199},
+					pos:        position{line: 771, col: 5, offset: 22364},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -5375,15 +5375,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 773, col: 1, offset: 22302},
+			pos:  position{line: 773, col: 1, offset: 22469},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 5, offset: 22318},
+				pos: position{line: 774, col: 5, offset: 22485},
 				run: (*parser).callonTypeLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 774, col: 5, offset: 22318},
+					pos:   position{line: 774, col: 5, offset: 22485},
 					label: "typ",
 					expr: &ruleRefExpr{
-						pos:  position{line: 774, col: 9, offset: 22322},
+						pos:  position{line: 774, col: 9, offset: 22489},
 						name: "TypeExternal",
 					},
 				},
@@ -5391,16 +5391,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 778, col: 1, offset: 22418},
+			pos:  position{line: 778, col: 1, offset: 22587},
 			expr: &choiceExpr{
-				pos: position{line: 779, col: 5, offset: 22431},
+				pos: position{line: 779, col: 5, offset: 22600},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 779, col: 5, offset: 22431},
+						pos:  position{line: 779, col: 5, offset: 22600},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 780, col: 5, offset: 22448},
+						pos:  position{line: 780, col: 5, offset: 22617},
 						name: "PrimitiveType",
 					},
 				},
@@ -5408,48 +5408,48 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 782, col: 1, offset: 22463},
+			pos:  position{line: 782, col: 1, offset: 22632},
 			expr: &choiceExpr{
-				pos: position{line: 783, col: 5, offset: 22480},
+				pos: position{line: 783, col: 5, offset: 22649},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 783, col: 5, offset: 22480},
+						pos: position{line: 783, col: 5, offset: 22649},
 						run: (*parser).callonTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 783, col: 5, offset: 22480},
+							pos: position{line: 783, col: 5, offset: 22649},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 783, col: 5, offset: 22480},
+									pos:        position{line: 783, col: 5, offset: 22649},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 12, offset: 22487},
+									pos:  position{line: 783, col: 12, offset: 22656},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 783, col: 15, offset: 22490},
+									pos:        position{line: 783, col: 15, offset: 22659},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 19, offset: 22494},
+									pos:  position{line: 783, col: 19, offset: 22663},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 783, col: 22, offset: 22497},
+									pos:   position{line: 783, col: 22, offset: 22666},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 783, col: 26, offset: 22501},
+										pos:  position{line: 783, col: 26, offset: 22670},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 783, col: 31, offset: 22506},
+									pos:  position{line: 783, col: 31, offset: 22675},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 783, col: 34, offset: 22509},
+									pos:        position{line: 783, col: 34, offset: 22678},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5457,43 +5457,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 22536},
+						pos: position{line: 784, col: 5, offset: 22705},
 						run: (*parser).callonTypeExternal12,
 						expr: &seqExpr{
-							pos: position{line: 784, col: 5, offset: 22536},
+							pos: position{line: 784, col: 5, offset: 22705},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 784, col: 5, offset: 22536},
+									pos:        position{line: 784, col: 5, offset: 22705},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 12, offset: 22543},
+									pos:  position{line: 784, col: 12, offset: 22712},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 15, offset: 22546},
+									pos:        position{line: 784, col: 15, offset: 22715},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 19, offset: 22550},
+									pos:  position{line: 784, col: 19, offset: 22719},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 784, col: 22, offset: 22553},
+									pos:   position{line: 784, col: 22, offset: 22722},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 784, col: 26, offset: 22557},
+										pos:  position{line: 784, col: 26, offset: 22726},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 36, offset: 22567},
+									pos:  position{line: 784, col: 36, offset: 22736},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 39, offset: 22570},
+									pos:        position{line: 784, col: 39, offset: 22739},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5501,27 +5501,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 785, col: 5, offset: 22598},
+						pos:  position{line: 785, col: 5, offset: 22767},
 						name: "ComplexType",
 					},
 					&actionExpr{
-						pos: position{line: 786, col: 5, offset: 22614},
+						pos: position{line: 786, col: 5, offset: 22783},
 						run: (*parser).callonTypeExternal23,
 						expr: &seqExpr{
-							pos: position{line: 786, col: 5, offset: 22614},
+							pos: position{line: 786, col: 5, offset: 22783},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 786, col: 5, offset: 22614},
+									pos:   position{line: 786, col: 5, offset: 22783},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 786, col: 9, offset: 22618},
+										pos:  position{line: 786, col: 9, offset: 22787},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 786, col: 31, offset: 22640},
+									pos: position{line: 786, col: 31, offset: 22809},
 									expr: &ruleRefExpr{
-										pos:  position{line: 786, col: 32, offset: 22641},
+										pos:  position{line: 786, col: 32, offset: 22810},
 										name: "IdentifierRest",
 									},
 								},
@@ -5533,16 +5533,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 788, col: 1, offset: 22677},
+			pos:  position{line: 788, col: 1, offset: 22846},
 			expr: &choiceExpr{
-				pos: position{line: 789, col: 5, offset: 22686},
+				pos: position{line: 789, col: 5, offset: 22855},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 789, col: 5, offset: 22686},
+						pos:  position{line: 789, col: 5, offset: 22855},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 790, col: 5, offset: 22704},
+						pos:  position{line: 790, col: 5, offset: 22873},
 						name: "ComplexType",
 					},
 				},
@@ -5550,77 +5550,77 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 792, col: 1, offset: 22717},
+			pos:  position{line: 792, col: 1, offset: 22886},
 			expr: &choiceExpr{
-				pos: position{line: 793, col: 5, offset: 22735},
+				pos: position{line: 793, col: 5, offset: 22904},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 793, col: 5, offset: 22735},
+						pos: position{line: 793, col: 5, offset: 22904},
 						run: (*parser).callonAmbiguousType2,
 						expr: &litMatcher{
-							pos:        position{line: 793, col: 5, offset: 22735},
+							pos:        position{line: 793, col: 5, offset: 22904},
 							val:        "null",
 							ignoreCase: false,
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 796, col: 5, offset: 22813},
+						pos:   position{line: 796, col: 5, offset: 22984},
 						label: "name",
 						expr: &ruleRefExpr{
-							pos:  position{line: 796, col: 10, offset: 22818},
+							pos:  position{line: 796, col: 10, offset: 22989},
 							name: "PrimitiveType",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 797, col: 5, offset: 22836},
+						pos: position{line: 797, col: 5, offset: 23007},
 						run: (*parser).callonAmbiguousType6,
 						expr: &seqExpr{
-							pos: position{line: 797, col: 5, offset: 22836},
+							pos: position{line: 797, col: 5, offset: 23007},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 797, col: 5, offset: 22836},
+									pos:   position{line: 797, col: 5, offset: 23007},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 797, col: 10, offset: 22841},
+										pos:  position{line: 797, col: 10, offset: 23012},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 25, offset: 22856},
+									pos:  position{line: 797, col: 25, offset: 23027},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 28, offset: 22859},
+									pos:        position{line: 797, col: 28, offset: 23030},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 32, offset: 22863},
+									pos:  position{line: 797, col: 32, offset: 23034},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 35, offset: 22866},
+									pos:        position{line: 797, col: 35, offset: 23037},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 39, offset: 22870},
+									pos:  position{line: 797, col: 39, offset: 23041},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 797, col: 42, offset: 22873},
+									pos:   position{line: 797, col: 42, offset: 23044},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 797, col: 46, offset: 22877},
+										pos:  position{line: 797, col: 46, offset: 23048},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 797, col: 51, offset: 22882},
+									pos:  position{line: 797, col: 51, offset: 23053},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 797, col: 54, offset: 22885},
+									pos:        position{line: 797, col: 54, offset: 23056},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5628,42 +5628,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 800, col: 5, offset: 22984},
+						pos: position{line: 800, col: 5, offset: 23157},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 800, col: 5, offset: 22984},
+							pos:   position{line: 800, col: 5, offset: 23157},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 800, col: 10, offset: 22989},
+								pos:  position{line: 800, col: 10, offset: 23162},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 803, col: 5, offset: 23089},
+						pos: position{line: 803, col: 5, offset: 23264},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 803, col: 5, offset: 23089},
+							pos: position{line: 803, col: 5, offset: 23264},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 803, col: 5, offset: 23089},
+									pos:        position{line: 803, col: 5, offset: 23264},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 803, col: 9, offset: 23093},
+									pos:  position{line: 803, col: 9, offset: 23268},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 803, col: 12, offset: 23096},
+									pos:   position{line: 803, col: 12, offset: 23271},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 803, col: 14, offset: 23098},
+										pos:  position{line: 803, col: 14, offset: 23273},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 803, col: 25, offset: 23109},
+									pos:        position{line: 803, col: 25, offset: 23284},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5675,15 +5675,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 805, col: 1, offset: 23132},
+			pos:  position{line: 805, col: 1, offset: 23307},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 23146},
+				pos: position{line: 806, col: 5, offset: 23321},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 806, col: 5, offset: 23146},
+					pos:   position{line: 806, col: 5, offset: 23321},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 806, col: 11, offset: 23152},
+						pos:  position{line: 806, col: 11, offset: 23327},
 						name: "TypeList",
 					},
 				},
@@ -5691,28 +5691,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 810, col: 1, offset: 23246},
+			pos:  position{line: 810, col: 1, offset: 23423},
 			expr: &actionExpr{
-				pos: position{line: 811, col: 5, offset: 23259},
+				pos: position{line: 811, col: 5, offset: 23436},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 811, col: 5, offset: 23259},
+					pos: position{line: 811, col: 5, offset: 23436},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 811, col: 5, offset: 23259},
+							pos:   position{line: 811, col: 5, offset: 23436},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 811, col: 11, offset: 23265},
+								pos:  position{line: 811, col: 11, offset: 23442},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 811, col: 16, offset: 23270},
+							pos:   position{line: 811, col: 16, offset: 23447},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 811, col: 21, offset: 23275},
+								pos: position{line: 811, col: 21, offset: 23452},
 								expr: &ruleRefExpr{
-									pos:  position{line: 811, col: 21, offset: 23275},
+									pos:  position{line: 811, col: 21, offset: 23452},
 									name: "TypeListTail",
 								},
 							},
@@ -5723,31 +5723,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 815, col: 1, offset: 23369},
+			pos:  position{line: 815, col: 1, offset: 23546},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 16, offset: 23384},
+				pos: position{line: 815, col: 16, offset: 23561},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 16, offset: 23384},
+					pos: position{line: 815, col: 16, offset: 23561},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 16, offset: 23384},
+							pos:  position{line: 815, col: 16, offset: 23561},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 815, col: 19, offset: 23387},
+							pos:        position{line: 815, col: 19, offset: 23564},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 23, offset: 23391},
+							pos:  position{line: 815, col: 23, offset: 23568},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 26, offset: 23394},
+							pos:   position{line: 815, col: 26, offset: 23571},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 30, offset: 23398},
+								pos:  position{line: 815, col: 30, offset: 23575},
 								name: "Type",
 							},
 						},
@@ -5757,39 +5757,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 817, col: 1, offset: 23424},
+			pos:  position{line: 817, col: 1, offset: 23601},
 			expr: &choiceExpr{
-				pos: position{line: 818, col: 5, offset: 23440},
+				pos: position{line: 818, col: 5, offset: 23617},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 818, col: 5, offset: 23440},
+						pos: position{line: 818, col: 5, offset: 23617},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 818, col: 5, offset: 23440},
+							pos: position{line: 818, col: 5, offset: 23617},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 818, col: 5, offset: 23440},
+									pos:        position{line: 818, col: 5, offset: 23617},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 818, col: 9, offset: 23444},
+									pos:  position{line: 818, col: 9, offset: 23621},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 818, col: 12, offset: 23447},
+									pos:   position{line: 818, col: 12, offset: 23624},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 818, col: 19, offset: 23454},
+										pos:  position{line: 818, col: 19, offset: 23631},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 818, col: 33, offset: 23468},
+									pos:  position{line: 818, col: 33, offset: 23645},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 818, col: 36, offset: 23471},
+									pos:        position{line: 818, col: 36, offset: 23648},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5797,34 +5797,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 821, col: 5, offset: 23564},
+						pos: position{line: 821, col: 5, offset: 23743},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 821, col: 5, offset: 23564},
+							pos: position{line: 821, col: 5, offset: 23743},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 821, col: 5, offset: 23564},
+									pos:        position{line: 821, col: 5, offset: 23743},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 9, offset: 23568},
+									pos:  position{line: 821, col: 9, offset: 23747},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 821, col: 12, offset: 23571},
+									pos:   position{line: 821, col: 12, offset: 23750},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 821, col: 16, offset: 23575},
+										pos:  position{line: 821, col: 16, offset: 23754},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 21, offset: 23580},
+									pos:  position{line: 821, col: 21, offset: 23759},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 821, col: 24, offset: 23583},
+									pos:        position{line: 821, col: 24, offset: 23762},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5832,34 +5832,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 824, col: 5, offset: 23670},
+						pos: position{line: 824, col: 5, offset: 23851},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 824, col: 5, offset: 23670},
+							pos: position{line: 824, col: 5, offset: 23851},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 824, col: 5, offset: 23670},
+									pos:        position{line: 824, col: 5, offset: 23851},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 824, col: 10, offset: 23675},
+									pos:  position{line: 824, col: 10, offset: 23856},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 824, col: 13, offset: 23678},
+									pos:   position{line: 824, col: 13, offset: 23859},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 824, col: 17, offset: 23682},
+										pos:  position{line: 824, col: 17, offset: 23863},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 824, col: 22, offset: 23687},
+									pos:  position{line: 824, col: 22, offset: 23868},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 824, col: 25, offset: 23690},
+									pos:        position{line: 824, col: 25, offset: 23871},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -5867,55 +5867,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 827, col: 5, offset: 23776},
+						pos: position{line: 827, col: 5, offset: 23959},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 827, col: 5, offset: 23776},
+							pos: position{line: 827, col: 5, offset: 23959},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 827, col: 5, offset: 23776},
+									pos:        position{line: 827, col: 5, offset: 23959},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 10, offset: 23781},
+									pos:  position{line: 827, col: 10, offset: 23964},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 827, col: 13, offset: 23784},
+									pos:   position{line: 827, col: 13, offset: 23967},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 827, col: 21, offset: 23792},
+										pos:  position{line: 827, col: 21, offset: 23975},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 26, offset: 23797},
+									pos:  position{line: 827, col: 26, offset: 23980},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 827, col: 29, offset: 23800},
+									pos:        position{line: 827, col: 29, offset: 23983},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 33, offset: 23804},
+									pos:  position{line: 827, col: 33, offset: 23987},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 827, col: 36, offset: 23807},
+									pos:   position{line: 827, col: 36, offset: 23990},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 827, col: 44, offset: 23815},
+										pos:  position{line: 827, col: 44, offset: 23998},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 827, col: 49, offset: 23820},
+									pos:  position{line: 827, col: 49, offset: 24003},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 827, col: 52, offset: 23823},
+									pos:        position{line: 827, col: 52, offset: 24006},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -5927,16 +5927,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 831, col: 1, offset: 23935},
+			pos:  position{line: 831, col: 1, offset: 24120},
 			expr: &choiceExpr{
-				pos: position{line: 832, col: 5, offset: 23953},
+				pos: position{line: 832, col: 5, offset: 24138},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 832, col: 5, offset: 23953},
+						pos:  position{line: 832, col: 5, offset: 24138},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 833, col: 5, offset: 23979},
+						pos:  position{line: 833, col: 5, offset: 24164},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -5944,65 +5944,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 839, col: 1, offset: 24238},
+			pos:  position{line: 839, col: 1, offset: 24423},
 			expr: &actionExpr{
-				pos: position{line: 840, col: 5, offset: 24264},
+				pos: position{line: 840, col: 5, offset: 24449},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 840, col: 9, offset: 24268},
+					pos: position{line: 840, col: 9, offset: 24453},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 840, col: 9, offset: 24268},
+							pos:        position{line: 840, col: 9, offset: 24453},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 19, offset: 24278},
+							pos:        position{line: 840, col: 19, offset: 24463},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 30, offset: 24289},
+							pos:        position{line: 840, col: 30, offset: 24474},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 840, col: 41, offset: 24300},
+							pos:        position{line: 840, col: 41, offset: 24485},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 9, offset: 24317},
+							pos:        position{line: 841, col: 9, offset: 24502},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 18, offset: 24326},
+							pos:        position{line: 841, col: 18, offset: 24511},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 28, offset: 24336},
+							pos:        position{line: 841, col: 28, offset: 24521},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 38, offset: 24346},
+							pos:        position{line: 841, col: 38, offset: 24531},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 9, offset: 24362},
+							pos:        position{line: 842, col: 9, offset: 24547},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 843, col: 9, offset: 24380},
+							pos:        position{line: 843, col: 9, offset: 24565},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 843, col: 18, offset: 24389},
+							pos:        position{line: 843, col: 18, offset: 24574},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -6012,50 +6012,50 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 852, col: 1, offset: 24871},
+			pos:  position{line: 852, col: 1, offset: 25058},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 24897},
+				pos: position{line: 853, col: 5, offset: 25084},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 853, col: 9, offset: 24901},
+					pos: position{line: 853, col: 9, offset: 25088},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 853, col: 9, offset: 24901},
+							pos:        position{line: 853, col: 9, offset: 25088},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 853, col: 22, offset: 24914},
+							pos:        position{line: 853, col: 22, offset: 25101},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 854, col: 9, offset: 24929},
+							pos:        position{line: 854, col: 9, offset: 25116},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 855, col: 9, offset: 24945},
+							pos:        position{line: 855, col: 9, offset: 25132},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 9, offset: 24963},
+							pos:        position{line: 856, col: 9, offset: 25150},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 16, offset: 24970},
+							pos:        position{line: 856, col: 16, offset: 25157},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 857, col: 9, offset: 24984},
+							pos:        position{line: 857, col: 9, offset: 25171},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 857, col: 18, offset: 24993},
+							pos:        position{line: 857, col: 18, offset: 25180},
 							val:        "error",
 							ignoreCase: false,
 						},
@@ -6065,28 +6065,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 861, col: 1, offset: 25108},
+			pos:  position{line: 861, col: 1, offset: 25297},
 			expr: &actionExpr{
-				pos: position{line: 862, col: 5, offset: 25126},
+				pos: position{line: 862, col: 5, offset: 25315},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 862, col: 5, offset: 25126},
+					pos: position{line: 862, col: 5, offset: 25315},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 25126},
+							pos:   position{line: 862, col: 5, offset: 25315},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 11, offset: 25132},
+								pos:  position{line: 862, col: 11, offset: 25321},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 21, offset: 25142},
+							pos:   position{line: 862, col: 21, offset: 25331},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 862, col: 26, offset: 25147},
+								pos: position{line: 862, col: 26, offset: 25336},
 								expr: &ruleRefExpr{
-									pos:  position{line: 862, col: 26, offset: 25147},
+									pos:  position{line: 862, col: 26, offset: 25336},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -6097,31 +6097,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 866, col: 1, offset: 25246},
+			pos:  position{line: 866, col: 1, offset: 25435},
 			expr: &actionExpr{
-				pos: position{line: 866, col: 21, offset: 25266},
+				pos: position{line: 866, col: 21, offset: 25455},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 866, col: 21, offset: 25266},
+					pos: position{line: 866, col: 21, offset: 25455},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 21, offset: 25266},
+							pos:  position{line: 866, col: 21, offset: 25455},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 866, col: 24, offset: 25269},
+							pos:        position{line: 866, col: 24, offset: 25458},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 28, offset: 25273},
+							pos:  position{line: 866, col: 28, offset: 25462},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 866, col: 31, offset: 25276},
+							pos:   position{line: 866, col: 31, offset: 25465},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 35, offset: 25280},
+								pos:  position{line: 866, col: 35, offset: 25469},
 								name: "TypeField",
 							},
 						},
@@ -6131,39 +6131,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 868, col: 1, offset: 25311},
+			pos:  position{line: 868, col: 1, offset: 25500},
 			expr: &actionExpr{
-				pos: position{line: 869, col: 5, offset: 25325},
+				pos: position{line: 869, col: 5, offset: 25514},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 869, col: 5, offset: 25325},
+					pos: position{line: 869, col: 5, offset: 25514},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 869, col: 5, offset: 25325},
+							pos:   position{line: 869, col: 5, offset: 25514},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 869, col: 10, offset: 25330},
+								pos:  position{line: 869, col: 10, offset: 25519},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 25, offset: 25345},
+							pos:  position{line: 869, col: 25, offset: 25534},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 869, col: 28, offset: 25348},
+							pos:        position{line: 869, col: 28, offset: 25537},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 32, offset: 25352},
+							pos:  position{line: 869, col: 32, offset: 25541},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 869, col: 35, offset: 25355},
+							pos:   position{line: 869, col: 35, offset: 25544},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 869, col: 39, offset: 25359},
+								pos:  position{line: 869, col: 39, offset: 25548},
 								name: "Type",
 							},
 						},
@@ -6173,16 +6173,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 873, col: 1, offset: 25441},
+			pos:  position{line: 873, col: 1, offset: 25630},
 			expr: &choiceExpr{
-				pos: position{line: 874, col: 5, offset: 25459},
+				pos: position{line: 874, col: 5, offset: 25648},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 874, col: 5, offset: 25459},
+						pos:  position{line: 874, col: 5, offset: 25648},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 874, col: 24, offset: 25478},
+						pos:  position{line: 874, col: 24, offset: 25667},
 						name: "RelativeOperator",
 					},
 				},
@@ -6190,12 +6190,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 876, col: 1, offset: 25496},
+			pos:  position{line: 876, col: 1, offset: 25685},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 12, offset: 25507},
+				pos: position{line: 876, col: 12, offset: 25696},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 876, col: 12, offset: 25507},
+					pos:        position{line: 876, col: 12, offset: 25696},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -6203,12 +6203,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 878, col: 1, offset: 25537},
+			pos:  position{line: 878, col: 1, offset: 25726},
 			expr: &actionExpr{
-				pos: position{line: 878, col: 11, offset: 25547},
+				pos: position{line: 878, col: 11, offset: 25736},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 878, col: 11, offset: 25547},
+					pos:        position{line: 878, col: 11, offset: 25736},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -6216,12 +6216,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 880, col: 1, offset: 25575},
+			pos:  position{line: 880, col: 1, offset: 25764},
 			expr: &actionExpr{
-				pos: position{line: 880, col: 11, offset: 25585},
+				pos: position{line: 880, col: 11, offset: 25774},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 880, col: 11, offset: 25585},
+					pos:        position{line: 880, col: 11, offset: 25774},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -6229,12 +6229,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 882, col: 1, offset: 25613},
+			pos:  position{line: 882, col: 1, offset: 25802},
 			expr: &actionExpr{
-				pos: position{line: 882, col: 12, offset: 25624},
+				pos: position{line: 882, col: 12, offset: 25813},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 882, col: 12, offset: 25624},
+					pos:        position{line: 882, col: 12, offset: 25813},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -6242,12 +6242,12 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 884, col: 1, offset: 25654},
+			pos:  position{line: 884, col: 1, offset: 25843},
 			expr: &actionExpr{
-				pos: position{line: 884, col: 11, offset: 25664},
+				pos: position{line: 884, col: 11, offset: 25853},
 				run: (*parser).callonByToken1,
 				expr: &litMatcher{
-					pos:        position{line: 884, col: 11, offset: 25664},
+					pos:        position{line: 884, col: 11, offset: 25853},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -6255,9 +6255,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 886, col: 1, offset: 25692},
+			pos:  position{line: 886, col: 1, offset: 25881},
 			expr: &charClassMatcher{
-				pos:        position{line: 886, col: 19, offset: 25710},
+				pos:        position{line: 886, col: 19, offset: 25899},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -6267,16 +6267,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 888, col: 1, offset: 25722},
+			pos:  position{line: 888, col: 1, offset: 25911},
 			expr: &choiceExpr{
-				pos: position{line: 888, col: 18, offset: 25739},
+				pos: position{line: 888, col: 18, offset: 25928},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 888, col: 18, offset: 25739},
+						pos:  position{line: 888, col: 18, offset: 25928},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 888, col: 36, offset: 25757},
+						pos:        position{line: 888, col: 36, offset: 25946},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -6287,15 +6287,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 890, col: 1, offset: 25764},
+			pos:  position{line: 890, col: 1, offset: 25953},
 			expr: &actionExpr{
-				pos: position{line: 891, col: 5, offset: 25779},
+				pos: position{line: 891, col: 5, offset: 25968},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 891, col: 5, offset: 25779},
+					pos:   position{line: 891, col: 5, offset: 25968},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 891, col: 8, offset: 25782},
+						pos:  position{line: 891, col: 8, offset: 25971},
 						name: "IdentifierName",
 					},
 				},
@@ -6303,29 +6303,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 893, col: 1, offset: 25861},
+			pos:  position{line: 893, col: 1, offset: 26052},
 			expr: &choiceExpr{
-				pos: position{line: 894, col: 5, offset: 25880},
+				pos: position{line: 894, col: 5, offset: 26071},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 894, col: 5, offset: 25880},
+						pos: position{line: 894, col: 5, offset: 26071},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 894, col: 5, offset: 25880},
+							pos: position{line: 894, col: 5, offset: 26071},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 894, col: 5, offset: 25880},
+									pos: position{line: 894, col: 5, offset: 26071},
 									expr: &seqExpr{
-										pos: position{line: 894, col: 7, offset: 25882},
+										pos: position{line: 894, col: 7, offset: 26073},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 894, col: 7, offset: 25882},
+												pos:  position{line: 894, col: 7, offset: 26073},
 												name: "IdGuard",
 											},
 											&notExpr{
-												pos: position{line: 894, col: 15, offset: 25890},
+												pos: position{line: 894, col: 15, offset: 26081},
 												expr: &ruleRefExpr{
-													pos:  position{line: 894, col: 16, offset: 25891},
+													pos:  position{line: 894, col: 16, offset: 26082},
 													name: "IdentifierRest",
 												},
 											},
@@ -6333,13 +6333,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 894, col: 32, offset: 25907},
+									pos:  position{line: 894, col: 32, offset: 26098},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 894, col: 48, offset: 25923},
+									pos: position{line: 894, col: 48, offset: 26114},
 									expr: &ruleRefExpr{
-										pos:  position{line: 894, col: 48, offset: 25923},
+										pos:  position{line: 894, col: 48, offset: 26114},
 										name: "IdentifierRest",
 									},
 								},
@@ -6347,30 +6347,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 895, col: 5, offset: 25975},
+						pos: position{line: 895, col: 5, offset: 26166},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 895, col: 5, offset: 25975},
+							pos:        position{line: 895, col: 5, offset: 26166},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 26014},
+						pos: position{line: 896, col: 5, offset: 26205},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 896, col: 5, offset: 26014},
+							pos: position{line: 896, col: 5, offset: 26205},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 896, col: 5, offset: 26014},
+									pos:        position{line: 896, col: 5, offset: 26205},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 896, col: 10, offset: 26019},
+									pos:   position{line: 896, col: 10, offset: 26210},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 896, col: 13, offset: 26022},
+										pos:  position{line: 896, col: 13, offset: 26213},
 										name: "IdGuard",
 									},
 								},
@@ -6378,10 +6378,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 898, col: 5, offset: 26113},
+						pos: position{line: 898, col: 5, offset: 26304},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 898, col: 5, offset: 26113},
+							pos:        position{line: 898, col: 5, offset: 26304},
 							val:        "type",
 							ignoreCase: false,
 						},
@@ -6391,24 +6391,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdGuard",
-			pos:  position{line: 901, col: 1, offset: 26153},
+			pos:  position{line: 901, col: 1, offset: 26344},
 			expr: &choiceExpr{
-				pos: position{line: 902, col: 5, offset: 26165},
+				pos: position{line: 902, col: 5, offset: 26356},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 902, col: 5, offset: 26165},
+						pos:  position{line: 902, col: 5, offset: 26356},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 903, col: 5, offset: 26184},
+						pos:  position{line: 903, col: 5, offset: 26375},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 904, col: 5, offset: 26200},
+						pos:  position{line: 904, col: 5, offset: 26391},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 905, col: 5, offset: 26217},
+						pos:  position{line: 905, col: 5, offset: 26408},
 						name: "SearchGuard",
 					},
 				},
@@ -6416,54 +6416,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 907, col: 1, offset: 26230},
+			pos:  position{line: 907, col: 1, offset: 26421},
 			expr: &choiceExpr{
-				pos: position{line: 908, col: 5, offset: 26243},
+				pos: position{line: 908, col: 5, offset: 26434},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 908, col: 5, offset: 26243},
+						pos:  position{line: 908, col: 5, offset: 26434},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 909, col: 5, offset: 26255},
+						pos:  position{line: 909, col: 5, offset: 26446},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 910, col: 5, offset: 26267},
+						pos:  position{line: 910, col: 5, offset: 26458},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 911, col: 5, offset: 26277},
+						pos: position{line: 911, col: 5, offset: 26468},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 5, offset: 26277},
+								pos:  position{line: 911, col: 5, offset: 26468},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 11, offset: 26283},
+								pos:  position{line: 911, col: 11, offset: 26474},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 911, col: 13, offset: 26285},
+								pos:        position{line: 911, col: 13, offset: 26476},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 19, offset: 26291},
+								pos:  position{line: 911, col: 19, offset: 26482},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 911, col: 21, offset: 26293},
+								pos:  position{line: 911, col: 21, offset: 26484},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 912, col: 5, offset: 26305},
+						pos:  position{line: 912, col: 5, offset: 26496},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 913, col: 5, offset: 26314},
+						pos:  position{line: 913, col: 5, offset: 26505},
 						name: "Weeks",
 					},
 				},
@@ -6471,32 +6471,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 915, col: 1, offset: 26321},
+			pos:  position{line: 915, col: 1, offset: 26512},
 			expr: &choiceExpr{
-				pos: position{line: 916, col: 5, offset: 26338},
+				pos: position{line: 916, col: 5, offset: 26529},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 916, col: 5, offset: 26338},
+						pos:        position{line: 916, col: 5, offset: 26529},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 917, col: 5, offset: 26352},
+						pos:        position{line: 917, col: 5, offset: 26543},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 918, col: 5, offset: 26365},
+						pos:        position{line: 918, col: 5, offset: 26556},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 919, col: 5, offset: 26376},
+						pos:        position{line: 919, col: 5, offset: 26567},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 920, col: 5, offset: 26386},
+						pos:        position{line: 920, col: 5, offset: 26577},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -6505,32 +6505,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 922, col: 1, offset: 26391},
+			pos:  position{line: 922, col: 1, offset: 26582},
 			expr: &choiceExpr{
-				pos: position{line: 923, col: 5, offset: 26408},
+				pos: position{line: 923, col: 5, offset: 26599},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 923, col: 5, offset: 26408},
+						pos:        position{line: 923, col: 5, offset: 26599},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 924, col: 5, offset: 26422},
+						pos:        position{line: 924, col: 5, offset: 26613},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 925, col: 5, offset: 26435},
+						pos:        position{line: 925, col: 5, offset: 26626},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 926, col: 5, offset: 26446},
+						pos:        position{line: 926, col: 5, offset: 26637},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 927, col: 5, offset: 26456},
+						pos:        position{line: 927, col: 5, offset: 26647},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -6539,32 +6539,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 929, col: 1, offset: 26461},
+			pos:  position{line: 929, col: 1, offset: 26652},
 			expr: &choiceExpr{
-				pos: position{line: 930, col: 5, offset: 26476},
+				pos: position{line: 930, col: 5, offset: 26667},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 930, col: 5, offset: 26476},
+						pos:        position{line: 930, col: 5, offset: 26667},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 931, col: 5, offset: 26488},
+						pos:        position{line: 931, col: 5, offset: 26679},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 932, col: 5, offset: 26498},
+						pos:        position{line: 932, col: 5, offset: 26689},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 933, col: 5, offset: 26507},
+						pos:        position{line: 933, col: 5, offset: 26698},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 934, col: 5, offset: 26515},
+						pos:        position{line: 934, col: 5, offset: 26706},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -6573,22 +6573,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 936, col: 1, offset: 26523},
+			pos:  position{line: 936, col: 1, offset: 26714},
 			expr: &choiceExpr{
-				pos: position{line: 936, col: 13, offset: 26535},
+				pos: position{line: 936, col: 13, offset: 26726},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 936, col: 13, offset: 26535},
+						pos:        position{line: 936, col: 13, offset: 26726},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 936, col: 20, offset: 26542},
+						pos:        position{line: 936, col: 20, offset: 26733},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 936, col: 26, offset: 26548},
+						pos:        position{line: 936, col: 26, offset: 26739},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -6597,32 +6597,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 938, col: 1, offset: 26553},
+			pos:  position{line: 938, col: 1, offset: 26744},
 			expr: &choiceExpr{
-				pos: position{line: 938, col: 14, offset: 26566},
+				pos: position{line: 938, col: 14, offset: 26757},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 938, col: 14, offset: 26566},
+						pos:        position{line: 938, col: 14, offset: 26757},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 22, offset: 26574},
+						pos:        position{line: 938, col: 22, offset: 26765},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 29, offset: 26581},
+						pos:        position{line: 938, col: 29, offset: 26772},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 35, offset: 26587},
+						pos:        position{line: 938, col: 35, offset: 26778},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 938, col: 40, offset: 26592},
+						pos:        position{line: 938, col: 40, offset: 26783},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -6631,39 +6631,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 940, col: 1, offset: 26597},
+			pos:  position{line: 940, col: 1, offset: 26788},
 			expr: &choiceExpr{
-				pos: position{line: 941, col: 5, offset: 26609},
+				pos: position{line: 941, col: 5, offset: 26800},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 941, col: 5, offset: 26609},
+						pos: position{line: 941, col: 5, offset: 26800},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 941, col: 5, offset: 26609},
+							pos:        position{line: 941, col: 5, offset: 26800},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 26695},
+						pos: position{line: 942, col: 5, offset: 26886},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 26695},
+							pos: position{line: 942, col: 5, offset: 26886},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 942, col: 5, offset: 26695},
+									pos:   position{line: 942, col: 5, offset: 26886},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 9, offset: 26699},
+										pos:  position{line: 942, col: 9, offset: 26890},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 14, offset: 26704},
+									pos:  position{line: 942, col: 14, offset: 26895},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 17, offset: 26707},
+									pos:  position{line: 942, col: 17, offset: 26898},
 									name: "SecondsToken",
 								},
 							},
@@ -6674,39 +6674,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 944, col: 1, offset: 26796},
+			pos:  position{line: 944, col: 1, offset: 26987},
 			expr: &choiceExpr{
-				pos: position{line: 945, col: 5, offset: 26808},
+				pos: position{line: 945, col: 5, offset: 26999},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 945, col: 5, offset: 26808},
+						pos: position{line: 945, col: 5, offset: 26999},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 945, col: 5, offset: 26808},
+							pos:        position{line: 945, col: 5, offset: 26999},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 946, col: 5, offset: 26895},
+						pos: position{line: 946, col: 5, offset: 27086},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 946, col: 5, offset: 26895},
+							pos: position{line: 946, col: 5, offset: 27086},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 946, col: 5, offset: 26895},
+									pos:   position{line: 946, col: 5, offset: 27086},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 946, col: 9, offset: 26899},
+										pos:  position{line: 946, col: 9, offset: 27090},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 946, col: 14, offset: 26904},
+									pos:  position{line: 946, col: 14, offset: 27095},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 946, col: 17, offset: 26907},
+									pos:  position{line: 946, col: 17, offset: 27098},
 									name: "MinutesToken",
 								},
 							},
@@ -6717,39 +6717,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 948, col: 1, offset: 27005},
+			pos:  position{line: 948, col: 1, offset: 27196},
 			expr: &choiceExpr{
-				pos: position{line: 949, col: 5, offset: 27015},
+				pos: position{line: 949, col: 5, offset: 27206},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 949, col: 5, offset: 27015},
+						pos: position{line: 949, col: 5, offset: 27206},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 949, col: 5, offset: 27015},
+							pos:        position{line: 949, col: 5, offset: 27206},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 27102},
+						pos: position{line: 950, col: 5, offset: 27293},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 27102},
+							pos: position{line: 950, col: 5, offset: 27293},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 950, col: 5, offset: 27102},
+									pos:   position{line: 950, col: 5, offset: 27293},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 9, offset: 27106},
+										pos:  position{line: 950, col: 9, offset: 27297},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 14, offset: 27111},
+									pos:  position{line: 950, col: 14, offset: 27302},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 17, offset: 27114},
+									pos:  position{line: 950, col: 17, offset: 27305},
 									name: "HoursToken",
 								},
 							},
@@ -6760,39 +6760,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 952, col: 1, offset: 27212},
+			pos:  position{line: 952, col: 1, offset: 27403},
 			expr: &choiceExpr{
-				pos: position{line: 953, col: 5, offset: 27221},
+				pos: position{line: 953, col: 5, offset: 27412},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 953, col: 5, offset: 27221},
+						pos: position{line: 953, col: 5, offset: 27412},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 953, col: 5, offset: 27221},
+							pos:        position{line: 953, col: 5, offset: 27412},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 954, col: 5, offset: 27310},
+						pos: position{line: 954, col: 5, offset: 27501},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 954, col: 5, offset: 27310},
+							pos: position{line: 954, col: 5, offset: 27501},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 954, col: 5, offset: 27310},
+									pos:   position{line: 954, col: 5, offset: 27501},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 9, offset: 27314},
+										pos:  position{line: 954, col: 9, offset: 27505},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 14, offset: 27319},
+									pos:  position{line: 954, col: 14, offset: 27510},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 17, offset: 27322},
+									pos:  position{line: 954, col: 17, offset: 27513},
 									name: "DaysToken",
 								},
 							},
@@ -6803,39 +6803,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 956, col: 1, offset: 27424},
+			pos:  position{line: 956, col: 1, offset: 27615},
 			expr: &choiceExpr{
-				pos: position{line: 957, col: 5, offset: 27434},
+				pos: position{line: 957, col: 5, offset: 27625},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 957, col: 5, offset: 27434},
+						pos: position{line: 957, col: 5, offset: 27625},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 957, col: 5, offset: 27434},
+							pos:        position{line: 957, col: 5, offset: 27625},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 27526},
+						pos: position{line: 958, col: 5, offset: 27717},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 958, col: 5, offset: 27526},
+							pos: position{line: 958, col: 5, offset: 27717},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 958, col: 5, offset: 27526},
+									pos:   position{line: 958, col: 5, offset: 27717},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 9, offset: 27530},
+										pos:  position{line: 958, col: 9, offset: 27721},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 14, offset: 27535},
+									pos:  position{line: 958, col: 14, offset: 27726},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 958, col: 17, offset: 27538},
+									pos:  position{line: 958, col: 17, offset: 27729},
 									name: "WeeksToken",
 								},
 							},
@@ -6846,42 +6846,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 961, col: 1, offset: 27669},
+			pos:  position{line: 961, col: 1, offset: 27860},
 			expr: &actionExpr{
-				pos: position{line: 962, col: 5, offset: 27676},
+				pos: position{line: 962, col: 5, offset: 27867},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 962, col: 5, offset: 27676},
+					pos: position{line: 962, col: 5, offset: 27867},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 5, offset: 27676},
+							pos:  position{line: 962, col: 5, offset: 27867},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 962, col: 10, offset: 27681},
+							pos:        position{line: 962, col: 10, offset: 27872},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 14, offset: 27685},
+							pos:  position{line: 962, col: 14, offset: 27876},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 962, col: 19, offset: 27690},
+							pos:        position{line: 962, col: 19, offset: 27881},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 23, offset: 27694},
+							pos:  position{line: 962, col: 23, offset: 27885},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 962, col: 28, offset: 27699},
+							pos:        position{line: 962, col: 28, offset: 27890},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 32, offset: 27703},
+							pos:  position{line: 962, col: 32, offset: 27894},
 							name: "UInt",
 						},
 					},
@@ -6890,42 +6890,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 964, col: 1, offset: 27740},
+			pos:  position{line: 964, col: 1, offset: 27931},
 			expr: &actionExpr{
-				pos: position{line: 965, col: 5, offset: 27748},
+				pos: position{line: 965, col: 5, offset: 27939},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 965, col: 5, offset: 27748},
+					pos: position{line: 965, col: 5, offset: 27939},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 965, col: 5, offset: 27748},
+							pos: position{line: 965, col: 5, offset: 27939},
 							expr: &seqExpr{
-								pos: position{line: 965, col: 8, offset: 27751},
+								pos: position{line: 965, col: 8, offset: 27942},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 965, col: 8, offset: 27751},
+										pos:  position{line: 965, col: 8, offset: 27942},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 965, col: 12, offset: 27755},
+										pos:        position{line: 965, col: 12, offset: 27946},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 965, col: 16, offset: 27759},
+										pos:  position{line: 965, col: 16, offset: 27950},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 965, col: 20, offset: 27763},
+										pos: position{line: 965, col: 20, offset: 27954},
 										expr: &choiceExpr{
-											pos: position{line: 965, col: 22, offset: 27765},
+											pos: position{line: 965, col: 22, offset: 27956},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 22, offset: 27765},
+													pos:  position{line: 965, col: 22, offset: 27956},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 965, col: 33, offset: 27776},
+													pos:        position{line: 965, col: 33, offset: 27967},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -6936,10 +6936,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 39, offset: 27782},
+							pos:   position{line: 965, col: 39, offset: 27973},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 41, offset: 27784},
+								pos:  position{line: 965, col: 41, offset: 27975},
 								name: "IP6Variations",
 							},
 						},
@@ -6949,32 +6949,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 969, col: 1, offset: 27948},
+			pos:  position{line: 969, col: 1, offset: 28139},
 			expr: &choiceExpr{
-				pos: position{line: 970, col: 5, offset: 27966},
+				pos: position{line: 970, col: 5, offset: 28157},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 970, col: 5, offset: 27966},
+						pos: position{line: 970, col: 5, offset: 28157},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 970, col: 5, offset: 27966},
+							pos: position{line: 970, col: 5, offset: 28157},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 970, col: 5, offset: 27966},
+									pos:   position{line: 970, col: 5, offset: 28157},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 970, col: 7, offset: 27968},
+										pos: position{line: 970, col: 7, offset: 28159},
 										expr: &ruleRefExpr{
-											pos:  position{line: 970, col: 7, offset: 27968},
+											pos:  position{line: 970, col: 7, offset: 28159},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 970, col: 17, offset: 27978},
+									pos:   position{line: 970, col: 17, offset: 28169},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 19, offset: 27980},
+										pos:  position{line: 970, col: 19, offset: 28171},
 										name: "IP6Tail",
 									},
 								},
@@ -6982,51 +6982,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 973, col: 5, offset: 28044},
+						pos: position{line: 973, col: 5, offset: 28235},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 973, col: 5, offset: 28044},
+							pos: position{line: 973, col: 5, offset: 28235},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 973, col: 5, offset: 28044},
+									pos:   position{line: 973, col: 5, offset: 28235},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 973, col: 7, offset: 28046},
+										pos:  position{line: 973, col: 7, offset: 28237},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 11, offset: 28050},
+									pos:   position{line: 973, col: 11, offset: 28241},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 973, col: 13, offset: 28052},
+										pos: position{line: 973, col: 13, offset: 28243},
 										expr: &ruleRefExpr{
-											pos:  position{line: 973, col: 13, offset: 28052},
+											pos:  position{line: 973, col: 13, offset: 28243},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 973, col: 23, offset: 28062},
+									pos:        position{line: 973, col: 23, offset: 28253},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 28, offset: 28067},
+									pos:   position{line: 973, col: 28, offset: 28258},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 973, col: 30, offset: 28069},
+										pos: position{line: 973, col: 30, offset: 28260},
 										expr: &ruleRefExpr{
-											pos:  position{line: 973, col: 30, offset: 28069},
+											pos:  position{line: 973, col: 30, offset: 28260},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 40, offset: 28079},
+									pos:   position{line: 973, col: 40, offset: 28270},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 973, col: 42, offset: 28081},
+										pos:  position{line: 973, col: 42, offset: 28272},
 										name: "IP6Tail",
 									},
 								},
@@ -7034,32 +7034,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 976, col: 5, offset: 28180},
+						pos: position{line: 976, col: 5, offset: 28371},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 976, col: 5, offset: 28180},
+							pos: position{line: 976, col: 5, offset: 28371},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 976, col: 5, offset: 28180},
+									pos:        position{line: 976, col: 5, offset: 28371},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 10, offset: 28185},
+									pos:   position{line: 976, col: 10, offset: 28376},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 976, col: 12, offset: 28187},
+										pos: position{line: 976, col: 12, offset: 28378},
 										expr: &ruleRefExpr{
-											pos:  position{line: 976, col: 12, offset: 28187},
+											pos:  position{line: 976, col: 12, offset: 28378},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 22, offset: 28197},
+									pos:   position{line: 976, col: 22, offset: 28388},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 24, offset: 28199},
+										pos:  position{line: 976, col: 24, offset: 28390},
 										name: "IP6Tail",
 									},
 								},
@@ -7067,32 +7067,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 28270},
+						pos: position{line: 979, col: 5, offset: 28461},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 979, col: 5, offset: 28270},
+							pos: position{line: 979, col: 5, offset: 28461},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 979, col: 5, offset: 28270},
+									pos:   position{line: 979, col: 5, offset: 28461},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 979, col: 7, offset: 28272},
+										pos:  position{line: 979, col: 7, offset: 28463},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 979, col: 11, offset: 28276},
+									pos:   position{line: 979, col: 11, offset: 28467},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 979, col: 13, offset: 28278},
+										pos: position{line: 979, col: 13, offset: 28469},
 										expr: &ruleRefExpr{
-											pos:  position{line: 979, col: 13, offset: 28278},
+											pos:  position{line: 979, col: 13, offset: 28469},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 979, col: 23, offset: 28288},
+									pos:        position{line: 979, col: 23, offset: 28479},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -7100,10 +7100,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 28356},
+						pos: position{line: 982, col: 5, offset: 28547},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 982, col: 5, offset: 28356},
+							pos:        position{line: 982, col: 5, offset: 28547},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -7113,16 +7113,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 986, col: 1, offset: 28393},
+			pos:  position{line: 986, col: 1, offset: 28584},
 			expr: &choiceExpr{
-				pos: position{line: 987, col: 5, offset: 28405},
+				pos: position{line: 987, col: 5, offset: 28596},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 987, col: 5, offset: 28405},
+						pos:  position{line: 987, col: 5, offset: 28596},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 988, col: 5, offset: 28412},
+						pos:  position{line: 988, col: 5, offset: 28603},
 						name: "Hex",
 					},
 				},
@@ -7130,23 +7130,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 990, col: 1, offset: 28417},
+			pos:  position{line: 990, col: 1, offset: 28608},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 12, offset: 28428},
+				pos: position{line: 990, col: 12, offset: 28619},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 990, col: 12, offset: 28428},
+					pos: position{line: 990, col: 12, offset: 28619},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 990, col: 12, offset: 28428},
+							pos:        position{line: 990, col: 12, offset: 28619},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 990, col: 16, offset: 28432},
+							pos:   position{line: 990, col: 16, offset: 28623},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 990, col: 18, offset: 28434},
+								pos:  position{line: 990, col: 18, offset: 28625},
 								name: "Hex",
 							},
 						},
@@ -7156,23 +7156,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 992, col: 1, offset: 28472},
+			pos:  position{line: 992, col: 1, offset: 28663},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 12, offset: 28483},
+				pos: position{line: 992, col: 12, offset: 28674},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 992, col: 12, offset: 28483},
+					pos: position{line: 992, col: 12, offset: 28674},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 992, col: 12, offset: 28483},
+							pos:   position{line: 992, col: 12, offset: 28674},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 992, col: 14, offset: 28485},
+								pos:  position{line: 992, col: 14, offset: 28676},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 992, col: 18, offset: 28489},
+							pos:        position{line: 992, col: 18, offset: 28680},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -7182,31 +7182,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 994, col: 1, offset: 28527},
+			pos:  position{line: 994, col: 1, offset: 28718},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 5, offset: 28538},
+				pos: position{line: 995, col: 5, offset: 28729},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 995, col: 5, offset: 28538},
+					pos: position{line: 995, col: 5, offset: 28729},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 995, col: 5, offset: 28538},
+							pos:   position{line: 995, col: 5, offset: 28729},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 7, offset: 28540},
+								pos:  position{line: 995, col: 7, offset: 28731},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 995, col: 10, offset: 28543},
+							pos:        position{line: 995, col: 10, offset: 28734},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 995, col: 14, offset: 28547},
+							pos:   position{line: 995, col: 14, offset: 28738},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 16, offset: 28549},
+								pos:  position{line: 995, col: 16, offset: 28740},
 								name: "UInt",
 							},
 						},
@@ -7216,31 +7216,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 999, col: 1, offset: 28622},
+			pos:  position{line: 999, col: 1, offset: 28813},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 5, offset: 28633},
+				pos: position{line: 1000, col: 5, offset: 28824},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1000, col: 5, offset: 28633},
+					pos: position{line: 1000, col: 5, offset: 28824},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1000, col: 5, offset: 28633},
+							pos:   position{line: 1000, col: 5, offset: 28824},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 7, offset: 28635},
+								pos:  position{line: 1000, col: 7, offset: 28826},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1000, col: 11, offset: 28639},
+							pos:        position{line: 1000, col: 11, offset: 28830},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1000, col: 15, offset: 28643},
+							pos:   position{line: 1000, col: 15, offset: 28834},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 17, offset: 28645},
+								pos:  position{line: 1000, col: 17, offset: 28836},
 								name: "UInt",
 							},
 						},
@@ -7250,15 +7250,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1004, col: 1, offset: 28708},
+			pos:  position{line: 1004, col: 1, offset: 28899},
 			expr: &actionExpr{
-				pos: position{line: 1005, col: 4, offset: 28716},
+				pos: position{line: 1005, col: 4, offset: 28907},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1005, col: 4, offset: 28716},
+					pos:   position{line: 1005, col: 4, offset: 28907},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1005, col: 6, offset: 28718},
+						pos:  position{line: 1005, col: 6, offset: 28909},
 						name: "UIntString",
 					},
 				},
@@ -7266,16 +7266,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1007, col: 1, offset: 28758},
+			pos:  position{line: 1007, col: 1, offset: 28949},
 			expr: &choiceExpr{
-				pos: position{line: 1008, col: 5, offset: 28772},
+				pos: position{line: 1008, col: 5, offset: 28963},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28772},
+						pos:  position{line: 1008, col: 5, offset: 28963},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28787},
+						pos:  position{line: 1009, col: 5, offset: 28978},
 						name: "MinusIntString",
 					},
 				},
@@ -7283,14 +7283,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1011, col: 1, offset: 28803},
+			pos:  position{line: 1011, col: 1, offset: 28994},
 			expr: &actionExpr{
-				pos: position{line: 1011, col: 14, offset: 28816},
+				pos: position{line: 1011, col: 14, offset: 29007},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1011, col: 14, offset: 28816},
+					pos: position{line: 1011, col: 14, offset: 29007},
 					expr: &charClassMatcher{
-						pos:        position{line: 1011, col: 14, offset: 28816},
+						pos:        position{line: 1011, col: 14, offset: 29007},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7301,20 +7301,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1013, col: 1, offset: 28855},
+			pos:  position{line: 1013, col: 1, offset: 29046},
 			expr: &actionExpr{
-				pos: position{line: 1014, col: 5, offset: 28874},
+				pos: position{line: 1014, col: 5, offset: 29065},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1014, col: 5, offset: 28874},
+					pos: position{line: 1014, col: 5, offset: 29065},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1014, col: 5, offset: 28874},
+							pos:        position{line: 1014, col: 5, offset: 29065},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1014, col: 9, offset: 28878},
+							pos:  position{line: 1014, col: 9, offset: 29069},
 							name: "UIntString",
 						},
 					},
@@ -7323,28 +7323,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1016, col: 1, offset: 28921},
+			pos:  position{line: 1016, col: 1, offset: 29112},
 			expr: &choiceExpr{
-				pos: position{line: 1017, col: 5, offset: 28937},
+				pos: position{line: 1017, col: 5, offset: 29128},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1017, col: 5, offset: 28937},
+						pos: position{line: 1017, col: 5, offset: 29128},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1017, col: 5, offset: 28937},
+							pos: position{line: 1017, col: 5, offset: 29128},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1017, col: 5, offset: 28937},
+									pos: position{line: 1017, col: 5, offset: 29128},
 									expr: &litMatcher{
-										pos:        position{line: 1017, col: 5, offset: 28937},
+										pos:        position{line: 1017, col: 5, offset: 29128},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1017, col: 10, offset: 28942},
+									pos: position{line: 1017, col: 10, offset: 29133},
 									expr: &charClassMatcher{
-										pos:        position{line: 1017, col: 10, offset: 28942},
+										pos:        position{line: 1017, col: 10, offset: 29133},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7352,14 +7352,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1017, col: 17, offset: 28949},
+									pos:        position{line: 1017, col: 17, offset: 29140},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1017, col: 21, offset: 28953},
+									pos: position{line: 1017, col: 21, offset: 29144},
 									expr: &charClassMatcher{
-										pos:        position{line: 1017, col: 21, offset: 28953},
+										pos:        position{line: 1017, col: 21, offset: 29144},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7367,9 +7367,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1017, col: 28, offset: 28960},
+									pos: position{line: 1017, col: 28, offset: 29151},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1017, col: 28, offset: 28960},
+										pos:  position{line: 1017, col: 28, offset: 29151},
 										name: "ExponentPart",
 									},
 								},
@@ -7377,28 +7377,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 29019},
+						pos: position{line: 1020, col: 5, offset: 29210},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1020, col: 5, offset: 29019},
+							pos: position{line: 1020, col: 5, offset: 29210},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1020, col: 5, offset: 29019},
+									pos: position{line: 1020, col: 5, offset: 29210},
 									expr: &litMatcher{
-										pos:        position{line: 1020, col: 5, offset: 29019},
+										pos:        position{line: 1020, col: 5, offset: 29210},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 10, offset: 29024},
+									pos:        position{line: 1020, col: 10, offset: 29215},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1020, col: 14, offset: 29028},
+									pos: position{line: 1020, col: 14, offset: 29219},
 									expr: &charClassMatcher{
-										pos:        position{line: 1020, col: 14, offset: 29028},
+										pos:        position{line: 1020, col: 14, offset: 29219},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7406,9 +7406,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1020, col: 21, offset: 29035},
+									pos: position{line: 1020, col: 21, offset: 29226},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 21, offset: 29035},
+										pos:  position{line: 1020, col: 21, offset: 29226},
 										name: "ExponentPart",
 									},
 								},
@@ -7420,19 +7420,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1024, col: 1, offset: 29091},
+			pos:  position{line: 1024, col: 1, offset: 29282},
 			expr: &seqExpr{
-				pos: position{line: 1024, col: 16, offset: 29106},
+				pos: position{line: 1024, col: 16, offset: 29297},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1024, col: 16, offset: 29106},
+						pos:        position{line: 1024, col: 16, offset: 29297},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1024, col: 21, offset: 29111},
+						pos: position{line: 1024, col: 21, offset: 29302},
 						expr: &charClassMatcher{
-							pos:        position{line: 1024, col: 21, offset: 29111},
+							pos:        position{line: 1024, col: 21, offset: 29302},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -7440,7 +7440,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1024, col: 27, offset: 29117},
+						pos:  position{line: 1024, col: 27, offset: 29308},
 						name: "UIntString",
 					},
 				},
@@ -7448,14 +7448,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1026, col: 1, offset: 29129},
+			pos:  position{line: 1026, col: 1, offset: 29320},
 			expr: &actionExpr{
-				pos: position{line: 1026, col: 7, offset: 29135},
+				pos: position{line: 1026, col: 7, offset: 29326},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1026, col: 7, offset: 29135},
+					pos: position{line: 1026, col: 7, offset: 29326},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1026, col: 7, offset: 29135},
+						pos:  position{line: 1026, col: 7, offset: 29326},
 						name: "HexDigit",
 					},
 				},
@@ -7463,9 +7463,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1028, col: 1, offset: 29177},
+			pos:  position{line: 1028, col: 1, offset: 29368},
 			expr: &charClassMatcher{
-				pos:        position{line: 1028, col: 12, offset: 29188},
+				pos:        position{line: 1028, col: 12, offset: 29379},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -7474,34 +7474,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1031, col: 1, offset: 29202},
+			pos:  position{line: 1031, col: 1, offset: 29393},
 			expr: &choiceExpr{
-				pos: position{line: 1032, col: 5, offset: 29219},
+				pos: position{line: 1032, col: 5, offset: 29410},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 29219},
+						pos: position{line: 1032, col: 5, offset: 29410},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1032, col: 5, offset: 29219},
+							pos: position{line: 1032, col: 5, offset: 29410},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1032, col: 5, offset: 29219},
+									pos:        position{line: 1032, col: 5, offset: 29410},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1032, col: 9, offset: 29223},
+									pos:   position{line: 1032, col: 9, offset: 29414},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1032, col: 11, offset: 29225},
+										pos: position{line: 1032, col: 11, offset: 29416},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1032, col: 11, offset: 29225},
+											pos:  position{line: 1032, col: 11, offset: 29416},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 29, offset: 29243},
+									pos:        position{line: 1032, col: 29, offset: 29434},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -7509,29 +7509,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1033, col: 5, offset: 29280},
+						pos: position{line: 1033, col: 5, offset: 29471},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1033, col: 5, offset: 29280},
+							pos: position{line: 1033, col: 5, offset: 29471},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1033, col: 5, offset: 29280},
+									pos:        position{line: 1033, col: 5, offset: 29471},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 9, offset: 29284},
+									pos:   position{line: 1033, col: 9, offset: 29475},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1033, col: 11, offset: 29286},
+										pos: position{line: 1033, col: 11, offset: 29477},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1033, col: 11, offset: 29286},
+											pos:  position{line: 1033, col: 11, offset: 29477},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1033, col: 29, offset: 29304},
+									pos:        position{line: 1033, col: 29, offset: 29495},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -7543,55 +7543,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1035, col: 1, offset: 29338},
+			pos:  position{line: 1035, col: 1, offset: 29529},
 			expr: &choiceExpr{
-				pos: position{line: 1036, col: 5, offset: 29359},
+				pos: position{line: 1036, col: 5, offset: 29550},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 29359},
+						pos: position{line: 1036, col: 5, offset: 29550},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1036, col: 5, offset: 29359},
+							pos: position{line: 1036, col: 5, offset: 29550},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1036, col: 5, offset: 29359},
+									pos: position{line: 1036, col: 5, offset: 29550},
 									expr: &choiceExpr{
-										pos: position{line: 1036, col: 7, offset: 29361},
+										pos: position{line: 1036, col: 7, offset: 29552},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1036, col: 7, offset: 29361},
+												pos:        position{line: 1036, col: 7, offset: 29552},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1036, col: 13, offset: 29367},
+												pos:  position{line: 1036, col: 13, offset: 29558},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1036, col: 26, offset: 29380,
+									line: 1036, col: 26, offset: 29571,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 29417},
+						pos: position{line: 1037, col: 5, offset: 29608},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 29417},
+							pos: position{line: 1037, col: 5, offset: 29608},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1037, col: 5, offset: 29417},
+									pos:        position{line: 1037, col: 5, offset: 29608},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 10, offset: 29422},
+									pos:   position{line: 1037, col: 10, offset: 29613},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 12, offset: 29424},
+										pos:  position{line: 1037, col: 12, offset: 29615},
 										name: "EscapeSequence",
 									},
 								},
@@ -7603,28 +7603,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1039, col: 1, offset: 29458},
+			pos:  position{line: 1039, col: 1, offset: 29649},
 			expr: &actionExpr{
-				pos: position{line: 1040, col: 5, offset: 29470},
+				pos: position{line: 1040, col: 5, offset: 29661},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1040, col: 5, offset: 29470},
+					pos: position{line: 1040, col: 5, offset: 29661},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1040, col: 5, offset: 29470},
+							pos:   position{line: 1040, col: 5, offset: 29661},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1040, col: 10, offset: 29475},
+								pos:  position{line: 1040, col: 10, offset: 29666},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1040, col: 23, offset: 29488},
+							pos:   position{line: 1040, col: 23, offset: 29679},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1040, col: 28, offset: 29493},
+								pos: position{line: 1040, col: 28, offset: 29684},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1040, col: 28, offset: 29493},
+									pos:  position{line: 1040, col: 28, offset: 29684},
 									name: "KeyWordRest",
 								},
 							},
@@ -7635,15 +7635,15 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1042, col: 1, offset: 29555},
+			pos:  position{line: 1042, col: 1, offset: 29746},
 			expr: &choiceExpr{
-				pos: position{line: 1043, col: 5, offset: 29572},
+				pos: position{line: 1043, col: 5, offset: 29763},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 29572},
+						pos: position{line: 1043, col: 5, offset: 29763},
 						run: (*parser).callonKeyWordStart2,
 						expr: &charClassMatcher{
-							pos:        position{line: 1043, col: 5, offset: 29572},
+							pos:        position{line: 1043, col: 5, offset: 29763},
 							val:        "[a-zA-Z_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -7652,7 +7652,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 29624},
+						pos:  position{line: 1044, col: 5, offset: 29815},
 						name: "KeyWordEsc",
 					},
 				},
@@ -7660,16 +7660,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1046, col: 1, offset: 29636},
+			pos:  position{line: 1046, col: 1, offset: 29827},
 			expr: &choiceExpr{
-				pos: position{line: 1047, col: 5, offset: 29652},
+				pos: position{line: 1047, col: 5, offset: 29843},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 5, offset: 29652},
+						pos:  position{line: 1047, col: 5, offset: 29843},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1048, col: 5, offset: 29669},
+						pos:        position{line: 1048, col: 5, offset: 29860},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7680,30 +7680,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1050, col: 1, offset: 29676},
+			pos:  position{line: 1050, col: 1, offset: 29867},
 			expr: &actionExpr{
-				pos: position{line: 1050, col: 14, offset: 29689},
+				pos: position{line: 1050, col: 14, offset: 29880},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1050, col: 14, offset: 29689},
+					pos: position{line: 1050, col: 14, offset: 29880},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1050, col: 14, offset: 29689},
+							pos:        position{line: 1050, col: 14, offset: 29880},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1050, col: 19, offset: 29694},
+							pos:   position{line: 1050, col: 19, offset: 29885},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1050, col: 22, offset: 29697},
+								pos: position{line: 1050, col: 22, offset: 29888},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1050, col: 22, offset: 29697},
+										pos:  position{line: 1050, col: 22, offset: 29888},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1050, col: 38, offset: 29713},
+										pos:  position{line: 1050, col: 38, offset: 29904},
 										name: "EscapeSequence",
 									},
 								},
@@ -7715,55 +7715,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1052, col: 1, offset: 29749},
+			pos:  position{line: 1052, col: 1, offset: 29940},
 			expr: &choiceExpr{
-				pos: position{line: 1053, col: 5, offset: 29770},
+				pos: position{line: 1053, col: 5, offset: 29961},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1053, col: 5, offset: 29770},
+						pos: position{line: 1053, col: 5, offset: 29961},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1053, col: 5, offset: 29770},
+							pos: position{line: 1053, col: 5, offset: 29961},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1053, col: 5, offset: 29770},
+									pos: position{line: 1053, col: 5, offset: 29961},
 									expr: &choiceExpr{
-										pos: position{line: 1053, col: 7, offset: 29772},
+										pos: position{line: 1053, col: 7, offset: 29963},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1053, col: 7, offset: 29772},
+												pos:        position{line: 1053, col: 7, offset: 29963},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1053, col: 13, offset: 29778},
+												pos:  position{line: 1053, col: 13, offset: 29969},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1053, col: 26, offset: 29791,
+									line: 1053, col: 26, offset: 29982,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1054, col: 5, offset: 29828},
+						pos: position{line: 1054, col: 5, offset: 30019},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1054, col: 5, offset: 29828},
+							pos: position{line: 1054, col: 5, offset: 30019},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1054, col: 5, offset: 29828},
+									pos:        position{line: 1054, col: 5, offset: 30019},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1054, col: 10, offset: 29833},
+									pos:   position{line: 1054, col: 10, offset: 30024},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1054, col: 12, offset: 29835},
+										pos:  position{line: 1054, col: 12, offset: 30026},
 										name: "EscapeSequence",
 									},
 								},
@@ -7775,38 +7775,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1056, col: 1, offset: 29869},
+			pos:  position{line: 1056, col: 1, offset: 30060},
 			expr: &choiceExpr{
-				pos: position{line: 1057, col: 5, offset: 29888},
+				pos: position{line: 1057, col: 5, offset: 30079},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 29888},
+						pos: position{line: 1057, col: 5, offset: 30079},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 29888},
+							pos: position{line: 1057, col: 5, offset: 30079},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1057, col: 5, offset: 29888},
+									pos:        position{line: 1057, col: 5, offset: 30079},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 9, offset: 29892},
+									pos:  position{line: 1057, col: 9, offset: 30083},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 18, offset: 29901},
+									pos:  position{line: 1057, col: 18, offset: 30092},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1058, col: 5, offset: 29952},
+						pos:  position{line: 1058, col: 5, offset: 30143},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1059, col: 5, offset: 29973},
+						pos:  position{line: 1059, col: 5, offset: 30164},
 						name: "UnicodeEscape",
 					},
 				},
@@ -7814,75 +7814,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1061, col: 1, offset: 29988},
+			pos:  position{line: 1061, col: 1, offset: 30179},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 5, offset: 30009},
+				pos: position{line: 1062, col: 5, offset: 30200},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1062, col: 5, offset: 30009},
+						pos:        position{line: 1062, col: 5, offset: 30200},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1063, col: 5, offset: 30017},
+						pos:        position{line: 1063, col: 5, offset: 30208},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1064, col: 5, offset: 30026},
+						pos:        position{line: 1064, col: 5, offset: 30217},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 30035},
+						pos: position{line: 1065, col: 5, offset: 30226},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 1065, col: 5, offset: 30035},
+							pos:        position{line: 1065, col: 5, offset: 30226},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 30064},
+						pos: position{line: 1066, col: 5, offset: 30255},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 1066, col: 5, offset: 30064},
+							pos:        position{line: 1066, col: 5, offset: 30255},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30093},
+						pos: position{line: 1067, col: 5, offset: 30284},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 1067, col: 5, offset: 30093},
+							pos:        position{line: 1067, col: 5, offset: 30284},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 30122},
+						pos: position{line: 1068, col: 5, offset: 30313},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 1068, col: 5, offset: 30122},
+							pos:        position{line: 1068, col: 5, offset: 30313},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 30151},
+						pos: position{line: 1069, col: 5, offset: 30342},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 1069, col: 5, offset: 30151},
+							pos:        position{line: 1069, col: 5, offset: 30342},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 30180},
+						pos: position{line: 1070, col: 5, offset: 30371},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 1070, col: 5, offset: 30180},
+							pos:        position{line: 1070, col: 5, offset: 30371},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -7892,30 +7892,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1072, col: 1, offset: 30206},
+			pos:  position{line: 1072, col: 1, offset: 30397},
 			expr: &choiceExpr{
-				pos: position{line: 1073, col: 5, offset: 30224},
+				pos: position{line: 1073, col: 5, offset: 30415},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 30224},
+						pos: position{line: 1073, col: 5, offset: 30415},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1073, col: 5, offset: 30224},
+							pos:        position{line: 1073, col: 5, offset: 30415},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 30252},
+						pos: position{line: 1074, col: 5, offset: 30443},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1074, col: 5, offset: 30252},
+							pos:        position{line: 1074, col: 5, offset: 30443},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1075, col: 5, offset: 30282},
+						pos:        position{line: 1075, col: 5, offset: 30473},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -7926,41 +7926,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1077, col: 1, offset: 30288},
+			pos:  position{line: 1077, col: 1, offset: 30479},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 30306},
+				pos: position{line: 1078, col: 5, offset: 30497},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 30306},
+						pos: position{line: 1078, col: 5, offset: 30497},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 30306},
+							pos: position{line: 1078, col: 5, offset: 30497},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1078, col: 5, offset: 30306},
+									pos:        position{line: 1078, col: 5, offset: 30497},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 9, offset: 30310},
+									pos:   position{line: 1078, col: 9, offset: 30501},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1078, col: 16, offset: 30317},
+										pos: position{line: 1078, col: 16, offset: 30508},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 16, offset: 30317},
+												pos:  position{line: 1078, col: 16, offset: 30508},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 25, offset: 30326},
+												pos:  position{line: 1078, col: 25, offset: 30517},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 34, offset: 30335},
+												pos:  position{line: 1078, col: 34, offset: 30526},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 43, offset: 30344},
+												pos:  position{line: 1078, col: 43, offset: 30535},
 												name: "HexDigit",
 											},
 										},
@@ -7970,63 +7970,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 30407},
+						pos: position{line: 1081, col: 5, offset: 30598},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1081, col: 5, offset: 30407},
+							pos: position{line: 1081, col: 5, offset: 30598},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1081, col: 5, offset: 30407},
+									pos:        position{line: 1081, col: 5, offset: 30598},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 9, offset: 30411},
+									pos:        position{line: 1081, col: 9, offset: 30602},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1081, col: 13, offset: 30415},
+									pos:   position{line: 1081, col: 13, offset: 30606},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1081, col: 20, offset: 30422},
+										pos: position{line: 1081, col: 20, offset: 30613},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1081, col: 20, offset: 30422},
+												pos:  position{line: 1081, col: 20, offset: 30613},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 29, offset: 30431},
+												pos: position{line: 1081, col: 29, offset: 30622},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 29, offset: 30431},
+													pos:  position{line: 1081, col: 29, offset: 30622},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 39, offset: 30441},
+												pos: position{line: 1081, col: 39, offset: 30632},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 39, offset: 30441},
+													pos:  position{line: 1081, col: 39, offset: 30632},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 49, offset: 30451},
+												pos: position{line: 1081, col: 49, offset: 30642},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 49, offset: 30451},
+													pos:  position{line: 1081, col: 49, offset: 30642},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 59, offset: 30461},
+												pos: position{line: 1081, col: 59, offset: 30652},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 59, offset: 30461},
+													pos:  position{line: 1081, col: 59, offset: 30652},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1081, col: 69, offset: 30471},
+												pos: position{line: 1081, col: 69, offset: 30662},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1081, col: 69, offset: 30471},
+													pos:  position{line: 1081, col: 69, offset: 30662},
 													name: "HexDigit",
 												},
 											},
@@ -8034,7 +8034,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 80, offset: 30482},
+									pos:        position{line: 1081, col: 80, offset: 30673},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8046,28 +8046,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1085, col: 1, offset: 30536},
+			pos:  position{line: 1085, col: 1, offset: 30727},
 			expr: &actionExpr{
-				pos: position{line: 1086, col: 5, offset: 30547},
+				pos: position{line: 1086, col: 5, offset: 30738},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1086, col: 5, offset: 30547},
+					pos: position{line: 1086, col: 5, offset: 30738},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1086, col: 5, offset: 30547},
+							pos:        position{line: 1086, col: 5, offset: 30738},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1086, col: 9, offset: 30551},
+							pos:   position{line: 1086, col: 9, offset: 30742},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1086, col: 14, offset: 30556},
+								pos:  position{line: 1086, col: 14, offset: 30747},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1086, col: 25, offset: 30567},
+							pos:        position{line: 1086, col: 25, offset: 30758},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -8077,24 +8077,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1088, col: 1, offset: 30593},
+			pos:  position{line: 1088, col: 1, offset: 30784},
 			expr: &actionExpr{
-				pos: position{line: 1089, col: 5, offset: 30608},
+				pos: position{line: 1089, col: 5, offset: 30799},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1089, col: 5, offset: 30608},
+					pos: position{line: 1089, col: 5, offset: 30799},
 					expr: &choiceExpr{
-						pos: position{line: 1089, col: 6, offset: 30609},
+						pos: position{line: 1089, col: 6, offset: 30800},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1089, col: 6, offset: 30609},
+								pos:        position{line: 1089, col: 6, offset: 30800},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1089, col: 13, offset: 30616},
+								pos:        position{line: 1089, col: 13, offset: 30807},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -8105,9 +8105,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1091, col: 1, offset: 30656},
+			pos:  position{line: 1091, col: 1, offset: 30847},
 			expr: &charClassMatcher{
-				pos:        position{line: 1092, col: 5, offset: 30672},
+				pos:        position{line: 1092, col: 5, offset: 30863},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -8117,42 +8117,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1094, col: 1, offset: 30687},
+			pos:  position{line: 1094, col: 1, offset: 30878},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1094, col: 6, offset: 30692},
+				pos: position{line: 1094, col: 6, offset: 30883},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1094, col: 6, offset: 30692},
+					pos:  position{line: 1094, col: 6, offset: 30883},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1096, col: 1, offset: 30703},
+			pos:  position{line: 1096, col: 1, offset: 30894},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1096, col: 6, offset: 30708},
+				pos: position{line: 1096, col: 6, offset: 30899},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1096, col: 6, offset: 30708},
+					pos:  position{line: 1096, col: 6, offset: 30899},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1098, col: 1, offset: 30719},
+			pos:  position{line: 1098, col: 1, offset: 30910},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 30732},
+				pos: position{line: 1099, col: 5, offset: 30923},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 30732},
+						pos:  position{line: 1099, col: 5, offset: 30923},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 30747},
+						pos:  position{line: 1100, col: 5, offset: 30938},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 30766},
+						pos:  position{line: 1101, col: 5, offset: 30957},
 						name: "Comment",
 					},
 				},
@@ -8160,45 +8160,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1103, col: 1, offset: 30775},
+			pos:  position{line: 1103, col: 1, offset: 30966},
 			expr: &anyMatcher{
-				line: 1104, col: 5, offset: 30795,
+				line: 1104, col: 5, offset: 30986,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1106, col: 1, offset: 30798},
+			pos:         position{line: 1106, col: 1, offset: 30989},
 			expr: &choiceExpr{
-				pos: position{line: 1107, col: 5, offset: 30826},
+				pos: position{line: 1107, col: 5, offset: 31017},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1107, col: 5, offset: 30826},
+						pos:        position{line: 1107, col: 5, offset: 31017},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1108, col: 5, offset: 30835},
+						pos:        position{line: 1108, col: 5, offset: 31026},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1109, col: 5, offset: 30844},
+						pos:        position{line: 1109, col: 5, offset: 31035},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1110, col: 5, offset: 30853},
+						pos:        position{line: 1110, col: 5, offset: 31044},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1111, col: 5, offset: 30861},
+						pos:        position{line: 1111, col: 5, offset: 31052},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1112, col: 5, offset: 30874},
+						pos:        position{line: 1112, col: 5, offset: 31065},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -8207,9 +8207,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1114, col: 1, offset: 30884},
+			pos:  position{line: 1114, col: 1, offset: 31075},
 			expr: &charClassMatcher{
-				pos:        position{line: 1115, col: 5, offset: 30903},
+				pos:        position{line: 1115, col: 5, offset: 31094},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -8219,45 +8219,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1121, col: 1, offset: 31233},
+			pos:         position{line: 1121, col: 1, offset: 31424},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1124, col: 5, offset: 31304},
+				pos:  position{line: 1124, col: 5, offset: 31495},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1126, col: 1, offset: 31323},
+			pos:  position{line: 1126, col: 1, offset: 31514},
 			expr: &seqExpr{
-				pos: position{line: 1127, col: 5, offset: 31344},
+				pos: position{line: 1127, col: 5, offset: 31535},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1127, col: 5, offset: 31344},
+						pos:        position{line: 1127, col: 5, offset: 31535},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1127, col: 10, offset: 31349},
+						pos: position{line: 1127, col: 10, offset: 31540},
 						expr: &seqExpr{
-							pos: position{line: 1127, col: 11, offset: 31350},
+							pos: position{line: 1127, col: 11, offset: 31541},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1127, col: 11, offset: 31350},
+									pos: position{line: 1127, col: 11, offset: 31541},
 									expr: &litMatcher{
-										pos:        position{line: 1127, col: 12, offset: 31351},
+										pos:        position{line: 1127, col: 12, offset: 31542},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1127, col: 17, offset: 31356},
+									pos:  position{line: 1127, col: 17, offset: 31547},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1127, col: 35, offset: 31374},
+						pos:        position{line: 1127, col: 35, offset: 31565},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -8266,29 +8266,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1129, col: 1, offset: 31380},
+			pos:  position{line: 1129, col: 1, offset: 31571},
 			expr: &seqExpr{
-				pos: position{line: 1130, col: 5, offset: 31402},
+				pos: position{line: 1130, col: 5, offset: 31593},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1130, col: 5, offset: 31402},
+						pos:        position{line: 1130, col: 5, offset: 31593},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1130, col: 10, offset: 31407},
+						pos: position{line: 1130, col: 10, offset: 31598},
 						expr: &seqExpr{
-							pos: position{line: 1130, col: 11, offset: 31408},
+							pos: position{line: 1130, col: 11, offset: 31599},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1130, col: 11, offset: 31408},
+									pos: position{line: 1130, col: 11, offset: 31599},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1130, col: 12, offset: 31409},
+										pos:  position{line: 1130, col: 12, offset: 31600},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1130, col: 27, offset: 31424},
+									pos:  position{line: 1130, col: 27, offset: 31615},
 									name: "SourceCharacter",
 								},
 							},
@@ -8299,19 +8299,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1132, col: 1, offset: 31443},
+			pos:  position{line: 1132, col: 1, offset: 31634},
 			expr: &seqExpr{
-				pos: position{line: 1132, col: 7, offset: 31449},
+				pos: position{line: 1132, col: 7, offset: 31640},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1132, col: 7, offset: 31449},
+						pos: position{line: 1132, col: 7, offset: 31640},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1132, col: 7, offset: 31449},
+							pos:  position{line: 1132, col: 7, offset: 31640},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 19, offset: 31461},
+						pos:  position{line: 1132, col: 19, offset: 31652},
 						name: "LineTerminator",
 					},
 				},
@@ -8319,16 +8319,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1134, col: 1, offset: 31477},
+			pos:  position{line: 1134, col: 1, offset: 31668},
 			expr: &choiceExpr{
-				pos: position{line: 1134, col: 7, offset: 31483},
+				pos: position{line: 1134, col: 7, offset: 31674},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 7, offset: 31483},
+						pos:  position{line: 1134, col: 7, offset: 31674},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 11, offset: 31487},
+						pos:  position{line: 1134, col: 11, offset: 31678},
 						name: "EOF",
 					},
 				},
@@ -8336,11 +8336,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1136, col: 1, offset: 31492},
+			pos:  position{line: 1136, col: 1, offset: 31683},
 			expr: &notExpr{
-				pos: position{line: 1136, col: 7, offset: 31498},
+				pos: position{line: 1136, col: 7, offset: 31689},
 				expr: &anyMatcher{
-					line: 1136, col: 8, offset: 31499,
+					line: 1136, col: 8, offset: 31690,
 				},
 			},
 		},
@@ -8363,7 +8363,7 @@ func (c *current) onZ2(consts, first, rest interface{}) (interface{}, error) {
 	for _, p := range rest.([]interface{}) {
 		procs = append(procs, p)
 	}
-	return map[string]interface{}{"op": "Sequential", "procs": procs}, nil
+	return map[string]interface{}{"kind": "Sequential", "procs": procs}, nil
 
 }
 
@@ -8384,7 +8384,7 @@ func (p *parser) callonConst1() (interface{}, error) {
 }
 
 func (c *current) onAnyConst2(id, expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Const", "name": id, "expr": expr}, nil
+	return map[string]interface{}{"kind": "Const", "name": id, "expr": expr}, nil
 
 }
 
@@ -8395,7 +8395,7 @@ func (p *parser) callonAnyConst2() (interface{}, error) {
 }
 
 func (c *current) onAnyConst18(id, typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeProc", "name": id, "type": typ}, nil
+	return map[string]interface{}{"kind": "TypeProc", "name": id, "type": typ}, nil
 
 }
 
@@ -8406,7 +8406,7 @@ func (p *parser) callonAnyConst18() (interface{}, error) {
 }
 
 func (c *current) onSequential2(first, rest interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Sequential", "procs": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
+	return map[string]interface{}{"kind": "Sequential", "procs": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
 
 }
 
@@ -8417,7 +8417,7 @@ func (p *parser) callonSequential2() (interface{}, error) {
 }
 
 func (c *current) onSequential9(op interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Sequential", "procs": []interface{}{op}}, nil
+	return map[string]interface{}{"kind": "Sequential", "procs": []interface{}{op}}, nil
 
 }
 
@@ -8481,7 +8481,7 @@ func (p *parser) callonSwitchBranch2() (interface{}, error) {
 }
 
 func (c *current) onSwitchBranch14(proc interface{}) (interface{}, error) {
-	return map[string]interface{}{"expr": map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}, nil
+	return map[string]interface{}{"expr": map[string]interface{}{"kind": "Literal", "type": "bool", "value": "true"}, "proc": proc}, nil
 
 }
 
@@ -8514,7 +8514,7 @@ func (p *parser) callonSwitch9() (interface{}, error) {
 }
 
 func (c *current) onOperation2(procArray interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Parallel", "procs": procArray}, nil
+	return map[string]interface{}{"kind": "Parallel", "procs": procArray}, nil
 
 }
 
@@ -8525,7 +8525,7 @@ func (p *parser) callonOperation2() (interface{}, error) {
 }
 
 func (c *current) onOperation14(caseArray interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Switch", "cases": caseArray}, nil
+	return map[string]interface{}{"kind": "Switch", "cases": caseArray}, nil
 
 }
 
@@ -8556,7 +8556,7 @@ func (p *parser) callonOperation31() (interface{}, error) {
 }
 
 func (c *current) onOperation37(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Filter", "expr": expr}, nil
+	return map[string]interface{}{"kind": "Filter", "expr": expr}, nil
 
 }
 
@@ -8609,7 +8609,7 @@ func (p *parser) callonSearchAnd1() (interface{}, error) {
 }
 
 func (c *current) onSearchFactor2(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "UnaryExpr", "kind": "!", "operand": e}, nil
+	return map[string]interface{}{"kind": "UnaryExpr", "op": "!", "operand": e}, nil
 
 }
 
@@ -8630,21 +8630,21 @@ func (p *parser) callonSearchFactor15() (interface{}, error) {
 }
 
 func (c *current) onShortCut2(compareOp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Call", "name": "or",
+	return map[string]interface{}{"kind": "Call", "name": "or",
 
 		"args": []interface{}{
 
-			map[string]interface{}{"op": "SelectExpr",
+			map[string]interface{}{"kind": "SelectExpr",
 
-				"selectors": []interface{}{map[string]interface{}{"op": "Root"}},
+				"selectors": []interface{}{map[string]interface{}{"kind": "Root"}},
 
 				"methods": []interface{}{
 
-					map[string]interface{}{"op": "Call", "name": "map",
+					map[string]interface{}{"kind": "Call", "name": "map",
 
-						"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "kind": "=",
+						"args": []interface{}{map[string]interface{}{"kind": "BinaryExpr", "op": "=",
 
-							"lhs": map[string]interface{}{"op": "Id", "name": "$"},
+							"lhs": map[string]interface{}{"kind": "Id", "name": "$"},
 
 							"rhs": v}}}}}}}, nil
 
@@ -8657,7 +8657,7 @@ func (p *parser) callonShortCut2() (interface{}, error) {
 }
 
 func (c *current) onShortCut11(f, comp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "kind": comp, "lhs": f, "rhs": v}, nil
+	return map[string]interface{}{"kind": "BinaryExpr", "op": comp, "lhs": f, "rhs": v}, nil
 
 }
 
@@ -8668,21 +8668,21 @@ func (p *parser) callonShortCut11() (interface{}, error) {
 }
 
 func (c *current) onShortCut23(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Call", "name": "or",
+	return map[string]interface{}{"kind": "Call", "name": "or",
 
 		"args": []interface{}{
 
-			map[string]interface{}{"op": "SelectExpr",
+			map[string]interface{}{"kind": "SelectExpr",
 
-				"selectors": []interface{}{map[string]interface{}{"op": "Root"}},
+				"selectors": []interface{}{map[string]interface{}{"kind": "Root"}},
 
 				"methods": []interface{}{
 
-					map[string]interface{}{"op": "Call", "name": "map",
+					map[string]interface{}{"kind": "Call", "name": "map",
 
-						"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "kind": "in",
+						"args": []interface{}{map[string]interface{}{"kind": "BinaryExpr", "op": "in",
 
-							"rhs": map[string]interface{}{"op": "Id", "name": "$"},
+							"rhs": map[string]interface{}{"kind": "Id", "name": "$"},
 
 							"lhs": v}}}}}}}, nil
 
@@ -8695,7 +8695,7 @@ func (p *parser) callonShortCut23() (interface{}, error) {
 }
 
 func (c *current) onShortCut31(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Search", "text": string(c.text), "value": v}, nil
+	return map[string]interface{}{"kind": "Search", "text": string(c.text), "value": v}, nil
 
 }
 
@@ -8706,7 +8706,7 @@ func (p *parser) callonShortCut31() (interface{}, error) {
 }
 
 func (c *current) onShortCut41() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "bool", "value": "true"}, nil
 
 }
 
@@ -8717,7 +8717,7 @@ func (p *parser) callonShortCut41() (interface{}, error) {
 }
 
 func (c *current) onSearchValue3(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "string", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "string", "value": v}, nil
 
 }
 
@@ -8729,7 +8729,7 @@ func (p *parser) callonSearchValue3() (interface{}, error) {
 
 func (c *current) onGlobbySearchValue3(v interface{}) (interface{}, error) {
 	var str = v.(string)
-	var literal = map[string]interface{}{"op": "Literal", "type": "string", "value": v}
+	var literal = map[string]interface{}{"kind": "Literal", "type": "string", "value": v}
 	if reglob.IsGlobby(str) {
 		literal["type"] = "regexp"
 		literal["value"] = reglob.Reglob(str)
@@ -8849,7 +8849,7 @@ func (p *parser) callonSearchExprMul1() (interface{}, error) {
 }
 
 func (c *current) onSearchExprCast2(e, typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Cast", "expr": e, "type": typ}, nil
+	return map[string]interface{}{"kind": "Cast", "expr": e, "type": typ}, nil
 
 }
 
@@ -8871,7 +8871,7 @@ func (p *parser) callonSearchExprFunc4() (interface{}, error) {
 }
 
 func (c *current) onAggregation2(every, keys, limit interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Summarize", "keys": keys, "aggs": nil, "duration": every, "limit": limit}, nil
+	return map[string]interface{}{"kind": "Summarize", "keys": keys, "aggs": nil, "duration": every, "limit": limit}, nil
 
 }
 
@@ -8882,7 +8882,7 @@ func (p *parser) callonAggregation2() (interface{}, error) {
 }
 
 func (c *current) onAggregation11(every, aggs, keys, limit interface{}) (interface{}, error) {
-	var p = map[string]interface{}{"op": "Summarize", "keys": nil, "aggs": aggs, "duration": every, "limit": limit}
+	var p = map[string]interface{}{"kind": "Summarize", "keys": nil, "aggs": aggs, "duration": every, "limit": limit}
 	if keys != nil {
 		p["keys"] = keys.([]interface{})[1]
 	}
@@ -8947,7 +8947,7 @@ func (p *parser) callonLimitArg11() (interface{}, error) {
 }
 
 func (c *current) onFlexAssignment3(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "lhs": nil, "rhs": expr}, nil
+	return map[string]interface{}{"kind": "Assignment", "lhs": nil, "rhs": expr}, nil
 }
 
 func (p *parser) callonFlexAssignment3() (interface{}, error) {
@@ -8978,7 +8978,7 @@ func (p *parser) callonFlexAssignments1() (interface{}, error) {
 }
 
 func (c *current) onAggAssignment2(lval, agg interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "lhs": lval, "rhs": agg}, nil
+	return map[string]interface{}{"kind": "Assignment", "lhs": lval, "rhs": agg}, nil
 
 }
 
@@ -8989,7 +8989,7 @@ func (p *parser) callonAggAssignment2() (interface{}, error) {
 }
 
 func (c *current) onAggAssignment11(agg interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "lhs": nil, "rhs": agg}, nil
+	return map[string]interface{}{"kind": "Assignment", "lhs": nil, "rhs": agg}, nil
 
 }
 
@@ -9000,7 +9000,7 @@ func (p *parser) callonAggAssignment11() (interface{}, error) {
 }
 
 func (c *current) onAgg1(op, expr, where interface{}) (interface{}, error) {
-	var r = map[string]interface{}{"op": "Agg", "name": op, "expr": nil, "where": where}
+	var r = map[string]interface{}{"kind": "Agg", "name": op, "expr": nil, "where": where}
 	if expr != nil {
 		r["expr"] = expr
 	}
@@ -9051,7 +9051,7 @@ func (p *parser) callonSortProc8() (interface{}, error) {
 
 func (c *current) onSortProc1(args, list interface{}) (interface{}, error) {
 	var argm = args.(map[string]interface{})
-	var proc = map[string]interface{}{"op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false}
+	var proc = map[string]interface{}{"kind": "Sort", "args": list, "sortdir": 1, "nullsfirst": false}
 	if _, ok := argm["r"]; ok {
 		proc["sortdir"] = -1
 	}
@@ -9141,7 +9141,7 @@ func (p *parser) callonTopProc18() (interface{}, error) {
 }
 
 func (c *current) onTopProc1(limit, flush, fields interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "Top", "limit": 0, "args": nil, "flush": false}
+	var proc = map[string]interface{}{"kind": "Top", "limit": 0, "args": nil, "flush": false}
 	if limit != nil {
 		proc["limit"] = limit
 	}
@@ -9162,7 +9162,7 @@ func (p *parser) callonTopProc1() (interface{}, error) {
 }
 
 func (c *current) onCutProc1(args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Cut", "args": args}, nil
+	return map[string]interface{}{"kind": "Cut", "args": args}, nil
 
 }
 
@@ -9173,7 +9173,7 @@ func (p *parser) callonCutProc1() (interface{}, error) {
 }
 
 func (c *current) onPickProc1(args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Pick", "args": args}, nil
+	return map[string]interface{}{"kind": "Pick", "args": args}, nil
 
 }
 
@@ -9184,7 +9184,7 @@ func (p *parser) callonPickProc1() (interface{}, error) {
 }
 
 func (c *current) onDropProc1(args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Drop", "args": args}, nil
+	return map[string]interface{}{"kind": "Drop", "args": args}, nil
 
 }
 
@@ -9195,7 +9195,7 @@ func (p *parser) callonDropProc1() (interface{}, error) {
 }
 
 func (c *current) onHeadProc2(count interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Head", "count": count}, nil
+	return map[string]interface{}{"kind": "Head", "count": count}, nil
 }
 
 func (p *parser) callonHeadProc2() (interface{}, error) {
@@ -9205,7 +9205,7 @@ func (p *parser) callonHeadProc2() (interface{}, error) {
 }
 
 func (c *current) onHeadProc8() (interface{}, error) {
-	return map[string]interface{}{"op": "Head", "count": 1}, nil
+	return map[string]interface{}{"kind": "Head", "count": 1}, nil
 }
 
 func (p *parser) callonHeadProc8() (interface{}, error) {
@@ -9215,7 +9215,7 @@ func (p *parser) callonHeadProc8() (interface{}, error) {
 }
 
 func (c *current) onTailProc2(count interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Tail", "count": count}, nil
+	return map[string]interface{}{"kind": "Tail", "count": count}, nil
 }
 
 func (p *parser) callonTailProc2() (interface{}, error) {
@@ -9225,7 +9225,7 @@ func (p *parser) callonTailProc2() (interface{}, error) {
 }
 
 func (c *current) onTailProc8() (interface{}, error) {
-	return map[string]interface{}{"op": "Tail", "count": 1}, nil
+	return map[string]interface{}{"kind": "Tail", "count": 1}, nil
 }
 
 func (p *parser) callonTailProc8() (interface{}, error) {
@@ -9246,7 +9246,7 @@ func (p *parser) callonFilterProc1() (interface{}, error) {
 }
 
 func (c *current) onFilter1(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Filter", "expr": expr}, nil
+	return map[string]interface{}{"kind": "Filter", "expr": expr}, nil
 
 }
 
@@ -9257,7 +9257,7 @@ func (p *parser) callonFilter1() (interface{}, error) {
 }
 
 func (c *current) onUniqProc2() (interface{}, error) {
-	return map[string]interface{}{"op": "Uniq", "cflag": true}, nil
+	return map[string]interface{}{"kind": "Uniq", "cflag": true}, nil
 
 }
 
@@ -9268,7 +9268,7 @@ func (p *parser) callonUniqProc2() (interface{}, error) {
 }
 
 func (c *current) onUniqProc7() (interface{}, error) {
-	return map[string]interface{}{"op": "Uniq", "cflag": false}, nil
+	return map[string]interface{}{"kind": "Uniq", "cflag": false}, nil
 
 }
 
@@ -9279,7 +9279,7 @@ func (p *parser) callonUniqProc7() (interface{}, error) {
 }
 
 func (c *current) onPutProc1(args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Put", "args": args}, nil
+	return map[string]interface{}{"kind": "Put", "args": args}, nil
 
 }
 
@@ -9300,7 +9300,7 @@ func (p *parser) callonRenameProc9() (interface{}, error) {
 }
 
 func (c *current) onRenameProc1(first, rest interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Rename", "args": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
+	return map[string]interface{}{"kind": "Rename", "args": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
 
 }
 
@@ -9311,7 +9311,7 @@ func (p *parser) callonRenameProc1() (interface{}, error) {
 }
 
 func (c *current) onFuseProc1() (interface{}, error) {
-	return map[string]interface{}{"op": "Fuse"}, nil
+	return map[string]interface{}{"kind": "Fuse"}, nil
 
 }
 
@@ -9322,7 +9322,7 @@ func (p *parser) callonFuseProc1() (interface{}, error) {
 }
 
 func (c *current) onShapeProc1() (interface{}, error) {
-	return map[string]interface{}{"op": "Shape"}, nil
+	return map[string]interface{}{"kind": "Shape"}, nil
 
 }
 
@@ -9332,8 +9332,8 @@ func (p *parser) callonShapeProc1() (interface{}, error) {
 	return p.cur.onShapeProc1()
 }
 
-func (c *current) onJoinProc2(kind, leftKey, rightKey, columns interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": nil}
+func (c *current) onJoinProc2(style, leftKey, rightKey, columns interface{}) (interface{}, error) {
+	var proc = map[string]interface{}{"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": nil}
 	if columns != nil {
 		proc["args"] = columns.([]interface{})[1]
 	}
@@ -9344,11 +9344,11 @@ func (c *current) onJoinProc2(kind, leftKey, rightKey, columns interface{}) (int
 func (p *parser) callonJoinProc2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinProc2(stack["kind"], stack["leftKey"], stack["rightKey"], stack["columns"])
+	return p.cur.onJoinProc2(stack["style"], stack["leftKey"], stack["rightKey"], stack["columns"])
 }
 
-func (c *current) onJoinProc20(kind, key, columns interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": nil}
+func (c *current) onJoinProc20(style, key, columns interface{}) (interface{}, error) {
+	var proc = map[string]interface{}{"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": nil}
 	if columns != nil {
 		proc["args"] = columns.([]interface{})[1]
 	}
@@ -9359,47 +9359,47 @@ func (c *current) onJoinProc20(kind, key, columns interface{}) (interface{}, err
 func (p *parser) callonJoinProc20() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinProc20(stack["kind"], stack["key"], stack["columns"])
+	return p.cur.onJoinProc20(stack["style"], stack["key"], stack["columns"])
 }
 
-func (c *current) onJoinKind2() (interface{}, error) {
+func (c *current) onJoinStyle2() (interface{}, error) {
 	return "inner", nil
 }
 
-func (p *parser) callonJoinKind2() (interface{}, error) {
+func (p *parser) callonJoinStyle2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinKind2()
+	return p.cur.onJoinStyle2()
 }
 
-func (c *current) onJoinKind6() (interface{}, error) {
+func (c *current) onJoinStyle6() (interface{}, error) {
 	return "left", nil
 }
 
-func (p *parser) callonJoinKind6() (interface{}, error) {
+func (p *parser) callonJoinStyle6() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinKind6()
+	return p.cur.onJoinStyle6()
 }
 
-func (c *current) onJoinKind10() (interface{}, error) {
+func (c *current) onJoinStyle10() (interface{}, error) {
 	return "right", nil
 }
 
-func (p *parser) callonJoinKind10() (interface{}, error) {
+func (p *parser) callonJoinStyle10() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinKind10()
+	return p.cur.onJoinStyle10()
 }
 
-func (c *current) onJoinKind14() (interface{}, error) {
+func (c *current) onJoinStyle14() (interface{}, error) {
 	return "inner", nil
 }
 
-func (p *parser) callonJoinKind14() (interface{}, error) {
+func (p *parser) callonJoinStyle14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinKind14()
+	return p.cur.onJoinStyle14()
 }
 
 func (c *current) onJoinKey3(expr interface{}) (interface{}, error) {
@@ -9413,23 +9413,23 @@ func (p *parser) callonJoinKey3() (interface{}, error) {
 }
 
 func (c *current) onTasteProc1(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Sequential", "procs": []interface{}{
+	return map[string]interface{}{"kind": "Sequential", "procs": []interface{}{
 
-		map[string]interface{}{"op": "Summarize",
+		map[string]interface{}{"kind": "Summarize",
 
-			"keys": []interface{}{map[string]interface{}{"op": "Assignment",
+			"keys": []interface{}{map[string]interface{}{"kind": "Assignment",
 
-				"lhs": map[string]interface{}{"op": "Id", "name": "shape"},
+				"lhs": map[string]interface{}{"kind": "Id", "name": "shape"},
 
-				"rhs": map[string]interface{}{"op": "Call", "name": "typeof",
+				"rhs": map[string]interface{}{"kind": "Call", "name": "typeof",
 
 					"args": []interface{}{e}}}},
 
-			"aggs": []interface{}{map[string]interface{}{"op": "Assignment",
+			"aggs": []interface{}{map[string]interface{}{"kind": "Assignment",
 
-				"lhs": map[string]interface{}{"op": "Id", "name": "taste"},
+				"lhs": map[string]interface{}{"kind": "Id", "name": "taste"},
 
-				"rhs": map[string]interface{}{"op": "Agg",
+				"rhs": map[string]interface{}{"kind": "Agg",
 
 					"name": "any",
 
@@ -9439,13 +9439,13 @@ func (c *current) onTasteProc1(e interface{}) (interface{}, error) {
 
 			"duration": nil, "limit": 0},
 
-		map[string]interface{}{"op": "Cut",
+		map[string]interface{}{"kind": "Cut",
 
-			"args": []interface{}{map[string]interface{}{"op": "Assignment",
+			"args": []interface{}{map[string]interface{}{"kind": "Assignment",
 
 				"lhs": nil,
 
-				"rhs": map[string]interface{}{"op": "Id", "name": "taste"}}}}}}, nil
+				"rhs": map[string]interface{}{"kind": "Id", "name": "taste"}}}}}}, nil
 
 }
 
@@ -9466,7 +9466,7 @@ func (p *parser) callonTasteExpr2() (interface{}, error) {
 }
 
 func (c *current) onTasteExpr7() (interface{}, error) {
-	return map[string]interface{}{"op": "Root"}, nil
+	return map[string]interface{}{"kind": "Root"}, nil
 }
 
 func (p *parser) callonTasteExpr7() (interface{}, error) {
@@ -9510,7 +9510,7 @@ func (p *parser) callonExprs1() (interface{}, error) {
 }
 
 func (c *current) onAssignment1(lhs, rhs interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "lhs": lhs, "rhs": rhs}, nil
+	return map[string]interface{}{"kind": "Assignment", "lhs": lhs, "rhs": rhs}, nil
 }
 
 func (p *parser) callonAssignment1() (interface{}, error) {
@@ -9520,7 +9520,7 @@ func (p *parser) callonAssignment1() (interface{}, error) {
 }
 
 func (c *current) onConditionalExpr2(condition, thenClause, elseClause interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}, nil
+	return map[string]interface{}{"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}, nil
 
 }
 
@@ -9707,7 +9707,7 @@ func (p *parser) callonMultiplicativeOperator1() (interface{}, error) {
 }
 
 func (c *current) onNotExpr2(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "UnaryExpr", "kind": "!", "operand": e}, nil
+	return map[string]interface{}{"kind": "UnaryExpr", "op": "!", "operand": e}, nil
 
 }
 
@@ -9718,7 +9718,7 @@ func (p *parser) callonNotExpr2() (interface{}, error) {
 }
 
 func (c *current) onCastExpr2(e, typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Cast", "expr": e, "type": typ}, nil
+	return map[string]interface{}{"kind": "Cast", "expr": e, "type": typ}, nil
 
 }
 
@@ -9750,7 +9750,7 @@ func (p *parser) callonMatchExpr1() (interface{}, error) {
 }
 
 func (c *current) onSelectExpr1(args, methods interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SelectExpr", "selectors": args, "methods": methods}, nil
+	return map[string]interface{}{"kind": "SelectExpr", "selectors": args, "methods": methods}, nil
 
 }
 
@@ -9791,7 +9791,7 @@ func (p *parser) callonMethod1() (interface{}, error) {
 }
 
 func (c *current) onFunction1(fn, args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Call", "name": fn, "args": args}, nil
+	return map[string]interface{}{"kind": "Call", "name": fn, "args": args}, nil
 
 }
 
@@ -9855,7 +9855,7 @@ func (p *parser) callonDerefExpr9() (interface{}, error) {
 }
 
 func (c *current) onDerefExpr16() (interface{}, error) {
-	return map[string]interface{}{"op": "Root"}, nil
+	return map[string]interface{}{"kind": "Root"}, nil
 
 }
 
@@ -9866,9 +9866,9 @@ func (p *parser) callonDerefExpr16() (interface{}, error) {
 }
 
 func (c *current) onDotId2(field interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "kind": ".",
+	return map[string]interface{}{"kind": "BinaryExpr", "op": ".",
 
-		"lhs": map[string]interface{}{"op": "Root"},
+		"lhs": map[string]interface{}{"kind": "Root"},
 
 		"rhs": field}, nil
 
@@ -9881,9 +9881,9 @@ func (p *parser) callonDotId2() (interface{}, error) {
 }
 
 func (c *current) onDotId7(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "kind": "[",
+	return map[string]interface{}{"kind": "BinaryExpr", "op": "[",
 
-		"lhs": map[string]interface{}{"op": "Root"},
+		"lhs": map[string]interface{}{"kind": "Root"},
 
 		"rhs": expr}, nil
 
@@ -9896,7 +9896,7 @@ func (p *parser) callonDotId7() (interface{}, error) {
 }
 
 func (c *current) onDeref2(from, to interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "kind": ":",
+	return []interface{}{"[", map[string]interface{}{"kind": "BinaryExpr", "op": ":",
 
 		"lhs": from, "rhs": to}}, nil
 
@@ -9909,7 +9909,7 @@ func (p *parser) callonDeref2() (interface{}, error) {
 }
 
 func (c *current) onDeref13(to interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "kind": ":",
+	return []interface{}{"[", map[string]interface{}{"kind": "BinaryExpr", "op": ":",
 
 		"lhs": nil, "rhs": to}}, nil
 
@@ -9922,7 +9922,7 @@ func (p *parser) callonDeref13() (interface{}, error) {
 }
 
 func (c *current) onDeref22(from interface{}) (interface{}, error) {
-	return []interface{}{"[", map[string]interface{}{"op": "BinaryExpr", "kind": ":",
+	return []interface{}{"[", map[string]interface{}{"kind": "BinaryExpr", "op": ":",
 
 		"lhs": from, "rhs": nil}}, nil
 
@@ -9965,7 +9965,7 @@ func (p *parser) callonPrimary3() (interface{}, error) {
 }
 
 func (c *current) onStringLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "string", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "string", "value": v}, nil
 
 }
 
@@ -9976,7 +9976,7 @@ func (p *parser) callonStringLiteral1() (interface{}, error) {
 }
 
 func (c *current) onRegexpLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "regexp", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "regexp", "value": v}, nil
 
 }
 
@@ -9987,7 +9987,7 @@ func (p *parser) callonRegexpLiteral1() (interface{}, error) {
 }
 
 func (c *current) onSubnetLiteral2(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "net", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "net", "value": v}, nil
 
 }
 
@@ -9998,7 +9998,7 @@ func (p *parser) callonSubnetLiteral2() (interface{}, error) {
 }
 
 func (c *current) onSubnetLiteral8(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "net", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "net", "value": v}, nil
 
 }
 
@@ -10009,7 +10009,7 @@ func (p *parser) callonSubnetLiteral8() (interface{}, error) {
 }
 
 func (c *current) onAddressLiteral2(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "ip", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "ip", "value": v}, nil
 
 }
 
@@ -10020,7 +10020,7 @@ func (p *parser) callonAddressLiteral2() (interface{}, error) {
 }
 
 func (c *current) onAddressLiteral8(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "ip", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "ip", "value": v}, nil
 
 }
 
@@ -10031,7 +10031,7 @@ func (p *parser) callonAddressLiteral8() (interface{}, error) {
 }
 
 func (c *current) onFloatLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "float64", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "float64", "value": v}, nil
 
 }
 
@@ -10042,7 +10042,7 @@ func (p *parser) callonFloatLiteral1() (interface{}, error) {
 }
 
 func (c *current) onIntegerLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "int64", "value": v}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "int64", "value": v}, nil
 
 }
 
@@ -10053,7 +10053,7 @@ func (p *parser) callonIntegerLiteral1() (interface{}, error) {
 }
 
 func (c *current) onBooleanLiteral2() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "bool", "value": "true"}, nil
 }
 
 func (p *parser) callonBooleanLiteral2() (interface{}, error) {
@@ -10063,7 +10063,7 @@ func (p *parser) callonBooleanLiteral2() (interface{}, error) {
 }
 
 func (c *current) onBooleanLiteral4() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "false"}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "bool", "value": "false"}, nil
 }
 
 func (p *parser) callonBooleanLiteral4() (interface{}, error) {
@@ -10073,7 +10073,7 @@ func (p *parser) callonBooleanLiteral4() (interface{}, error) {
 }
 
 func (c *current) onNullLiteral1() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "null", "value": ""}, nil
+	return map[string]interface{}{"kind": "Literal", "type": "null", "value": ""}, nil
 }
 
 func (p *parser) callonNullLiteral1() (interface{}, error) {
@@ -10083,7 +10083,7 @@ func (p *parser) callonNullLiteral1() (interface{}, error) {
 }
 
 func (c *current) onTypeLiteral1(typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeValue", "value": typ}, nil
+	return map[string]interface{}{"kind": "TypeValue", "value": typ}, nil
 
 }
 
@@ -10124,7 +10124,7 @@ func (p *parser) callonTypeExternal23() (interface{}, error) {
 }
 
 func (c *current) onAmbiguousType2() (interface{}, error) {
-	return map[string]interface{}{"op": "TypeNull"}, nil
+	return map[string]interface{}{"kind": "TypeNull"}, nil
 
 }
 
@@ -10135,7 +10135,7 @@ func (p *parser) callonAmbiguousType2() (interface{}, error) {
 }
 
 func (c *current) onAmbiguousType6(name, typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeDef", "name": name, "type": typ}, nil
+	return map[string]interface{}{"kind": "TypeDef", "name": name, "type": typ}, nil
 
 }
 
@@ -10146,7 +10146,7 @@ func (p *parser) callonAmbiguousType6() (interface{}, error) {
 }
 
 func (c *current) onAmbiguousType19(name interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeName", "name": name}, nil
+	return map[string]interface{}{"kind": "TypeName", "name": name}, nil
 
 }
 
@@ -10167,7 +10167,7 @@ func (p *parser) callonAmbiguousType22() (interface{}, error) {
 }
 
 func (c *current) onTypeUnion1(types interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeUnion", "types": types}, nil
+	return map[string]interface{}{"kind": "TypeUnion", "types": types}, nil
 
 }
 
@@ -10199,7 +10199,7 @@ func (p *parser) callonTypeListTail1() (interface{}, error) {
 }
 
 func (c *current) onComplexType2(fields interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeRecord", "fields": fields}, nil
+	return map[string]interface{}{"kind": "TypeRecord", "fields": fields}, nil
 
 }
 
@@ -10210,7 +10210,7 @@ func (p *parser) callonComplexType2() (interface{}, error) {
 }
 
 func (c *current) onComplexType10(typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeArray", "type": typ}, nil
+	return map[string]interface{}{"kind": "TypeArray", "type": typ}, nil
 
 }
 
@@ -10221,7 +10221,7 @@ func (p *parser) callonComplexType10() (interface{}, error) {
 }
 
 func (c *current) onComplexType18(typ interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeSet", "type": typ}, nil
+	return map[string]interface{}{"kind": "TypeSet", "type": typ}, nil
 
 }
 
@@ -10232,7 +10232,7 @@ func (p *parser) callonComplexType18() (interface{}, error) {
 }
 
 func (c *current) onComplexType26(keyType, valType interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "TypeMap", "key_type": keyType, "val_type": valType}, nil
+	return map[string]interface{}{"kind": "TypeMap", "key_type": keyType, "val_type": valType}, nil
 
 }
 
@@ -10243,7 +10243,7 @@ func (p *parser) callonComplexType26() (interface{}, error) {
 }
 
 func (c *current) onPrimitiveTypeExternal1() (interface{}, error) {
-	return map[string]interface{}{"op": "TypePrimitive", "name": string(c.text)}, nil
+	return map[string]interface{}{"kind": "TypePrimitive", "name": string(c.text)}, nil
 
 }
 
@@ -10254,7 +10254,7 @@ func (p *parser) callonPrimitiveTypeExternal1() (interface{}, error) {
 }
 
 func (c *current) onPrimitiveTypeInternal1() (interface{}, error) {
-	return map[string]interface{}{"op": "TypePrimitive", "name": string(c.text)}, nil
+	return map[string]interface{}{"kind": "TypePrimitive", "name": string(c.text)}, nil
 
 }
 
@@ -10347,7 +10347,7 @@ func (p *parser) callonByToken1() (interface{}, error) {
 }
 
 func (c *current) onIdentifier1(id interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Id", "name": id}, nil
+	return map[string]interface{}{"kind": "Id", "name": id}, nil
 }
 
 func (p *parser) callonIdentifier1() (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -148,7 +148,7 @@ function peg$parse(input, options) {
             for(let  p of rest) {
               procs.push( p)
             }
-            return {"op": "SequentialProc", "procs": procs}
+            return {"op": "Sequential", "procs": procs}
           },
       peg$c2 = function(v) { return v },
       peg$c3 = "const",
@@ -158,7 +158,7 @@ function peg$parse(input, options) {
       peg$c7 = ";",
       peg$c8 = peg$literalExpectation(";", false),
       peg$c9 = function(id, expr) {
-            return {"op":"ConstProc","name":id, "expr":expr}
+            return {"op":"Const","name":id, "expr":expr}
           },
       peg$c10 = "type",
       peg$c11 = peg$literalExpectation("type", false),
@@ -166,10 +166,10 @@ function peg$parse(input, options) {
             return {"op":"TypeProc","name":id, "type":typ}
           },
       peg$c13 = function(first, rest) {
-            return {"op": "SequentialProc", "procs": [first, ... rest]}
+            return {"op": "Sequential", "procs": [first, ... rest]}
           },
       peg$c14 = function(op) {
-            return {"op": "SequentialProc", "procs": [op]}
+            return {"op": "Sequential", "procs": [op]}
           },
       peg$c15 = "|",
       peg$c16 = peg$literalExpectation("|", false),
@@ -183,11 +183,11 @@ function peg$parse(input, options) {
       peg$c20 = "=>",
       peg$c21 = peg$literalExpectation("=>", false),
       peg$c22 = function(ch) { return ch },
-      peg$c23 = function(filter, proc) {
-            return {"filter": filter, "proc": proc}
+      peg$c23 = function(e, proc) {
+            return {"expr": e, "proc": proc}
           },
       peg$c24 = function(proc) {
-            return {"filter": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
+            return {"expr": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
           },
       peg$c25 = "case",
       peg$c26 = peg$literalExpectation("case", true),
@@ -200,17 +200,17 @@ function peg$parse(input, options) {
       peg$c33 = ")",
       peg$c34 = peg$literalExpectation(")", false),
       peg$c35 = function(procArray) {
-            return {"op": "ParallelProc", "procs": procArray}
+            return {"op": "Parallel", "procs": procArray}
           },
       peg$c36 = "switch",
       peg$c37 = peg$literalExpectation("switch", false),
       peg$c38 = function(caseArray) {
-            return {"op": "SwitchProc", "cases": caseArray}
+            return {"op": "Switch", "cases": caseArray}
           },
       peg$c39 = function(f) { return f },
       peg$c40 = function(a) { return a },
       peg$c41 = function(expr) {
-            return {"op": "FilterProc", "filter": expr}
+            return {"op": "Filter", "expr": expr}
           },
       peg$c42 = ":",
       peg$c43 = peg$literalExpectation(":", false),
@@ -229,27 +229,27 @@ function peg$parse(input, options) {
       peg$c52 = "!",
       peg$c53 = peg$literalExpectation("!", false),
       peg$c54 = function(e) {
-            return {"op": "UnaryExpr", "operator": "!", "operand": e}
+            return {"op": "UnaryExpr", "kind": "!", "operand": e}
           },
       peg$c55 = function(expr) { return expr },
       peg$c56 = "*",
       peg$c57 = peg$literalExpectation("*", false),
       peg$c58 = function(compareOp, v) {
-            return {"op": "FunctionCall", "function": "or",
+            return {"op": "Call", "name": "or",
               
             "args": [
                 
             {"op": "SelectExpr",
                     
-            "selectors": [{"op": "RootRecord"}],
+            "selectors": [{"op": "Root"}],
                     
             "methods": [
                       
-            {"op": "FunctionCall", "function": "map",
+            {"op": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "operator": "=",
+            "args": [{"op": "BinaryExpr", "kind": "=",
                                             
-            "lhs": {"op": "Identifier", "name": "$"},
+            "lhs": {"op": "Id", "name": "$"},
                                             
             "rhs": v}]}]}]}
           
@@ -262,24 +262,24 @@ function peg$parse(input, options) {
 
           },
       peg$c59 = function(f, comp, v) {
-            return {"op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v}
+            return {"op": "BinaryExpr", "kind":comp, "lhs":f, "rhs":v}
           },
       peg$c60 = function(v) {
-            return {"op": "FunctionCall", "function": "or",
+            return {"op": "Call", "name": "or",
               
             "args": [
                 
             {"op": "SelectExpr",
                     
-            "selectors": [{"op": "RootRecord"}],
+            "selectors": [{"op": "Root"}],
                     
             "methods": [
                       
-            {"op": "FunctionCall", "function": "map",
+            {"op": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "operator": "in",
+            "args": [{"op": "BinaryExpr", "kind": "in",
                                             
-            "rhs": {"op": "Identifier", "name": "$"},
+            "rhs": {"op": "Id", "name": "$"},
                                             
             "lhs": v}]}]}]}
           
@@ -333,13 +333,13 @@ function peg$parse(input, options) {
               return makeBinaryExprChain(first, rest)
           },
       peg$c84 = function(e, typ) {
-            return {"op": "CastExpr", "expr": e, "type": typ}
+            return {"op": "Cast", "expr": e, "type": typ}
           },
       peg$c85 = function(every, keys, limit) {
-            return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
+            return {"op": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
-      peg$c86 = function(every, reducers, keys, limit) {
-            let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit}
+      peg$c86 = function(every, aggs, keys, limit) {
+            let p = {"op": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
@@ -361,16 +361,16 @@ function peg$parse(input, options) {
       peg$c100 = function() { return 0 },
       peg$c101 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
       peg$c102 = function(first, expr) { return expr },
-      peg$c103 = function(lval, reducer) {
-            return {"op": "Assignment", "lhs": lval, "rhs": reducer}
+      peg$c103 = function(lval, agg) {
+            return {"op": "Assignment", "lhs": lval, "rhs": agg}
           },
-      peg$c104 = function(reducer) {
-            return {"op": "Assignment", "lhs": null, "rhs": reducer}
+      peg$c104 = function(agg) {
+            return {"op": "Assignment", "lhs": null, "rhs": agg}
           },
       peg$c105 = ".",
       peg$c106 = peg$literalExpectation(".", false),
       peg$c107 = function(op, expr, where) {
-            let r = {"op": "Reducer", "operator": op, "expr": null, "where":where}
+            let r = {"op": "Agg", "name": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
@@ -390,7 +390,7 @@ function peg$parse(input, options) {
       peg$c113 = function(args, l) { return l },
       peg$c114 = function(args, list) {
             let argm = args
-            let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
+            let proc = {"op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
               proc["sortdir"] = -1
             }
@@ -419,12 +419,12 @@ function peg$parse(input, options) {
       peg$c130 = peg$literalExpectation("-flush", false),
       peg$c131 = function(limit, flush, f) { return f },
       peg$c132 = function(limit, flush, fields) {
-            let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false}
+            let proc = {"op": "Top", "limit": 0, "args": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
             }
             if (fields) {
-              proc["fields"] = fields
+              proc["args"] = fields
             }
             if (flush) {
               proc["flush"] = true
@@ -433,27 +433,27 @@ function peg$parse(input, options) {
           },
       peg$c133 = "cut",
       peg$c134 = peg$literalExpectation("cut", true),
-      peg$c135 = function(columns) {
-            return {"op": "CutProc", "fields": columns}
+      peg$c135 = function(args) {
+            return {"op": "Cut", "args": args}
           },
       peg$c136 = "pick",
       peg$c137 = peg$literalExpectation("pick", true),
-      peg$c138 = function(columns) {
-            return {"op": "PickProc", "fields": columns}
+      peg$c138 = function(args) {
+            return {"op": "Pick", "args": args}
           },
       peg$c139 = "drop",
       peg$c140 = peg$literalExpectation("drop", true),
-      peg$c141 = function(columns) {
-            return {"op": "DropProc", "fields": columns}
+      peg$c141 = function(args) {
+            return {"op": "Drop", "args": args}
           },
       peg$c142 = "head",
       peg$c143 = peg$literalExpectation("head", true),
-      peg$c144 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c145 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c144 = function(count) { return {"op": "Head", "count": count} },
+      peg$c145 = function() { return {"op": "Head", "count": 1} },
       peg$c146 = "tail",
       peg$c147 = peg$literalExpectation("tail", true),
-      peg$c148 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c149 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c148 = function(count) { return {"op": "Tail", "count": count} },
+      peg$c149 = function() { return {"op": "Tail", "count": 1} },
       peg$c150 = "filter",
       peg$c151 = peg$literalExpectation("filter", true),
       peg$c152 = function(op) {
@@ -464,45 +464,45 @@ function peg$parse(input, options) {
       peg$c155 = "-c",
       peg$c156 = peg$literalExpectation("-c", false),
       peg$c157 = function() {
-            return {"op": "UniqProc", "cflag": true}
+            return {"op": "Uniq", "cflag": true}
           },
       peg$c158 = function() {
-            return {"op": "UniqProc", "cflag": false}
+            return {"op": "Uniq", "cflag": false}
           },
       peg$c159 = "put",
       peg$c160 = peg$literalExpectation("put", true),
-      peg$c161 = function(columns) {
-            return {"op": "PutProc", "clauses": columns}
+      peg$c161 = function(args) {
+            return {"op": "Put", "args": args}
           },
       peg$c162 = "rename",
       peg$c163 = peg$literalExpectation("rename", true),
       peg$c164 = function(first, cl) { return cl },
       peg$c165 = function(first, rest) {
-            return {"op": "RenameProc", "fields": [first, ... rest]}
+            return {"op": "Rename", "args": [first, ... rest]}
           },
       peg$c166 = "fuse",
       peg$c167 = peg$literalExpectation("fuse", true),
       peg$c168 = function() {
-            return {"op": "FuseProc"}
+            return {"op": "Fuse"}
           },
       peg$c169 = "shape",
       peg$c170 = peg$literalExpectation("shape", true),
       peg$c171 = function() {
-            return {"op": "ShapeProc"}
+            return {"op": "Shape"}
           },
       peg$c172 = "join",
       peg$c173 = peg$literalExpectation("join", true),
       peg$c174 = function(kind, leftKey, rightKey, columns) {
-            let proc = {"op": "JoinProc", "kind": kind, "left_key": leftKey, "right_key": rightKey, "clauses": null}
+            let proc = {"op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": null}
             if (columns) {
-              proc["clauses"] = columns[1]
+              proc["args"] = columns[1]
             }
             return proc
           },
       peg$c175 = function(kind, key, columns) {
-            let proc = {"op": "JoinProc", "kind": kind, "left_key": key, "right_key": key, "clauses": null}
+            let proc = {"op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": null}
             if (columns) {
-              proc["clauses"] = columns[1]
+              proc["args"] = columns[1]
             }
             return proc
           },
@@ -518,25 +518,25 @@ function peg$parse(input, options) {
       peg$c185 = "taste",
       peg$c186 = peg$literalExpectation("taste", true),
       peg$c187 = function(e) {
-            return {"op": "SequentialProc", "procs": [
+            return {"op": "Sequential", "procs": [
               
-            {"op": "GroupByProc",
+            {"op": "Summarize",
                 
             "keys": [{"op": "Assignment",
                          
-            "lhs": {"op": "Identifier", "name": "shape"},
+            "lhs": {"op": "Id", "name": "shape"},
                          
-            "rhs": {"op": "FunctionCall", "function": "typeof",
+            "rhs": {"op": "Call", "name": "typeof",
                                     
             "args": [e]}}],
                 
-            "reducers": [{"op": "Assignment",
+            "aggs": [{"op": "Assignment",
                                     
-            "lhs": {"op": "Identifier", "name": "taste"},
+            "lhs": {"op": "Id", "name": "taste"},
                                     
-            "rhs": {"op": "Reducer",
+            "rhs": {"op": "Agg",
                                                
-            "operator": "any",
+            "name": "any",
                                                
             "expr": e,
                                                
@@ -544,17 +544,17 @@ function peg$parse(input, options) {
                 
             "duration": null, "limit": 0},
               
-            {"op": "CutProc",
+            {"op": "Cut",
                   
-            "fields": [{"op": "Assignment",
+            "args": [{"op": "Assignment",
                                       
             "lhs": null,
                                       
-            "rhs": {"op": "Identifier", "name": "taste"}}]}]}
+            "rhs": {"op": "Id", "name": "taste"}}]}]}
           
           },
       peg$c188 = function(lval) { return lval},
-      peg$c189 = function() { return {"op":"RootRecord"} },
+      peg$c189 = function() { return {"op":"Root"} },
       peg$c190 = function(first, rest) {
             let result = [first]
 
@@ -568,7 +568,7 @@ function peg$parse(input, options) {
       peg$c192 = "?",
       peg$c193 = peg$literalExpectation("?", false),
       peg$c194 = function(condition, thenClause, elseClause) {
-            return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
+            return {"op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
       peg$c195 = function(first, comp, expr) { return [comp, expr] },
       peg$c196 = "+",
@@ -578,7 +578,7 @@ function peg$parse(input, options) {
       peg$c200 = "/",
       peg$c201 = peg$literalExpectation("/", false),
       peg$c202 = function(e) {
-              return {"op": "UnaryExpr", "operator": "!", "operand": e}
+              return {"op": "UnaryExpr", "kind": "!", "operand": e}
           },
       peg$c203 = "not",
       peg$c204 = peg$literalExpectation("not", false),
@@ -591,17 +591,17 @@ function peg$parse(input, options) {
           },
       peg$c210 = function(methods) { return methods },
       peg$c211 = function(fn, args) {
-            return {"op": "FunctionCall", "function": fn, "args": args}
+            return {"op": "Call", "name": fn, "args": args}
           },
       peg$c212 = function(first, e) { return e },
       peg$c213 = function() { return [] },
       peg$c214 = function() {
-            return {"op":"RootRecord"}
+            return {"op":"Root"}
           },
       peg$c215 = function(field) {
-            return {"op": "BinaryExpr", "operator":".",
+            return {"op": "BinaryExpr", "kind":".",
                            
-            "lhs":{"op":"RootRecord"},
+            "lhs":{"op":"Root"},
                            
             "rhs":field}
           
@@ -612,28 +612,28 @@ function peg$parse(input, options) {
       peg$c218 = "]",
       peg$c219 = peg$literalExpectation("]", false),
       peg$c220 = function(expr) {
-            return {"op": "BinaryExpr", "operator":"[",
+            return {"op": "BinaryExpr", "kind":"[",
                            
-            "lhs":{"op":"RootRecord"},
+            "lhs":{"op":"Root"},
                            
             "rhs":expr}
           
 
           },
       peg$c221 = function(from, to) {
-            return ["[", {"op": "BinaryExpr", "operator":":",
+            return ["[", {"op": "BinaryExpr", "kind":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
       peg$c222 = function(to) {
-            return ["[", {"op": "BinaryExpr", "operator":":",
+            return ["[", {"op": "BinaryExpr", "kind":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
       peg$c223 = function(from) {
-            return ["[", {"op": "BinaryExpr", "operator":":",
+            return ["[", {"op": "BinaryExpr", "kind":":",
                                   
             "lhs":from, "rhs": null}]
           
@@ -665,7 +665,7 @@ function peg$parse(input, options) {
       peg$c238 = peg$literalExpectation("null", false),
       peg$c239 = function() { return {"op": "Literal", "type": "null", "value": ""} },
       peg$c240 = function(typ) {
-            return {"op": "TypeExpr", "type": typ}
+            return {"op": "TypeValue", "value": typ}
           },
       peg$c241 = function(typ) { return typ},
       peg$c242 = function(typ) { return typ },
@@ -768,7 +768,7 @@ function peg$parse(input, options) {
       peg$c317 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
       peg$c318 = /^[0-9]/,
       peg$c319 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c320 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c320 = function(id) { return {"op": "Id", "name": id} },
       peg$c321 = function() {  return text() },
       peg$c322 = "$",
       peg$c323 = peg$literalExpectation("$", false),
@@ -3281,7 +3281,7 @@ function peg$parse(input, options) {
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEveryDur();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseReducers();
+          s3 = peg$parseAggAssignments();
           if (s3 !== peg$FAILED) {
             s4 = peg$currPos;
             s5 = peg$parse_();
@@ -3621,7 +3621,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducerAssignment() {
+  function peg$parseAggAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -3639,7 +3639,7 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseReducer();
+            s5 = peg$parseAgg();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
               s1 = peg$c103(s1, s5);
@@ -3666,7 +3666,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseReducer();
+      s1 = peg$parseAgg();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c104(s1);
@@ -3677,7 +3677,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducer() {
+  function peg$parseAgg() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
 
     s0 = peg$currPos;
@@ -3692,7 +3692,7 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseReducerName();
+      s2 = peg$parseAggName();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -3804,7 +3804,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducerName() {
+  function peg$parseAggName() {
     var s0;
 
     s0 = peg$parseIdentifierName();
@@ -3859,11 +3859,11 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseReducers() {
+  function peg$parseAggAssignments() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$parseReducerAssignment();
+    s1 = peg$parseAggAssignment();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
@@ -3879,7 +3879,7 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
-            s7 = peg$parseReducerAssignment();
+            s7 = peg$parseAggAssignment();
             if (s7 !== peg$FAILED) {
               s4 = [s4, s5, s6, s7];
               s3 = s4;
@@ -3914,7 +3914,7 @@ function peg$parse(input, options) {
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
-              s7 = peg$parseReducerAssignment();
+              s7 = peg$parseAggAssignment();
               if (s7 !== peg$FAILED) {
                 s4 = [s4, s5, s6, s7];
                 s3 = s4;
@@ -11251,7 +11251,7 @@ function peg$parse(input, options) {
   function makeBinaryExprChain(first, rest) {
     let ret = first
     for (let part of rest) {
-      ret = { op: "BinaryExpr", operator: part[0], lhs: ret, rhs: part[1] };
+      ret = { op: "BinaryExpr", kind: part[0], lhs: ret, rhs: part[1] };
     }
     return ret
   }

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -148,7 +148,7 @@ function peg$parse(input, options) {
             for(let  p of rest) {
               procs.push( p)
             }
-            return {"op": "Sequential", "procs": procs}
+            return {"kind": "Sequential", "procs": procs}
           },
       peg$c2 = function(v) { return v },
       peg$c3 = "const",
@@ -158,18 +158,18 @@ function peg$parse(input, options) {
       peg$c7 = ";",
       peg$c8 = peg$literalExpectation(";", false),
       peg$c9 = function(id, expr) {
-            return {"op":"Const","name":id, "expr":expr}
+            return {"kind":"Const","name":id, "expr":expr}
           },
       peg$c10 = "type",
       peg$c11 = peg$literalExpectation("type", false),
       peg$c12 = function(id, typ) {
-            return {"op":"TypeProc","name":id, "type":typ}
+            return {"kind":"TypeProc","name":id, "type":typ}
           },
       peg$c13 = function(first, rest) {
-            return {"op": "Sequential", "procs": [first, ... rest]}
+            return {"kind": "Sequential", "procs": [first, ... rest]}
           },
       peg$c14 = function(op) {
-            return {"op": "Sequential", "procs": [op]}
+            return {"kind": "Sequential", "procs": [op]}
           },
       peg$c15 = "|",
       peg$c16 = peg$literalExpectation("|", false),
@@ -187,7 +187,7 @@ function peg$parse(input, options) {
             return {"expr": e, "proc": proc}
           },
       peg$c24 = function(proc) {
-            return {"expr": {"op": "Literal", "type": "bool", "value": "true"}, "proc": proc}
+            return {"expr": {"kind": "Literal", "type": "bool", "value": "true"}, "proc": proc}
           },
       peg$c25 = "case",
       peg$c26 = peg$literalExpectation("case", true),
@@ -200,17 +200,17 @@ function peg$parse(input, options) {
       peg$c33 = ")",
       peg$c34 = peg$literalExpectation(")", false),
       peg$c35 = function(procArray) {
-            return {"op": "Parallel", "procs": procArray}
+            return {"kind": "Parallel", "procs": procArray}
           },
       peg$c36 = "switch",
       peg$c37 = peg$literalExpectation("switch", false),
       peg$c38 = function(caseArray) {
-            return {"op": "Switch", "cases": caseArray}
+            return {"kind": "Switch", "cases": caseArray}
           },
       peg$c39 = function(f) { return f },
       peg$c40 = function(a) { return a },
       peg$c41 = function(expr) {
-            return {"op": "Filter", "expr": expr}
+            return {"kind": "Filter", "expr": expr}
           },
       peg$c42 = ":",
       peg$c43 = peg$literalExpectation(":", false),
@@ -229,27 +229,27 @@ function peg$parse(input, options) {
       peg$c52 = "!",
       peg$c53 = peg$literalExpectation("!", false),
       peg$c54 = function(e) {
-            return {"op": "UnaryExpr", "kind": "!", "operand": e}
+            return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
       peg$c55 = function(expr) { return expr },
       peg$c56 = "*",
       peg$c57 = peg$literalExpectation("*", false),
       peg$c58 = function(compareOp, v) {
-            return {"op": "Call", "name": "or",
+            return {"kind": "Call", "name": "or",
               
             "args": [
                 
-            {"op": "SelectExpr",
+            {"kind": "SelectExpr",
                     
-            "selectors": [{"op": "Root"}],
+            "selectors": [{"kind": "Root"}],
                     
             "methods": [
                       
-            {"op": "Call", "name": "map",
+            {"kind": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "kind": "=",
+            "args": [{"kind": "BinaryExpr", "op": "=",
                                             
-            "lhs": {"op": "Id", "name": "$"},
+            "lhs": {"kind": "Id", "name": "$"},
                                             
             "rhs": v}]}]}]}
           
@@ -262,24 +262,24 @@ function peg$parse(input, options) {
 
           },
       peg$c59 = function(f, comp, v) {
-            return {"op": "BinaryExpr", "kind":comp, "lhs":f, "rhs":v}
+            return {"kind": "BinaryExpr", "op":comp, "lhs":f, "rhs":v}
           },
       peg$c60 = function(v) {
-            return {"op": "Call", "name": "or",
+            return {"kind": "Call", "name": "or",
               
             "args": [
                 
-            {"op": "SelectExpr",
+            {"kind": "SelectExpr",
                     
-            "selectors": [{"op": "Root"}],
+            "selectors": [{"kind": "Root"}],
                     
             "methods": [
                       
-            {"op": "Call", "name": "map",
+            {"kind": "Call", "name": "map",
                           
-            "args": [{"op": "BinaryExpr", "kind": "in",
+            "args": [{"kind": "BinaryExpr", "op": "in",
                                             
-            "rhs": {"op": "Id", "name": "$"},
+            "rhs": {"kind": "Id", "name": "$"},
                                             
             "lhs": v}]}]}]}
           
@@ -292,17 +292,17 @@ function peg$parse(input, options) {
 
           },
       peg$c61 = function(v) {
-            return {"op": "Search", "text": text(), "value": v}
+            return {"kind": "Search", "text": text(), "value": v}
           },
       peg$c62 = function() {
-            return {"op": "Literal", "type": "bool", "value": "true"}
+            return {"kind": "Literal", "type": "bool", "value": "true"}
           },
       peg$c63 = function(v) {
-            return {"op": "Literal", "type": "string", "value": v}
+            return {"kind": "Literal", "type": "string", "value": v}
           },
       peg$c64 = function(v) {
             let str = v
-            let literal = {"op": "Literal", "type": "string", "value": v}
+            let literal = {"kind": "Literal", "type": "string", "value": v}
             if (reglob.IsGlobby(str)) {
               literal["type"] = "regexp"
               literal["value"] = reglob.Reglob(str)
@@ -333,13 +333,13 @@ function peg$parse(input, options) {
               return makeBinaryExprChain(first, rest)
           },
       peg$c84 = function(e, typ) {
-            return {"op": "Cast", "expr": e, "type": typ}
+            return {"kind": "Cast", "expr": e, "type": typ}
           },
       peg$c85 = function(every, keys, limit) {
-            return {"op": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
+            return {"kind": "Summarize", "keys": keys, "aggs": null, "duration": every, "limit": limit}
           },
       peg$c86 = function(every, aggs, keys, limit) {
-            let p = {"op": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit}
+            let p = {"kind": "Summarize", "keys": null, "aggs": aggs, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
@@ -359,18 +359,18 @@ function peg$parse(input, options) {
       peg$c98 = peg$literalExpectation("-limit", false),
       peg$c99 = function(limit) { return limit },
       peg$c100 = function() { return 0 },
-      peg$c101 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c101 = function(expr) { return {"kind": "Assignment", "lhs": null, "rhs": expr} },
       peg$c102 = function(first, expr) { return expr },
       peg$c103 = function(lval, agg) {
-            return {"op": "Assignment", "lhs": lval, "rhs": agg}
+            return {"kind": "Assignment", "lhs": lval, "rhs": agg}
           },
       peg$c104 = function(agg) {
-            return {"op": "Assignment", "lhs": null, "rhs": agg}
+            return {"kind": "Assignment", "lhs": null, "rhs": agg}
           },
       peg$c105 = ".",
       peg$c106 = peg$literalExpectation(".", false),
       peg$c107 = function(op, expr, where) {
-            let r = {"op": "Agg", "name": op, "expr": null, "where":where}
+            let r = {"kind": "Agg", "name": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
@@ -390,7 +390,7 @@ function peg$parse(input, options) {
       peg$c113 = function(args, l) { return l },
       peg$c114 = function(args, list) {
             let argm = args
-            let proc = {"op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false}
+            let proc = {"kind": "Sort", "args": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
               proc["sortdir"] = -1
             }
@@ -419,7 +419,7 @@ function peg$parse(input, options) {
       peg$c130 = peg$literalExpectation("-flush", false),
       peg$c131 = function(limit, flush, f) { return f },
       peg$c132 = function(limit, flush, fields) {
-            let proc = {"op": "Top", "limit": 0, "args": null, "flush": false}
+            let proc = {"kind": "Top", "limit": 0, "args": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
             }
@@ -434,26 +434,26 @@ function peg$parse(input, options) {
       peg$c133 = "cut",
       peg$c134 = peg$literalExpectation("cut", true),
       peg$c135 = function(args) {
-            return {"op": "Cut", "args": args}
+            return {"kind": "Cut", "args": args}
           },
       peg$c136 = "pick",
       peg$c137 = peg$literalExpectation("pick", true),
       peg$c138 = function(args) {
-            return {"op": "Pick", "args": args}
+            return {"kind": "Pick", "args": args}
           },
       peg$c139 = "drop",
       peg$c140 = peg$literalExpectation("drop", true),
       peg$c141 = function(args) {
-            return {"op": "Drop", "args": args}
+            return {"kind": "Drop", "args": args}
           },
       peg$c142 = "head",
       peg$c143 = peg$literalExpectation("head", true),
-      peg$c144 = function(count) { return {"op": "Head", "count": count} },
-      peg$c145 = function() { return {"op": "Head", "count": 1} },
+      peg$c144 = function(count) { return {"kind": "Head", "count": count} },
+      peg$c145 = function() { return {"kind": "Head", "count": 1} },
       peg$c146 = "tail",
       peg$c147 = peg$literalExpectation("tail", true),
-      peg$c148 = function(count) { return {"op": "Tail", "count": count} },
-      peg$c149 = function() { return {"op": "Tail", "count": 1} },
+      peg$c148 = function(count) { return {"kind": "Tail", "count": count} },
+      peg$c149 = function() { return {"kind": "Tail", "count": 1} },
       peg$c150 = "filter",
       peg$c151 = peg$literalExpectation("filter", true),
       peg$c152 = function(op) {
@@ -464,43 +464,43 @@ function peg$parse(input, options) {
       peg$c155 = "-c",
       peg$c156 = peg$literalExpectation("-c", false),
       peg$c157 = function() {
-            return {"op": "Uniq", "cflag": true}
+            return {"kind": "Uniq", "cflag": true}
           },
       peg$c158 = function() {
-            return {"op": "Uniq", "cflag": false}
+            return {"kind": "Uniq", "cflag": false}
           },
       peg$c159 = "put",
       peg$c160 = peg$literalExpectation("put", true),
       peg$c161 = function(args) {
-            return {"op": "Put", "args": args}
+            return {"kind": "Put", "args": args}
           },
       peg$c162 = "rename",
       peg$c163 = peg$literalExpectation("rename", true),
       peg$c164 = function(first, cl) { return cl },
       peg$c165 = function(first, rest) {
-            return {"op": "Rename", "args": [first, ... rest]}
+            return {"kind": "Rename", "args": [first, ... rest]}
           },
       peg$c166 = "fuse",
       peg$c167 = peg$literalExpectation("fuse", true),
       peg$c168 = function() {
-            return {"op": "Fuse"}
+            return {"kind": "Fuse"}
           },
       peg$c169 = "shape",
       peg$c170 = peg$literalExpectation("shape", true),
       peg$c171 = function() {
-            return {"op": "Shape"}
+            return {"kind": "Shape"}
           },
       peg$c172 = "join",
       peg$c173 = peg$literalExpectation("join", true),
-      peg$c174 = function(kind, leftKey, rightKey, columns) {
-            let proc = {"op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": null}
+      peg$c174 = function(style, leftKey, rightKey, columns) {
+            let proc = {"kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": null}
             if (columns) {
               proc["args"] = columns[1]
             }
             return proc
           },
-      peg$c175 = function(kind, key, columns) {
-            let proc = {"op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": null}
+      peg$c175 = function(style, key, columns) {
+            let proc = {"kind": "Join", "style": style, "left_key": key, "right_key": key, "args": null}
             if (columns) {
               proc["args"] = columns[1]
             }
@@ -518,23 +518,23 @@ function peg$parse(input, options) {
       peg$c185 = "taste",
       peg$c186 = peg$literalExpectation("taste", true),
       peg$c187 = function(e) {
-            return {"op": "Sequential", "procs": [
+            return {"kind": "Sequential", "procs": [
               
-            {"op": "Summarize",
+            {"kind": "Summarize",
                 
-            "keys": [{"op": "Assignment",
+            "keys": [{"kind": "Assignment",
                          
-            "lhs": {"op": "Id", "name": "shape"},
+            "lhs": {"kind": "Id", "name": "shape"},
                          
-            "rhs": {"op": "Call", "name": "typeof",
+            "rhs": {"kind": "Call", "name": "typeof",
                                     
             "args": [e]}}],
                 
-            "aggs": [{"op": "Assignment",
+            "aggs": [{"kind": "Assignment",
                                     
-            "lhs": {"op": "Id", "name": "taste"},
+            "lhs": {"kind": "Id", "name": "taste"},
                                     
-            "rhs": {"op": "Agg",
+            "rhs": {"kind": "Agg",
                                                
             "name": "any",
                                                
@@ -544,17 +544,17 @@ function peg$parse(input, options) {
                 
             "duration": null, "limit": 0},
               
-            {"op": "Cut",
+            {"kind": "Cut",
                   
-            "args": [{"op": "Assignment",
+            "args": [{"kind": "Assignment",
                                       
             "lhs": null,
                                       
-            "rhs": {"op": "Id", "name": "taste"}}]}]}
+            "rhs": {"kind": "Id", "name": "taste"}}]}]}
           
           },
       peg$c188 = function(lval) { return lval},
-      peg$c189 = function() { return {"op":"Root"} },
+      peg$c189 = function() { return {"kind":"Root"} },
       peg$c190 = function(first, rest) {
             let result = [first]
 
@@ -564,11 +564,11 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c191 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c191 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
       peg$c192 = "?",
       peg$c193 = peg$literalExpectation("?", false),
       peg$c194 = function(condition, thenClause, elseClause) {
-            return {"op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
+            return {"kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause}
           },
       peg$c195 = function(first, comp, expr) { return [comp, expr] },
       peg$c196 = "+",
@@ -578,7 +578,7 @@ function peg$parse(input, options) {
       peg$c200 = "/",
       peg$c201 = peg$literalExpectation("/", false),
       peg$c202 = function(e) {
-              return {"op": "UnaryExpr", "kind": "!", "operand": e}
+              return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
       peg$c203 = "not",
       peg$c204 = peg$literalExpectation("not", false),
@@ -587,21 +587,21 @@ function peg$parse(input, options) {
       peg$c207 = "select",
       peg$c208 = peg$literalExpectation("select", false),
       peg$c209 = function(args, methods) {
-            return {"op":"SelectExpr", "selectors":args, "methods": methods}
+            return {"kind":"SelectExpr", "selectors":args, "methods": methods}
           },
       peg$c210 = function(methods) { return methods },
       peg$c211 = function(fn, args) {
-            return {"op": "Call", "name": fn, "args": args}
+            return {"kind": "Call", "name": fn, "args": args}
           },
       peg$c212 = function(first, e) { return e },
       peg$c213 = function() { return [] },
       peg$c214 = function() {
-            return {"op":"Root"}
+            return {"kind":"Root"}
           },
       peg$c215 = function(field) {
-            return {"op": "BinaryExpr", "kind":".",
+            return {"kind": "BinaryExpr", "op":".",
                            
-            "lhs":{"op":"Root"},
+            "lhs":{"kind":"Root"},
                            
             "rhs":field}
           
@@ -612,28 +612,28 @@ function peg$parse(input, options) {
       peg$c218 = "]",
       peg$c219 = peg$literalExpectation("]", false),
       peg$c220 = function(expr) {
-            return {"op": "BinaryExpr", "kind":"[",
+            return {"kind": "BinaryExpr", "op":"[",
                            
-            "lhs":{"op":"Root"},
+            "lhs":{"kind":"Root"},
                            
             "rhs":expr}
           
 
           },
       peg$c221 = function(from, to) {
-            return ["[", {"op": "BinaryExpr", "kind":":",
+            return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
       peg$c222 = function(to) {
-            return ["[", {"op": "BinaryExpr", "kind":":",
+            return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
       peg$c223 = function(from) {
-            return ["[", {"op": "BinaryExpr", "kind":":",
+            return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs": null}]
           
@@ -641,46 +641,46 @@ function peg$parse(input, options) {
       peg$c224 = function(expr) { return ["[", expr] },
       peg$c225 = function(id) { return [".", id] },
       peg$c226 = function(v) {
-            return {"op": "Literal", "type": "regexp", "value": v}
+            return {"kind": "Literal", "type": "regexp", "value": v}
           },
       peg$c227 = function(v) {
-            return {"op": "Literal", "type": "net", "value": v}
+            return {"kind": "Literal", "type": "net", "value": v}
           },
       peg$c228 = function(v) {
-            return {"op": "Literal", "type": "ip", "value": v}
+            return {"kind": "Literal", "type": "ip", "value": v}
           },
       peg$c229 = function(v) {
-            return {"op": "Literal", "type": "float64", "value": v}
+            return {"kind": "Literal", "type": "float64", "value": v}
           },
       peg$c230 = function(v) {
-            return {"op": "Literal", "type": "int64", "value": v}
+            return {"kind": "Literal", "type": "int64", "value": v}
           },
       peg$c231 = "true",
       peg$c232 = peg$literalExpectation("true", false),
-      peg$c233 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c233 = function() { return {"kind": "Literal", "type": "bool", "value": "true"} },
       peg$c234 = "false",
       peg$c235 = peg$literalExpectation("false", false),
-      peg$c236 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c236 = function() { return {"kind": "Literal", "type": "bool", "value": "false"} },
       peg$c237 = "null",
       peg$c238 = peg$literalExpectation("null", false),
-      peg$c239 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c239 = function() { return {"kind": "Literal", "type": "null", "value": ""} },
       peg$c240 = function(typ) {
-            return {"op": "TypeValue", "value": typ}
+            return {"kind": "TypeValue", "value": typ}
           },
       peg$c241 = function(typ) { return typ},
       peg$c242 = function(typ) { return typ },
       peg$c243 = function() {
-            return {"op": "TypeNull"}
+            return {"kind": "TypeNull"}
           },
       peg$c244 = function(name, typ) {
-            return {"op": "TypeDef", "name": name, "type": typ}
+            return {"kind": "TypeDef", "name": name, "type": typ}
         },
       peg$c245 = function(name) {
-            return {"op": "TypeName", "name": name}
+            return {"kind": "TypeName", "name": name}
           },
       peg$c246 = function(u) { return u },
       peg$c247 = function(types) {
-            return {"op": "TypeUnion", "types": types}
+            return {"kind": "TypeUnion", "types": types}
           },
       peg$c248 = function(first, rest) {
           return [first, ... rest]
@@ -690,24 +690,24 @@ function peg$parse(input, options) {
       peg$c251 = "}",
       peg$c252 = peg$literalExpectation("}", false),
       peg$c253 = function(fields) {
-            return {"op":"TypeRecord", "fields":fields}
+            return {"kind":"TypeRecord", "fields":fields}
           },
       peg$c254 = function(typ) {
-            return {"op":"TypeArray", "type":typ}
+            return {"kind":"TypeArray", "type":typ}
           },
       peg$c255 = "|[",
       peg$c256 = peg$literalExpectation("|[", false),
       peg$c257 = "]|",
       peg$c258 = peg$literalExpectation("]|", false),
       peg$c259 = function(typ) {
-            return {"op":"TypeSet", "type":typ}
+            return {"kind":"TypeSet", "type":typ}
           },
       peg$c260 = "|{",
       peg$c261 = peg$literalExpectation("|{", false),
       peg$c262 = "}|",
       peg$c263 = peg$literalExpectation("}|", false),
       peg$c264 = function(keyType, valType) {
-            return {"op":"TypeMap", "key_type":keyType, "val_type": valType}
+            return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
       peg$c265 = "uint8",
       peg$c266 = peg$literalExpectation("uint8", false),
@@ -732,7 +732,7 @@ function peg$parse(input, options) {
       peg$c285 = "string",
       peg$c286 = peg$literalExpectation("string", false),
       peg$c287 = function() {
-                return {"op": "TypePrimitive", "name": text()}
+                return {"kind": "TypePrimitive", "name": text()}
               },
       peg$c288 = "duration",
       peg$c289 = peg$literalExpectation("duration", false),
@@ -768,7 +768,7 @@ function peg$parse(input, options) {
       peg$c317 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
       peg$c318 = /^[0-9]/,
       peg$c319 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c320 = function(id) { return {"op": "Id", "name": id} },
+      peg$c320 = function(id) { return {"kind": "Id", "name": id} },
       peg$c321 = function() {  return text() },
       peg$c322 = "$",
       peg$c323 = peg$literalExpectation("$", false),
@@ -4813,7 +4813,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    s1 = peg$parseJoinKind();
+    s1 = peg$parseJoinStyle();
     if (s1 !== peg$FAILED) {
       if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
         s2 = input.substr(peg$currPos, 4);
@@ -4901,7 +4901,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseJoinKind();
+      s1 = peg$parseJoinStyle();
       if (s1 !== peg$FAILED) {
         if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
           s2 = input.substr(peg$currPos, 4);
@@ -4962,7 +4962,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseJoinKind() {
+  function peg$parseJoinStyle() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
@@ -11251,7 +11251,7 @@ function peg$parse(input, options) {
   function makeBinaryExprChain(first, rest) {
     let ret = first
     for (let part of rest) {
-      ret = { op: "BinaryExpr", kind: part[0], lhs: ret, rhs: part[1] };
+      ret = { kind: "BinaryExpr", op: part[0], lhs: ret, rhs: part[1] };
     }
     return ret
   }

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -57,7 +57,7 @@ Z // = !(Operator / Aggregation / "(") op:Operation &EOF { RETURN(op) }
       FOREACH(ASSERT_ARRAY(rest), p) {
         APPEND(procs, p)
       }
-      RETURN(MAP("op": "Sequential", "procs": procs))
+      RETURN(MAP("kind": "Sequential", "procs": procs))
     }
   / Sequential
 
@@ -65,18 +65,18 @@ Const = __ v:AnyConst { RETURN(v) }
 
 AnyConst
   = "const" _ id:IdentifierName __ "=" __ expr:Expr ( __ ";" / EOL ) {
-      RETURN(MAP("op":"Const","name":id, "expr":expr))
+      RETURN(MAP("kind":"Const","name":id, "expr":expr))
     }
   / "type" _ id:IdentifierName __ "=" __ typ:Type ( __ ";" / EOL ) {
-      RETURN(MAP("op":"TypeProc","name":id, "type":typ))
+      RETURN(MAP("kind":"TypeProc","name":id, "type":typ))
     }
 
 Sequential
   = first:Operation rest:SequentialTail+ {
-      RETURN(MAP("op": "Sequential", "procs": PREPEND(first, rest)))
+      RETURN(MAP("kind": "Sequential", "procs": PREPEND(first, rest)))
     }
   / op:Operation {
-      RETURN(MAP("op": "Sequential", "procs": ARRAY(op)))
+      RETURN(MAP("kind": "Sequential", "procs": ARRAY(op)))
     }
 
 SequentialTail = __ "|" __ p:Operation { RETURN(p) }
@@ -97,7 +97,7 @@ SwitchBranch
       RETURN(MAP("expr": e, "proc": proc))
     }
   / __ DefaultToken __ "=>" __ proc:Sequential {
-      RETURN(MAP("expr": MAP("op": "Literal", "type": "bool", "value": "true"), "proc": proc))
+      RETURN(MAP("expr": MAP("kind": "Literal", "type": "bool", "value": "true"), "proc": proc))
     }
 
 Switch
@@ -113,16 +113,16 @@ DefaultToken = "default"i
 
 Operation
   = "split" __ "(" __ "=>" __ procArray:Parallel __ ")" {
-      RETURN(MAP("op": "Parallel", "procs": procArray))
+      RETURN(MAP("kind": "Parallel", "procs": procArray))
     }
   / "switch" __ "(" __ caseArray:Switch __ ")" {
-      RETURN(MAP("op": "Switch", "cases": caseArray))
+      RETURN(MAP("kind": "Switch", "cases": caseArray))
     }
   / Operator
   / f:Function &EndOfOp { RETURN(f) }
   / a:Aggregation &EndOfOp  { RETURN(a) }
   / expr:SearchBoolean !AggGuard {
-      RETURN(MAP("op": "Filter", "expr": expr))
+      RETURN(MAP("kind": "Filter", "expr": expr))
     }
 
 EndOfOp = __ ("|" / "=>" / ")" / EOF)
@@ -146,7 +146,7 @@ SearchAnd
 
 SearchFactor
   = (NotToken _ / "!" __) e:SearchFactor {
-      RETURN(MAP("op": "UnaryExpr", "kind": "!", "operand": e))
+      RETURN(MAP("kind": "UnaryExpr", "op": "!", "operand": e))
     }
   / ShortCut
   / SearchExpr
@@ -154,48 +154,48 @@ SearchFactor
 
 ShortCut
   = "*" __ compareOp:EqualityToken __ v:SearchValue {
-      RETURN(MAP("op": "Call", "name": "or",
+      RETURN(MAP("kind": "Call", "name": "or",
         "args": ARRAY(
-          MAP("op": "SelectExpr",
-              "selectors": ARRAY(MAP("op": "Root")),
+          MAP("kind": "SelectExpr",
+              "selectors": ARRAY(MAP("kind": "Root")),
               "methods": ARRAY(
-                MAP("op": "Call", "name": "map",
-                    "args": ARRAY(MAP("op": "BinaryExpr", "kind": "=",
-                                      "lhs": MAP("op": "Id", "name": "$"),
+                MAP("kind": "Call", "name": "map",
+                    "args": ARRAY(MAP("kind": "BinaryExpr", "op": "=",
+                                      "lhs": MAP("kind": "Id", "name": "$"),
                                       "rhs": v))))))))
     }
   / f:Lval __ comp:EqualityToken __ v:GlobbySearchValue !ExprGuard {
-      RETURN(MAP("op": "BinaryExpr", "kind":comp, "lhs":f, "rhs":v))
+      RETURN(MAP("kind": "BinaryExpr", "op":comp, "lhs":f, "rhs":v))
     }
   / v:SearchValue _ InToken _ "*" {
-      RETURN(MAP("op": "Call", "name": "or",
+      RETURN(MAP("kind": "Call", "name": "or",
         "args": ARRAY(
-          MAP("op": "SelectExpr",
-              "selectors": ARRAY(MAP("op": "Root")),
+          MAP("kind": "SelectExpr",
+              "selectors": ARRAY(MAP("kind": "Root")),
               "methods": ARRAY(
-                MAP("op": "Call", "name": "map",
-                    "args": ARRAY(MAP("op": "BinaryExpr", "kind": "in",
-                                      "rhs": MAP("op": "Id", "name": "$"),
+                MAP("kind": "Call", "name": "map",
+                    "args": ARRAY(MAP("kind": "BinaryExpr", "op": "in",
+                                      "rhs": MAP("kind": "Id", "name": "$"),
                                       "lhs": v))))))))
     }
   / !(SearchGuard EOT) v:GlobbySearchValue !ExprGuard {
-      RETURN(MAP("op": "Search", "text": TEXT, "value": v))
+      RETURN(MAP("kind": "Search", "text": TEXT, "value": v))
     }
   / "*" !ExprGuard {
-      RETURN(MAP("op": "Literal", "type": "bool", "value": "true"))
+      RETURN(MAP("kind": "Literal", "type": "bool", "value": "true"))
     }
 
 SearchValue
   = Literal
   / v:KeyWord {
-      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "string", "value": v))
     }
 
 GlobbySearchValue
   = Literal
   / v:SearchGlob {
       VAR(str) = ASSERT_STRING(v)
-      VAR(literal) = MAP("op": "Literal", "type": "string", "value": v)
+      VAR(literal) = MAP("kind": "Literal", "type": "string", "value": v)
       if (reglob.IsGlobby(str)) {
         literal["type"] = "regexp"
         literal["value"] = reglob.Reglob(str)
@@ -250,7 +250,7 @@ SearchExprMul
 
 SearchExprCast
   = e:SearchExprFunc __ ":" __ typ:CastType {
-      RETURN(MAP("op": "Cast", "expr": e, "type": typ))
+      RETURN(MAP("kind": "Cast", "expr": e, "type": typ))
     }
   / SearchExprFunc
 
@@ -267,10 +267,10 @@ SearchExprFunc
 
 Aggregation
   = Summarize every:EveryDur keys:GroupByKeys limit:LimitArg {
-      RETURN(MAP("op": "Summarize", "keys": keys, "aggs": NULL, "duration": every, "limit": limit))
+      RETURN(MAP("kind": "Summarize", "keys": keys, "aggs": NULL, "duration": every, "limit": limit))
     }
   / Summarize every:EveryDur aggs:AggAssignments keys:(_ GroupByKeys)? limit:LimitArg {
-      VAR(p) = MAP("op": "Summarize", "keys": NULL, "aggs": aggs, "duration": every, "limit": limit)
+      VAR(p) = MAP("kind": "Summarize", "keys": NULL, "aggs": aggs, "duration": every, "limit": limit)
       if ISNOTNULL(keys) {
         p["keys"] = ASSERT_ARRAY(keys)[1]
       }
@@ -295,7 +295,7 @@ LimitArg
 // an expression like "count() by foo", the rhs is Field "foo" and the lhs is nil.
 FlexAssignment
   = Assignment
-  / expr:Expr { RETURN(MAP("op": "Assignment", "lhs": NULL, "rhs": expr)) }
+  / expr:Expr { RETURN(MAP("kind": "Assignment", "lhs": NULL, "rhs": expr)) }
 
 FlexAssignments
   = first:FlexAssignment rest:(__ "," __ expr:FlexAssignment { RETURN(expr) })* {
@@ -304,15 +304,15 @@ FlexAssignments
 
 AggAssignment
   = lval:Lval __ "=" __ agg:Agg {
-      RETURN(MAP("op": "Assignment", "lhs": lval, "rhs": agg))
+      RETURN(MAP("kind": "Assignment", "lhs": lval, "rhs": agg))
     }
   / agg:Agg {
-      RETURN(MAP("op": "Assignment", "lhs": NULL, "rhs": agg))
+      RETURN(MAP("kind": "Assignment", "lhs": NULL, "rhs": agg))
     }
 
 Agg
   = !FuncGuard op:AggName __ "(" __ expr:Expr?  __ ")" !(__ ".") where:WhereClause? {
-      VAR(r) = MAP("op": "Agg", "name": op, "expr": NULL, "where":where)
+      VAR(r) = MAP("kind": "Agg", "name": op, "expr": NULL, "where":where)
       if ISNOTNULL(expr) {
         r["expr"] = expr
       }
@@ -355,7 +355,7 @@ Operator
 SortProc
   = "sort"i args:SortArgs list:(_ l:Exprs { RETURN(l) })? {
       VAR(argm) = ASSERT_MAP(args)
-      VAR(proc) = MAP("op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false)
+      VAR(proc) = MAP("kind": "Sort", "args": list, "sortdir": 1, "nullsfirst": false)
       if HAS(argm, "r") {
         proc["sortdir"] = -1
       }
@@ -375,7 +375,7 @@ SortArg
 
 TopProc
   = "top"i limit:(_ n:UInt { RETURN(n)})? flush:(_ "-flush")? fields:(_ f:FieldExprs { RETURN(f) })? {
-      VAR(proc) = MAP("op": "Top", "limit": 0, "args": NULL, "flush": false)
+      VAR(proc) = MAP("kind": "Top", "limit": 0, "args": NULL, "flush": false)
       if ISNOTNULL(limit) {
         proc["limit"] = limit
       }
@@ -390,26 +390,26 @@ TopProc
 
 CutProc
   = "cut"i _ args:FlexAssignments {
-      RETURN(MAP("op": "Cut", "args": args))
+      RETURN(MAP("kind": "Cut", "args": args))
     }
 
 PickProc
   = "pick"i _ args:FlexAssignments {
-      RETURN(MAP("op": "Pick", "args": args))
+      RETURN(MAP("kind": "Pick", "args": args))
     }
 
 DropProc
   = "drop"i _ args:FieldExprs {
-      RETURN(MAP("op": "Drop", "args": args))
+      RETURN(MAP("kind": "Drop", "args": args))
     }
 
 HeadProc
-  = "head"i _ count:UInt { RETURN(MAP("op": "Head", "count": count)) }
-  / "head"i { RETURN(MAP("op": "Head", "count": 1)) }
+  = "head"i _ count:UInt { RETURN(MAP("kind": "Head", "count": count)) }
+  / "head"i { RETURN(MAP("kind": "Head", "count": 1)) }
 
 TailProc
-  = "tail"i _ count:UInt { RETURN(MAP("op": "Tail", "count": count)) }
-  / "tail"i { RETURN(MAP("op": "Tail", "count": 1)) }
+  = "tail"i _ count:UInt { RETURN(MAP("kind": "Tail", "count": count)) }
+  / "tail"i { RETURN(MAP("kind": "Tail", "count": 1)) }
 
 FilterProc
   = "filter"i _ op:Filter {
@@ -418,25 +418,25 @@ FilterProc
 
 Filter
   = expr:SearchBoolean {
-      RETURN(MAP("op": "Filter", "expr": expr))
+      RETURN(MAP("kind": "Filter", "expr": expr))
     }
 
 UniqProc
   = "uniq"i _ "-c" {
-      RETURN(MAP("op": "Uniq", "cflag": true))
+      RETURN(MAP("kind": "Uniq", "cflag": true))
     }
   / "uniq"i {
-      RETURN(MAP("op": "Uniq", "cflag": false))
+      RETURN(MAP("kind": "Uniq", "cflag": false))
     }
 
 PutProc
   = "put"i _ args:FlexAssignments {
-      RETURN(MAP("op": "Put", "args": args))
+      RETURN(MAP("kind": "Put", "args": args))
     }
 
 RenameProc
   = "rename"i _ first:Assignment rest:(__ "," __ cl:Assignment { RETURN(cl) })* {
-      RETURN(MAP("op": "Rename", "args": PREPEND(first, rest)))
+      RETURN(MAP("kind": "Rename", "args": PREPEND(first, rest)))
     }
 
 // The paren guard is to allow parsing fuse() as an aggregator. This
@@ -445,31 +445,31 @@ RenameProc
 // aggregator, at which point we may no longer need this.
 FuseProc
   = "fuse"i !(__ "(") {
-      RETURN(MAP("op": "Fuse"))
+      RETURN(MAP("kind": "Fuse"))
     }
 
 ShapeProc
   = "shape"i {
-      RETURN(MAP("op": "Shape"))
+      RETURN(MAP("kind": "Shape"))
     }
 
 JoinProc
-  = kind:JoinKind "join"i _ leftKey:JoinKey __ "=" __ rightKey:JoinKey columns:(_ FlexAssignments)? {
-      VAR(proc) = MAP("op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": NULL)
+  = style:JoinStyle "join"i _ leftKey:JoinKey __ "=" __ rightKey:JoinKey columns:(_ FlexAssignments)? {
+      VAR(proc) = MAP("kind": "Join", "style": style, "left_key": leftKey, "right_key": rightKey, "args": NULL)
       if ISNOTNULL(columns) {
         proc["args"] = ASSERT_ARRAY(columns)[1]
       }
       RETURN(proc)
     }
-  / kind:JoinKind  "join"i _ key:JoinKey columns:(_ FlexAssignments)? {
-      VAR(proc) = MAP("op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": NULL)
+  / style:JoinStyle  "join"i _ key:JoinKey columns:(_ FlexAssignments)? {
+      VAR(proc) = MAP("kind": "Join", "style": style, "left_key": key, "right_key": key, "args": NULL)
       if ISNOTNULL(columns) {
         proc["args"] = ASSERT_ARRAY(columns)[1]
       }
       RETURN(proc)
     }
 
-JoinKind
+JoinStyle
   = "inner"i _ { RETURN("inner") }
   / "left"i  _ { RETURN("left") }
   / "right"i _ { RETURN("right") }
@@ -481,28 +481,28 @@ JoinKey
 
 TasteProc
   = "taste"i e:TasteExpr {
-      RETURN(MAP("op": "Sequential", "procs": ARRAY(
-        MAP("op": "Summarize",
-          "keys": ARRAY(MAP("op": "Assignment",
-                   "lhs": MAP("op": "Id", "name": "shape"),
-                   "rhs": MAP("op": "Call", "name": "typeof",
+      RETURN(MAP("kind": "Sequential", "procs": ARRAY(
+        MAP("kind": "Summarize",
+          "keys": ARRAY(MAP("kind": "Assignment",
+                   "lhs": MAP("kind": "Id", "name": "shape"),
+                   "rhs": MAP("kind": "Call", "name": "typeof",
                               "args": ARRAY(e)))),
-          "aggs": ARRAY(MAP("op": "Assignment",
-                              "lhs": MAP("op": "Id", "name": "taste"),
-                              "rhs": MAP("op": "Agg",
+          "aggs": ARRAY(MAP("kind": "Assignment",
+                              "lhs": MAP("kind": "Id", "name": "taste"),
+                              "rhs": MAP("kind": "Agg",
                                          "name": "any",
                                          "expr": e,
                                          "where": NULL))),
           "duration": NULL, "limit": 0),
-        MAP("op": "Cut",
-            "args": ARRAY(MAP("op": "Assignment",
+        MAP("kind": "Cut",
+            "args": ARRAY(MAP("kind": "Assignment",
                                 "lhs": NULL,
-                                "rhs": MAP("op": "Id", "name": "taste")))))))
+                                "rhs": MAP("kind": "Id", "name": "taste")))))))
     }
 
 TasteExpr
   = _ lval:Lval { RETURN(lval)}
-  / "" { RETURN(MAP("op":"Root")) }
+  / "" { RETURN(MAP("kind":"Root")) }
 
 Lval = DerefExpr
 
@@ -531,13 +531,13 @@ Exprs
     }
 
 Assignment
-  = lhs:Lval __ "=" __ rhs:Expr { RETURN(MAP("op": "Assignment", "lhs": lhs, "rhs": rhs)) }
+  = lhs:Lval __ "=" __ rhs:Expr { RETURN(MAP("kind": "Assignment", "lhs": lhs, "rhs": rhs)) }
 
 Expr = ConditionalExpr
 
 ConditionalExpr
   = condition:LogicalOrExpr __ "?" __ thenClause:Expr __ ":" __ elseClause:Expr {
-      RETURN(MAP("op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause))
+      RETURN(MAP("kind": "Conditional", "cond": condition, "then": thenClause, "else": elseClause))
     }
   / LogicalOrExpr
 
@@ -592,13 +592,13 @@ MultiplicativeOperator = ("*" / "/") { RETURN(TEXT) }
 
 NotExpr
   = "!" __ e:NotExpr {
-        RETURN(MAP("op": "UnaryExpr", "kind": "!", "operand": e))
+        RETURN(MAP("kind": "UnaryExpr", "op": "!", "operand": e))
     }
   / CastExpr
 
 CastExpr
   = e:FuncExpr __ ":" __ typ:CastType {
-      RETURN(MAP("op": "Cast", "expr": e, "type": typ))
+      RETURN(MAP("kind": "Cast", "expr": e, "type": typ))
     }
   / FuncExpr
 
@@ -625,7 +625,7 @@ MatchExpr
 
 SelectExpr
   = "select" __ "(" __ args:ArgumentList __ ")" methods:Methods {
-      RETURN(MAP("op":"SelectExpr", "selectors":args, "methods": methods))
+      RETURN(MAP("kind":"SelectExpr", "selectors":args, "methods": methods))
     }
 
 // Note that this is written this way instead of using Method* above since
@@ -641,7 +641,7 @@ Method
 
 Function
   = !FuncGuard fn:IdentifierName __ "(" __ args:ArgumentList __ ")" {
-      RETURN(MAP("op": "Call", "name": fn, "args": args))
+      RETURN(MAP("kind": "Call", "name": fn, "args": args))
     }
 
 ArgumentList
@@ -658,32 +658,32 @@ DerefExpr
       RETURN(makeBinaryExprChain(first, rest))
     }
   / "." {
-      RETURN(MAP("op":"Root"))
+      RETURN(MAP("kind":"Root"))
     }
 
 DotId
   = "." field:Identifier {
-      RETURN(MAP("op": "BinaryExpr", "kind":".",
-                     "lhs":MAP("op":"Root"),
+      RETURN(MAP("kind": "BinaryExpr", "op":".",
+                     "lhs":MAP("kind":"Root"),
                      "rhs":field))
     }
   / "." "[" expr:Expr "]" {
-      RETURN(MAP("op": "BinaryExpr", "kind":"[",
-                     "lhs":MAP("op":"Root"),
+      RETURN(MAP("kind": "BinaryExpr", "op":"[",
+                     "lhs":MAP("kind":"Root"),
                      "rhs":expr))
     }
 
 Deref
   = "[" from:AdditiveExpr __ ":" __ to:AdditiveExpr "]" {
-      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "kind":":",
+      RETURN(ARRAY("[", MAP("kind": "BinaryExpr", "op":":",
                             "lhs":from, "rhs":to)))
     }
   / "[" __ ":" __ to:AdditiveExpr "]" {
-      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "kind":":",
+      RETURN(ARRAY("[", MAP("kind": "BinaryExpr", "op":":",
                             "lhs": NULL, "rhs":to)))
     }
   / "[" from:AdditiveExpr __ ":" __ "]" {
-      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "kind":":",
+      RETURN(ARRAY("[", MAP("kind": "BinaryExpr", "op":":",
                             "lhs":from, "rhs": NULL)))
     }
   / "[" expr:Expr "]" { RETURN(ARRAY("[", expr)) }
@@ -706,50 +706,50 @@ Literal
 
 StringLiteral
   = v:QuotedString {
-      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "string", "value": v))
     }
 
 RegexpLiteral
   = v:Regexp !KeyWordStart {
-      RETURN(MAP("op": "Literal", "type": "regexp", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "regexp", "value": v))
     }
 
 SubnetLiteral
   = v:IP6Net !IdentifierRest {
-      RETURN(MAP("op": "Literal", "type": "net", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "net", "value": v))
     }
   / v:IP4Net {
-      RETURN(MAP("op": "Literal", "type": "net", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "net", "value": v))
     }
 
 AddressLiteral
   = v:IP6 !IdentifierRest {
-      RETURN(MAP("op": "Literal", "type": "ip", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "ip", "value": v))
     }
   / v:IP {
-      RETURN(MAP("op": "Literal", "type": "ip", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "ip", "value": v))
     }
 
 FloatLiteral
   = v:FloatString {
-      RETURN(MAP("op": "Literal", "type": "float64", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "float64", "value": v))
     }
 
 IntegerLiteral
   = v:IntString {
-      RETURN(MAP("op": "Literal", "type": "int64", "value": v))
+      RETURN(MAP("kind": "Literal", "type": "int64", "value": v))
     }
 
 BooleanLiteral
-  = "true"           { RETURN(MAP("op": "Literal", "type": "bool", "value": "true")) }
-  / "false"          { RETURN(MAP("op": "Literal", "type": "bool", "value": "false")) }
+  = "true"           { RETURN(MAP("kind": "Literal", "type": "bool", "value": "true")) }
+  / "false"          { RETURN(MAP("kind": "Literal", "type": "bool", "value": "false")) }
 
 NullLiteral
-  = "null"           { RETURN(MAP("op": "Literal", "type": "null", "value": "")) }
+  = "null"           { RETURN(MAP("kind": "Literal", "type": "null", "value": "")) }
 
 TypeLiteral
   = typ:TypeExternal {
-      RETURN(MAP("op": "TypeValue", "value": typ))
+      RETURN(MAP("kind": "TypeValue", "value": typ))
     }
 
 CastType
@@ -768,20 +768,20 @@ Type
 
 AmbiguousType
   = "null" {
-      RETURN(MAP("op": "TypeNull"))
+      RETURN(MAP("kind": "TypeNull"))
     }
   / name:PrimitiveType
   / name:IdentifierName __ '=' __ "(" __ typ:Type __ ")" {
-      RETURN(MAP("op": "TypeDef", "name": name, "type": typ))
+      RETURN(MAP("kind": "TypeDef", "name": name, "type": typ))
   }
   / name:IdentifierName {
-      RETURN(MAP("op": "TypeName", "name": name))
+      RETURN(MAP("kind": "TypeName", "name": name))
     }
   / "(" __ u:TypeUnion  ")" { RETURN(u) }
 
 TypeUnion
   = types:TypeList {
-      RETURN(MAP("op": "TypeUnion", "types": types))
+      RETURN(MAP("kind": "TypeUnion", "types": types))
     }
 
 TypeList
@@ -793,16 +793,16 @@ TypeListTail = __ "," __ typ:Type { RETURN(typ) }
 
 ComplexType
   = "{" __ fields:TypeFieldList __ "}" {
-      RETURN(MAP("op":"TypeRecord", "fields":fields))
+      RETURN(MAP("kind":"TypeRecord", "fields":fields))
     }
   / "[" __ typ:Type __ "]" {
-      RETURN(MAP("op":"TypeArray", "type":typ))
+      RETURN(MAP("kind":"TypeArray", "type":typ))
     }
   / "|[" __ typ:Type __ "]|" {
-      RETURN(MAP("op":"TypeSet", "type":typ))
+      RETURN(MAP("kind":"TypeSet", "type":typ))
     }
   / "|{" __ keyType:Type __ "," __ valType:Type __ "}|" {
-      RETURN(MAP("op":"TypeMap", "key_type":keyType, "val_type": valType))
+      RETURN(MAP("kind":"TypeMap", "key_type":keyType, "val_type": valType))
     }
 
 PrimitiveType
@@ -818,7 +818,7 @@ PrimitiveTypeExternal
       / "int8" / "int16" / "int32" / "int64"
       / "float64"
       / "bool" / "string" ) {
-          RETURN(MAP("op": "TypePrimitive", "name": TEXT))
+          RETURN(MAP("kind": "TypePrimitive", "name": TEXT))
         }
 
 // Internal types must be enclosed in a type() operator when appearing in an
@@ -832,7 +832,7 @@ PrimitiveTypeInternal
       / "bstring"
       / "ip" / "net"
       / "type" / "error" ) {
-          RETURN(MAP("op": "TypePrimitive", "name": TEXT))
+          RETURN(MAP("kind": "TypePrimitive", "name": TEXT))
         }
 
 TypeFieldList
@@ -865,7 +865,7 @@ IdentifierStart = [A-Za-z_$]
 IdentifierRest = IdentifierStart / [0-9]
 
 Identifier
-  = id:IdentifierName { RETURN(MAP("op": "Id", "name": id)) }
+  = id:IdentifierName { RETURN(MAP("kind": "Id", "name": id)) }
 
 IdentifierName
   = !(IdGuard !IdentifierRest) IdentifierStart IdentifierRest* {  RETURN(TEXT) }

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -57,7 +57,7 @@ Z // = !(Operator / Aggregation / "(") op:Operation &EOF { RETURN(op) }
       FOREACH(ASSERT_ARRAY(rest), p) {
         APPEND(procs, p)
       }
-      RETURN(MAP("op": "SequentialProc", "procs": procs))
+      RETURN(MAP("op": "Sequential", "procs": procs))
     }
   / Sequential
 
@@ -65,7 +65,7 @@ Const = __ v:AnyConst { RETURN(v) }
 
 AnyConst
   = "const" _ id:IdentifierName __ "=" __ expr:Expr ( __ ";" / EOL ) {
-      RETURN(MAP("op":"ConstProc","name":id, "expr":expr))
+      RETURN(MAP("op":"Const","name":id, "expr":expr))
     }
   / "type" _ id:IdentifierName __ "=" __ typ:Type ( __ ";" / EOL ) {
       RETURN(MAP("op":"TypeProc","name":id, "type":typ))
@@ -73,10 +73,10 @@ AnyConst
 
 Sequential
   = first:Operation rest:SequentialTail+ {
-      RETURN(MAP("op": "SequentialProc", "procs": PREPEND(first, rest)))
+      RETURN(MAP("op": "Sequential", "procs": PREPEND(first, rest)))
     }
   / op:Operation {
-      RETURN(MAP("op": "SequentialProc", "procs": ARRAY(op)))
+      RETURN(MAP("op": "Sequential", "procs": ARRAY(op)))
     }
 
 SequentialTail = __ "|" __ p:Operation { RETURN(p) }
@@ -93,11 +93,11 @@ ParallelTail
   = __ "=>" __ ch:Sequential { RETURN(ch) }
 
 SwitchBranch
-  = __ CaseToken _ filter:SearchBoolean __ "=>" __ proc:Sequential {
-      RETURN(MAP("filter": filter, "proc": proc))
+  = __ CaseToken _ e:SearchBoolean __ "=>" __ proc:Sequential {
+      RETURN(MAP("expr": e, "proc": proc))
     }
   / __ DefaultToken __ "=>" __ proc:Sequential {
-      RETURN(MAP("filter": MAP("op": "Literal", "type": "bool", "value": "true"), "proc": proc))
+      RETURN(MAP("expr": MAP("op": "Literal", "type": "bool", "value": "true"), "proc": proc))
     }
 
 Switch
@@ -113,16 +113,16 @@ DefaultToken = "default"i
 
 Operation
   = "split" __ "(" __ "=>" __ procArray:Parallel __ ")" {
-      RETURN(MAP("op": "ParallelProc", "procs": procArray))
+      RETURN(MAP("op": "Parallel", "procs": procArray))
     }
   / "switch" __ "(" __ caseArray:Switch __ ")" {
-      RETURN(MAP("op": "SwitchProc", "cases": caseArray))
+      RETURN(MAP("op": "Switch", "cases": caseArray))
     }
   / Operator
   / f:Function &EndOfOp { RETURN(f) }
   / a:Aggregation &EndOfOp  { RETURN(a) }
   / expr:SearchBoolean !AggGuard {
-      RETURN(MAP("op": "FilterProc", "filter": expr))
+      RETURN(MAP("op": "Filter", "expr": expr))
     }
 
 EndOfOp = __ ("|" / "=>" / ")" / EOF)
@@ -146,7 +146,7 @@ SearchAnd
 
 SearchFactor
   = (NotToken _ / "!" __) e:SearchFactor {
-      RETURN(MAP("op": "UnaryExpr", "operator": "!", "operand": e))
+      RETURN(MAP("op": "UnaryExpr", "kind": "!", "operand": e))
     }
   / ShortCut
   / SearchExpr
@@ -154,28 +154,28 @@ SearchFactor
 
 ShortCut
   = "*" __ compareOp:EqualityToken __ v:SearchValue {
-      RETURN(MAP("op": "FunctionCall", "function": "or",
+      RETURN(MAP("op": "Call", "name": "or",
         "args": ARRAY(
           MAP("op": "SelectExpr",
-              "selectors": ARRAY(MAP("op": "RootRecord")),
+              "selectors": ARRAY(MAP("op": "Root")),
               "methods": ARRAY(
-                MAP("op": "FunctionCall", "function": "map",
-                    "args": ARRAY(MAP("op": "BinaryExpr", "operator": "=",
-                                      "lhs": MAP("op": "Identifier", "name": "$"),
+                MAP("op": "Call", "name": "map",
+                    "args": ARRAY(MAP("op": "BinaryExpr", "kind": "=",
+                                      "lhs": MAP("op": "Id", "name": "$"),
                                       "rhs": v))))))))
     }
   / f:Lval __ comp:EqualityToken __ v:GlobbySearchValue !ExprGuard {
-      RETURN(MAP("op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v))
+      RETURN(MAP("op": "BinaryExpr", "kind":comp, "lhs":f, "rhs":v))
     }
   / v:SearchValue _ InToken _ "*" {
-      RETURN(MAP("op": "FunctionCall", "function": "or",
+      RETURN(MAP("op": "Call", "name": "or",
         "args": ARRAY(
           MAP("op": "SelectExpr",
-              "selectors": ARRAY(MAP("op": "RootRecord")),
+              "selectors": ARRAY(MAP("op": "Root")),
               "methods": ARRAY(
-                MAP("op": "FunctionCall", "function": "map",
-                    "args": ARRAY(MAP("op": "BinaryExpr", "operator": "in",
-                                      "rhs": MAP("op": "Identifier", "name": "$"),
+                MAP("op": "Call", "name": "map",
+                    "args": ARRAY(MAP("op": "BinaryExpr", "kind": "in",
+                                      "rhs": MAP("op": "Id", "name": "$"),
                                       "lhs": v))))))))
     }
   / !(SearchGuard EOT) v:GlobbySearchValue !ExprGuard {
@@ -250,7 +250,7 @@ SearchExprMul
 
 SearchExprCast
   = e:SearchExprFunc __ ":" __ typ:CastType {
-      RETURN(MAP("op": "CastExpr", "expr": e, "type": typ))
+      RETURN(MAP("op": "Cast", "expr": e, "type": typ))
     }
   / SearchExprFunc
 
@@ -267,10 +267,10 @@ SearchExprFunc
 
 Aggregation
   = Summarize every:EveryDur keys:GroupByKeys limit:LimitArg {
-      RETURN(MAP("op": "GroupByProc", "keys": keys, "reducers": NULL, "duration": every, "limit": limit))
+      RETURN(MAP("op": "Summarize", "keys": keys, "aggs": NULL, "duration": every, "limit": limit))
     }
-  / Summarize every:EveryDur reducers:Reducers keys:(_ GroupByKeys)? limit:LimitArg {
-      VAR(p) = MAP("op": "GroupByProc", "keys": NULL, "reducers": reducers, "duration": every, "limit": limit)
+  / Summarize every:EveryDur aggs:AggAssignments keys:(_ GroupByKeys)? limit:LimitArg {
+      VAR(p) = MAP("op": "Summarize", "keys": NULL, "aggs": aggs, "duration": every, "limit": limit)
       if ISNOTNULL(keys) {
         p["keys"] = ASSERT_ARRAY(keys)[1]
       }
@@ -302,32 +302,32 @@ FlexAssignments
       RETURN(PREPEND(first, rest))
     }
 
-ReducerAssignment
-  = lval:Lval __ "=" __ reducer:Reducer {
-      RETURN(MAP("op": "Assignment", "lhs": lval, "rhs": reducer))
+AggAssignment
+  = lval:Lval __ "=" __ agg:Agg {
+      RETURN(MAP("op": "Assignment", "lhs": lval, "rhs": agg))
     }
-  / reducer:Reducer {
-      RETURN(MAP("op": "Assignment", "lhs": NULL, "rhs": reducer))
+  / agg:Agg {
+      RETURN(MAP("op": "Assignment", "lhs": NULL, "rhs": agg))
     }
 
-Reducer
-  = !FuncGuard op:ReducerName __ "(" __ expr:Expr?  __ ")" !(__ ".") where:WhereClause? {
-      VAR(r) = MAP("op": "Reducer", "operator": op, "expr": NULL, "where":where)
+Agg
+  = !FuncGuard op:AggName __ "(" __ expr:Expr?  __ ")" !(__ ".") where:WhereClause? {
+      VAR(r) = MAP("op": "Agg", "name": op, "expr": NULL, "where":where)
       if ISNOTNULL(expr) {
         r["expr"] = expr
       }
       RETURN(r)
     }
 
-ReducerName
+AggName
   = IdentifierName
   / AndToken
   / OrToken
 
 WhereClause = _ "where" _ expr:SearchBoolean { RETURN(expr) }
 
-Reducers
-  = first:ReducerAssignment rest:(__ "," __ ReducerAssignment)* {
+AggAssignments
+  = first:AggAssignment rest:(__ "," __ AggAssignment)* {
       VAR(result) = ARRAY(first)
       FOREACH(ASSERT_ARRAY(rest), r) {
         APPEND(result, ASSERT_ARRAY(r)[3])
@@ -355,7 +355,7 @@ Operator
 SortProc
   = "sort"i args:SortArgs list:(_ l:Exprs { RETURN(l) })? {
       VAR(argm) = ASSERT_MAP(args)
-      VAR(proc) = MAP("op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false)
+      VAR(proc) = MAP("op": "Sort", "args": list, "sortdir": 1, "nullsfirst": false)
       if HAS(argm, "r") {
         proc["sortdir"] = -1
       }
@@ -375,12 +375,12 @@ SortArg
 
 TopProc
   = "top"i limit:(_ n:UInt { RETURN(n)})? flush:(_ "-flush")? fields:(_ f:FieldExprs { RETURN(f) })? {
-      VAR(proc) = MAP("op": "TopProc", "limit": 0, "fields": NULL, "flush": false)
+      VAR(proc) = MAP("op": "Top", "limit": 0, "args": NULL, "flush": false)
       if ISNOTNULL(limit) {
         proc["limit"] = limit
       }
       if ISNOTNULL(fields) {
-        proc["fields"] = fields
+        proc["args"] = fields
       }
       if ISNOTNULL(flush) {
         proc["flush"] = true
@@ -389,27 +389,27 @@ TopProc
     }
 
 CutProc
-  = "cut"i _ columns:FlexAssignments {
-      RETURN(MAP("op": "CutProc", "fields": columns))
+  = "cut"i _ args:FlexAssignments {
+      RETURN(MAP("op": "Cut", "args": args))
     }
 
 PickProc
-  = "pick"i _ columns:FlexAssignments {
-      RETURN(MAP("op": "PickProc", "fields": columns))
+  = "pick"i _ args:FlexAssignments {
+      RETURN(MAP("op": "Pick", "args": args))
     }
 
 DropProc
-  = "drop"i _ columns:FieldExprs {
-      RETURN(MAP("op": "DropProc", "fields": columns))
+  = "drop"i _ args:FieldExprs {
+      RETURN(MAP("op": "Drop", "args": args))
     }
 
 HeadProc
-  = "head"i _ count:UInt { RETURN(MAP("op": "HeadProc", "count": count)) }
-  / "head"i { RETURN(MAP("op": "HeadProc", "count": 1)) }
+  = "head"i _ count:UInt { RETURN(MAP("op": "Head", "count": count)) }
+  / "head"i { RETURN(MAP("op": "Head", "count": 1)) }
 
 TailProc
-  = "tail"i _ count:UInt { RETURN(MAP("op": "TailProc", "count": count)) }
-  / "tail"i { RETURN(MAP("op": "TailProc", "count": 1)) }
+  = "tail"i _ count:UInt { RETURN(MAP("op": "Tail", "count": count)) }
+  / "tail"i { RETURN(MAP("op": "Tail", "count": 1)) }
 
 FilterProc
   = "filter"i _ op:Filter {
@@ -418,25 +418,25 @@ FilterProc
 
 Filter
   = expr:SearchBoolean {
-      RETURN(MAP("op": "FilterProc", "filter": expr))
+      RETURN(MAP("op": "Filter", "expr": expr))
     }
 
 UniqProc
   = "uniq"i _ "-c" {
-      RETURN(MAP("op": "UniqProc", "cflag": true))
+      RETURN(MAP("op": "Uniq", "cflag": true))
     }
   / "uniq"i {
-      RETURN(MAP("op": "UniqProc", "cflag": false))
+      RETURN(MAP("op": "Uniq", "cflag": false))
     }
 
 PutProc
-  = "put"i _ columns:FlexAssignments {
-      RETURN(MAP("op": "PutProc", "clauses": columns))
+  = "put"i _ args:FlexAssignments {
+      RETURN(MAP("op": "Put", "args": args))
     }
 
 RenameProc
   = "rename"i _ first:Assignment rest:(__ "," __ cl:Assignment { RETURN(cl) })* {
-      RETURN(MAP("op": "RenameProc", "fields": PREPEND(first, rest)))
+      RETURN(MAP("op": "Rename", "args": PREPEND(first, rest)))
     }
 
 // The paren guard is to allow parsing fuse() as an aggregator. This
@@ -445,26 +445,26 @@ RenameProc
 // aggregator, at which point we may no longer need this.
 FuseProc
   = "fuse"i !(__ "(") {
-      RETURN(MAP("op": "FuseProc"))
+      RETURN(MAP("op": "Fuse"))
     }
 
 ShapeProc
   = "shape"i {
-      RETURN(MAP("op": "ShapeProc"))
+      RETURN(MAP("op": "Shape"))
     }
 
 JoinProc
   = kind:JoinKind "join"i _ leftKey:JoinKey __ "=" __ rightKey:JoinKey columns:(_ FlexAssignments)? {
-      VAR(proc) = MAP("op": "JoinProc", "kind": kind, "left_key": leftKey, "right_key": rightKey, "clauses": NULL)
+      VAR(proc) = MAP("op": "Join", "kind": kind, "left_key": leftKey, "right_key": rightKey, "args": NULL)
       if ISNOTNULL(columns) {
-        proc["clauses"] = ASSERT_ARRAY(columns)[1]
+        proc["args"] = ASSERT_ARRAY(columns)[1]
       }
       RETURN(proc)
     }
   / kind:JoinKind  "join"i _ key:JoinKey columns:(_ FlexAssignments)? {
-      VAR(proc) = MAP("op": "JoinProc", "kind": kind, "left_key": key, "right_key": key, "clauses": NULL)
+      VAR(proc) = MAP("op": "Join", "kind": kind, "left_key": key, "right_key": key, "args": NULL)
       if ISNOTNULL(columns) {
-        proc["clauses"] = ASSERT_ARRAY(columns)[1]
+        proc["args"] = ASSERT_ARRAY(columns)[1]
       }
       RETURN(proc)
     }
@@ -481,28 +481,28 @@ JoinKey
 
 TasteProc
   = "taste"i e:TasteExpr {
-      RETURN(MAP("op": "SequentialProc", "procs": ARRAY(
-        MAP("op": "GroupByProc",
+      RETURN(MAP("op": "Sequential", "procs": ARRAY(
+        MAP("op": "Summarize",
           "keys": ARRAY(MAP("op": "Assignment",
-                   "lhs": MAP("op": "Identifier", "name": "shape"),
-                   "rhs": MAP("op": "FunctionCall", "function": "typeof",
+                   "lhs": MAP("op": "Id", "name": "shape"),
+                   "rhs": MAP("op": "Call", "name": "typeof",
                               "args": ARRAY(e)))),
-          "reducers": ARRAY(MAP("op": "Assignment",
-                              "lhs": MAP("op": "Identifier", "name": "taste"),
-                              "rhs": MAP("op": "Reducer",
-                                         "operator": "any",
+          "aggs": ARRAY(MAP("op": "Assignment",
+                              "lhs": MAP("op": "Id", "name": "taste"),
+                              "rhs": MAP("op": "Agg",
+                                         "name": "any",
                                          "expr": e,
                                          "where": NULL))),
           "duration": NULL, "limit": 0),
-        MAP("op": "CutProc",
-            "fields": ARRAY(MAP("op": "Assignment",
+        MAP("op": "Cut",
+            "args": ARRAY(MAP("op": "Assignment",
                                 "lhs": NULL,
-                                "rhs": MAP("op": "Identifier", "name": "taste")))))))
+                                "rhs": MAP("op": "Id", "name": "taste")))))))
     }
 
 TasteExpr
   = _ lval:Lval { RETURN(lval)}
-  / "" { RETURN(MAP("op":"RootRecord")) }
+  / "" { RETURN(MAP("op":"Root")) }
 
 Lval = DerefExpr
 
@@ -537,7 +537,7 @@ Expr = ConditionalExpr
 
 ConditionalExpr
   = condition:LogicalOrExpr __ "?" __ thenClause:Expr __ ":" __ elseClause:Expr {
-      RETURN(MAP("op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause))
+      RETURN(MAP("op": "Conditional", "cond": condition, "then": thenClause, "else": elseClause))
     }
   / LogicalOrExpr
 
@@ -592,13 +592,13 @@ MultiplicativeOperator = ("*" / "/") { RETURN(TEXT) }
 
 NotExpr
   = "!" __ e:NotExpr {
-        RETURN(MAP("op": "UnaryExpr", "operator": "!", "operand": e))
+        RETURN(MAP("op": "UnaryExpr", "kind": "!", "operand": e))
     }
   / CastExpr
 
 CastExpr
   = e:FuncExpr __ ":" __ typ:CastType {
-      RETURN(MAP("op": "CastExpr", "expr": e, "type": typ))
+      RETURN(MAP("op": "Cast", "expr": e, "type": typ))
     }
   / FuncExpr
 
@@ -641,7 +641,7 @@ Method
 
 Function
   = !FuncGuard fn:IdentifierName __ "(" __ args:ArgumentList __ ")" {
-      RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
+      RETURN(MAP("op": "Call", "name": fn, "args": args))
     }
 
 ArgumentList
@@ -658,32 +658,32 @@ DerefExpr
       RETURN(makeBinaryExprChain(first, rest))
     }
   / "." {
-      RETURN(MAP("op":"RootRecord"))
+      RETURN(MAP("op":"Root"))
     }
 
 DotId
   = "." field:Identifier {
-      RETURN(MAP("op": "BinaryExpr", "operator":".",
-                     "lhs":MAP("op":"RootRecord"),
+      RETURN(MAP("op": "BinaryExpr", "kind":".",
+                     "lhs":MAP("op":"Root"),
                      "rhs":field))
     }
   / "." "[" expr:Expr "]" {
-      RETURN(MAP("op": "BinaryExpr", "operator":"[",
-                     "lhs":MAP("op":"RootRecord"),
+      RETURN(MAP("op": "BinaryExpr", "kind":"[",
+                     "lhs":MAP("op":"Root"),
                      "rhs":expr))
     }
 
 Deref
   = "[" from:AdditiveExpr __ ":" __ to:AdditiveExpr "]" {
-      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "operator":":",
+      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "kind":":",
                             "lhs":from, "rhs":to)))
     }
   / "[" __ ":" __ to:AdditiveExpr "]" {
-      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "operator":":",
+      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "kind":":",
                             "lhs": NULL, "rhs":to)))
     }
   / "[" from:AdditiveExpr __ ":" __ "]" {
-      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "operator":":",
+      RETURN(ARRAY("[", MAP("op": "BinaryExpr", "kind":":",
                             "lhs":from, "rhs": NULL)))
     }
   / "[" expr:Expr "]" { RETURN(ARRAY("[", expr)) }
@@ -749,7 +749,7 @@ NullLiteral
 
 TypeLiteral
   = typ:TypeExternal {
-      RETURN(MAP("op": "TypeExpr", "type": typ))
+      RETURN(MAP("op": "TypeValue", "value": typ))
     }
 
 CastType
@@ -865,7 +865,7 @@ IdentifierStart = [A-Za-z_$]
 IdentifierRest = IdentifierStart / [0-9]
 
 Identifier
-  = id:IdentifierName { RETURN(MAP("op": "Identifier", "name": id)) }
+  = id:IdentifierName { RETURN(MAP("op": "Id", "name": id)) }
 
 IdentifierName
   = !(IdGuard !IdentifierRest) IdentifierStart IdentifierRest* {  RETURN(TEXT) }

--- a/zql/zql_test.go
+++ b/zql/zql_test.go
@@ -123,20 +123,20 @@ func parseString(in string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if seq, ok := tree.(*ast.SequentialProc); ok {
+	if seq, ok := tree.(*ast.Sequential); ok {
 		tree = seq.Procs[0]
 	}
-	filt, ok := tree.(*ast.FilterProc)
+	filt, ok := tree.(*ast.Filter)
 	if !ok {
-		return "", fmt.Errorf("Expected FilterProc got %T", tree)
+		return "", fmt.Errorf("Expected Filter proc got %T", tree)
 	}
-	comp, ok := filt.Filter.(*ast.BinaryExpression)
+	comp, ok := filt.Expr.(*ast.BinaryExpr)
 	if !ok {
-		return "", fmt.Errorf("Expected BinaryExpression got %T", filt.Filter)
+		return "", fmt.Errorf("Expected BinaryExpr got %T", filt.Expr)
 	}
 	literal, ok := comp.RHS.(*ast.Literal)
 	if !ok {
-		return "", fmt.Errorf("Expected Literal got %T", filt.Filter)
+		return "", fmt.Errorf("Expected Literal got %T", filt.Expr)
 	}
 	return literal.Value, nil
 }

--- a/zson/parser-types.go
+++ b/zson/parser-types.go
@@ -84,7 +84,7 @@ func (p *Parser) matchTypeName() (ast.Type, error) {
 		return nil, p.errorf("bad type sytax in typedef '%s=...'", name)
 	}
 	return &ast.TypeDef{
-		Op:   "TypeDef",
+		Kind: "TypeDef",
 		Name: name,
 		Type: tv.Value,
 	}, nil
@@ -121,7 +121,7 @@ func (p *Parser) matchTypeRecord() (*ast.TypeRecord, error) {
 		return nil, p.error("mismatched braces while parsing record type")
 	}
 	return &ast.TypeRecord{
-		Op:     "TypeRecord",
+		Kind:   "TypeRecord",
 		Fields: fields,
 	}, nil
 }
@@ -169,7 +169,7 @@ func (p *Parser) matchTypeArray() (*ast.TypeArray, error) {
 		return nil, p.error("mismatched brackets while parsing array type")
 	}
 	return &ast.TypeArray{
-		Op:   "TypeArray",
+		Kind: "TypeArray",
 		Type: typ,
 	}, nil
 }
@@ -199,7 +199,7 @@ func (p *Parser) matchTypeSetOrMap() (ast.Type, error) {
 			return nil, p.error("mismatched set-brackets while parsing set type")
 		}
 		typ = &ast.TypeSet{
-			Op:   "TypeSet",
+			Kind: "TypeSet",
 			Type: inner,
 		}
 	} else {
@@ -251,7 +251,7 @@ func (p *Parser) parseTypeMap() (*ast.TypeMap, error) {
 		return nil, err
 	}
 	return &ast.TypeMap{
-		Op:      "TypeMap",
+		Kind:    "TypeMap",
 		KeyType: keyType,
 		ValType: valType,
 	}, nil
@@ -291,7 +291,7 @@ func (p *Parser) matchTypeUnion() (*ast.TypeUnion, error) {
 		return nil, p.error("mismatched parentheses while parsing union type")
 	}
 	return &ast.TypeUnion{
-		Op:    "TypeUnion",
+		Kind:  "TypeUnion",
 		Types: types,
 	}, nil
 }
@@ -313,7 +313,7 @@ func (p *Parser) matchTypeEnum() (*ast.TypeEnum, error) {
 		return nil, p.error("mismatched brackets while parsing enum type")
 	}
 	return &ast.TypeEnum{
-		Op:       "TypeEnum",
+		Kind:     "TypeEnum",
 		Elements: fields,
 	}, nil
 }

--- a/zson/parser-values.go
+++ b/zson/parser-values.go
@@ -59,8 +59,8 @@ func (p *Parser) matchValue() (ast.Value, error) {
 
 func anyAsValue(any ast.Any) *ast.ImpliedValue {
 	return &ast.ImpliedValue{
-		Op: ast.ImpliedValueOp,
-		Of: any,
+		Kind: "ImpliedValue",
+		Of:   any,
 	}
 }
 
@@ -133,7 +133,7 @@ func (p *Parser) parseDecorator(any ast.Any, val ast.Value) (ast.Value, error) {
 			return nil, p.error("bad short-form type definition")
 		}
 		return &ast.DefValue{
-			Op:       ast.DefValueOp,
+			Kind:     "DefValue",
 			Of:       any,
 			TypeName: name,
 		}, nil
@@ -144,13 +144,13 @@ func (p *Parser) parseDecorator(any ast.Any, val ast.Value) (ast.Value, error) {
 	}
 	if any != nil {
 		return &ast.CastValue{
-			Op:   ast.CastValueOp,
+			Kind: "CastValue",
 			Of:   anyAsValue(any),
 			Type: typ,
 		}, nil
 	}
 	return &ast.CastValue{
-		Op:   ast.CastValueOp,
+		Kind: "CastValue",
 		Of:   val,
 		Type: typ,
 	}, nil
@@ -215,7 +215,7 @@ func (p *Parser) matchPrimitive() (*ast.Primitive, error) {
 	}
 	l.skip(len(s))
 	return &ast.Primitive{
-		Op:   "Primitive",
+		Kind: "Primitive",
 		Type: typ,
 		Text: s,
 	}, nil
@@ -227,7 +227,7 @@ func (p *Parser) matchStringPrimitive() (*ast.Primitive, error) {
 		return nil, noEOF(err)
 	}
 	return &ast.Primitive{
-		Op:   "Primitive",
+		Kind: "Primitive",
 		Type: "string",
 		Text: s,
 	}, nil
@@ -284,7 +284,7 @@ func (p *Parser) matchBacktickString() (*ast.Primitive, error) {
 		return nil, p.error("mismatched string backticks")
 	}
 	return &ast.Primitive{
-		Op:   "Primitive",
+		Kind: "Primitive",
 		Type: "string",
 		Text: s,
 	}, nil
@@ -307,7 +307,7 @@ func (p *Parser) matchRecord() (*ast.Record, error) {
 		return nil, p.error("mismatched braces while parsing record type")
 	}
 	return &ast.Record{
-		Op:     "Record",
+		Kind:   "Record",
 		Fields: fields,
 	}, nil
 }
@@ -393,7 +393,7 @@ func (p *Parser) matchArray() (*ast.Array, error) {
 		return nil, p.error("mismatched brackets while parsing array type")
 	}
 	return &ast.Array{
-		Op:       "Array",
+		Kind:     "Array",
 		Elements: vals,
 	}, nil
 }
@@ -446,7 +446,7 @@ func (p *Parser) matchSetOrMap() (ast.Any, error) {
 			return nil, p.error("mismatched set value brackets")
 		}
 		val = &ast.Set{
-			Op:       "Set",
+			Kind:     "Set",
 			Elements: vals,
 		}
 	} else {
@@ -470,7 +470,7 @@ func (p *Parser) matchSetOrMap() (ast.Any, error) {
 			return nil, p.error("mismatched map value brackets")
 		}
 		val = &ast.Map{
-			Op:      "Map",
+			Kind:    "Map",
 			Entries: entries,
 		}
 	}
@@ -553,7 +553,7 @@ func (p *Parser) matchEnum() (*ast.Enum, error) {
 		return nil, noEOF(err)
 	}
 	return &ast.Enum{
-		Op:   "Enum",
+		Kind: "Enum",
 		Name: name,
 	}, nil
 }
@@ -575,7 +575,7 @@ func (p *Parser) matchTypeValue() (*ast.TypeValue, error) {
 		return nil, p.error("mismatched parentheses while parsing type value")
 	}
 	return &ast.TypeValue{
-		Op:    "TypeValue",
+		Kind:  "TypeValue",
 		Value: typ,
 	}, nil
 }


### PR DESCRIPTION
The various names in the AST data structures evolved over
time and became inconsistent.  This commit cleans it all
up in the favor of short and consistent names.  We also
changed the "reducer" concept to "aggregator" throughout
and replaced ast.TypeExpr with ast.TypeValue as they were
logically equivalent.

Closes #2222
Closes #2165