### PR TITLE
fix bug parsing aliased primitive values

### DIFF
--- a/zio/tzngio/parser.go
+++ b/zio/tzngio/parser.go
@@ -264,6 +264,8 @@ func ParseTime(in []byte) (zcode.Bytes, error) {
 
 func ParseValue(typ zng.Type, in []byte) (zcode.Bytes, error) {
 	switch typ := typ.(type) {
+	case *zng.TypeAlias:
+		return ParseValue(typ.Type, in)
 	case *zng.TypeRecord:
 		return ParseRecord(typ, in)
 	case *zng.TypeArray, *zng.TypeSet, *zng.TypeUnion, *zng.TypeMap:

--- a/ztests/fixedbugs/2366.yaml
+++ b/ztests/fixedbugs/2366.yaml
@@ -1,0 +1,17 @@
+script: |
+  zq -z -j types.json "count()" sample.ndjson
+
+inputs:
+  - name: types.json
+    source: ../../zeek/types.json
+  - name: sample.ndjson
+    data: |
+      {"_path":"capture_loss","_write_ts":"2020-02-25T16:03:17.838527Z","ts":"2020-02-25T16:03:17.838527Z","ts_delta":11.854892015457153,"peer":"zeek","gaps":0,"acks":6,"percent_lost":0.0}
+      {"_path":"conn","_write_ts":"2020-02-25T16:03:17.838527Z","ts":"2020-02-25T16:03:11.275550Z","uid":"CQ137z1tDVuWxqRxR2","id.orig_h":"192.168.1.110","id.orig_p":54375,"id.resp_h":"192.168.1.254","id.resp_p":53,"proto":"udp","service":"dns","duration":0.01794600486755371,"orig_bytes":46,"resp_bytes":62,"conn_state":"SF","missed_bytes":0,"history":"Dd","orig_pkts":1,"orig_ip_bytes":74,"resp_pkts":1,"resp_ip_bytes":90}
+
+outputs:
+  - name: stdout
+    data: |
+      {count:2 (uint64)} (=0)
+  - name: stderr
+    data: ""


### PR DESCRIPTION
This commit fixes a bug introduced in the extract-tzng PR #2355
where primitives of aliased types were not properly parsed.
This broke app-integration tests because zq did not have
coverage.  The coverage is now in ztests/fixedbugs/2366.yaml.

Closes #2366