### PR TITLE
Simplify Zeek shaper

### DIFF
--- a/zeek/shaper.zql
+++ b/zeek/shaper.zql
@@ -54,7 +54,7 @@ type weird={_path:string,ts:time,uid:bstring,id:id,name:bstring,addl:bstring,not
 type x509={_path:string,ts:time,id:bstring,certificate:{version:uint64,serial:bstring,subject:bstring,issuer:bstring,not_valid_before:time,not_valid_after:time,key_alg:bstring,sig_alg:bstring,key_type:bstring,key_length:uint64,exponent:bstring,curve:bstring},san:{dns:[bstring],uri:[bstring],email:[bstring],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},_write_ts:time};
 
 
-put ts = iso(ts), _write_ts=iso(_write_ts) | put .=unflatten(.)
+put .=unflatten(.)
    | switch (
     case _path=files => put . = shape(files)
     case _path=http => put . = shape(http)


### PR DESCRIPTION
Once #2104 was addressed, I started trying to verify it by comparing the ZSON that was generated from reading shaped Zeek NDJSON alongside ZSON generated by reading its Zeek TSV equivalent. This revealed a glitch in the shaping functionality/config has since been fixed, as well as other Zeek-specific corner cases that have apparently always been there it seems nobody's noticed until now.

The simplification to the Zeek shaper script in this PR addresses the one major glitch. Specifically, the shortcoming of the shaper script as it existed after #2104 was closed was that only the `ts` and `_write_ts` fields were being casted to `time` types, but there's lots more `time` fields in common Zeek logs (`ref_time` in `ntp` events, `from` and `till` in `kerberos` events, etc.) @mccanne was able to address this very cleanly by fixing long-standing issue #962. This allows me now to take out the hacky calls to `iso()` that had been covering only `ts` and `_write_ts` and now rely on the `shape()` calls to cast _all_ the `time` fields. :+1:

With that out of the way, here's a walk through of a complete verification that explains the remaining deltas as being glitches in our Zeek handling that are not specific to shaping and/or glitches in Zeek itself.

I start from a `mergecap` of the same wrccdc 2018 pcap subset that was used to create the [zq-sample-data](https://github.com/brimsec/zq-sample-data), then run it through Zeek v4.0.0 while simultaneously outputting both TSV and JSON-format logs.

```
$ /usr/local/zeek-4.0.0/bin/zeek -r ../wrccdc.pcap "JSONStreaming::enable_log_rotation=F" local 
WARNING: No Site::local_nets have been defined.  It's usually a good idea to define your local networks.

$ ls -l
total 1775368
-rw-r--r--  1 phil  staff        399 Mar 17 12:06 capture_loss.log
-rw-r--r--  1 phil  staff  121697552 Mar 17 12:06 conn.log
-rw-r--r--  1 phil  staff       9609 Mar 17 12:06 dce_rpc.log
-rw-r--r--  1 phil  staff   10313324 Mar 17 12:06 dns.log
-rw-r--r--  1 phil  staff       8077 Mar 17 12:06 dpd.log
-rw-r--r--  1 phil  staff   36613297 Mar 17 12:06 files.log
-rw-r--r--  1 phil  staff      20239 Mar 17 12:06 ftp.log
-rw-r--r--  1 phil  staff   44458429 Mar 17 12:06 http.log
-rw-r--r--  1 phil  staff        605 Mar 17 12:06 json_streaming_capture_loss.log
-rw-r--r--  1 phil  staff  414604364 Mar 17 12:06 json_streaming_conn.log
-rw-r--r--  1 phil  staff      24819 Mar 17 12:05 json_streaming_dce_rpc.log
-rw-r--r--  1 phil  staff   26933247 Mar 17 12:06 json_streaming_dns.log
-rw-r--r--  1 phil  staff      20371 Mar 17 12:04 json_streaming_dpd.log
-rw-r--r--  1 phil  staff   82595431 Mar 17 12:06 json_streaming_files.log
-rw-r--r--  1 phil  staff      41867 Mar 17 12:02 json_streaming_ftp.log
-rw-r--r--  1 phil  staff   88521203 Mar 17 12:06 json_streaming_http.log
-rw-r--r--  1 phil  staff       3815 Mar 17 12:04 json_streaming_kerberos.log
-rw-r--r--  1 phil  staff      67696 Mar 17 12:01 json_streaming_loaded_scripts.log
-rw-r--r--  1 phil  staff      29629 Mar 17 12:06 json_streaming_modbus.log
-rw-r--r--  1 phil  staff      34842 Mar 17 12:05 json_streaming_notice.log
-rw-r--r--  1 phil  staff     165229 Mar 17 12:05 json_streaming_ntlm.log
-rw-r--r--  1 phil  staff     470468 Mar 17 12:06 json_streaming_ntp.log
-rw-r--r--  1 phil  staff        168 Mar 17 12:01 json_streaming_packet_filter.log
-rw-r--r--  1 phil  staff      10310 Mar 17 12:05 json_streaming_pe.log
-rw-r--r--  1 phil  staff    1135904 Mar 17 12:04 json_streaming_rdp.log
-rw-r--r--  1 phil  staff       1066 Mar 17 12:04 json_streaming_rfb.log
-rw-r--r--  1 phil  staff       3416 Mar 17 12:05 json_streaming_smb_files.log
-rw-r--r--  1 phil  staff     106828 Mar 17 12:05 json_streaming_smb_mapping.log
-rw-r--r--  1 phil  staff     441076 Mar 17 12:05 json_streaming_smtp.log
-rw-r--r--  1 phil  staff      22607 Mar 17 12:06 json_streaming_snmp.log
-rw-r--r--  1 phil  staff       9502 Mar 17 12:06 json_streaming_ssh.log
-rw-r--r--  1 phil  staff   12568227 Mar 17 12:06 json_streaming_ssl.log
-rw-r--r--  1 phil  staff       3192 Mar 17 12:06 json_streaming_stats.log
-rw-r--r--  1 phil  staff    1887994 Mar 17 12:05 json_streaming_syslog.log
-rw-r--r--  1 phil  staff    6990002 Mar 17 12:06 json_streaming_weird.log
-rw-r--r--  1 phil  staff    8240631 Mar 17 12:06 json_streaming_x509.log
-rw-r--r--  1 phil  staff       1797 Mar 17 12:06 kerberos.log
-rw-r--r--  1 phil  staff      33468 Mar 17 12:06 loaded_scripts.log
-rw-r--r--  1 phil  staff      11182 Mar 17 12:06 modbus.log
-rw-r--r--  1 phil  staff      22103 Mar 17 12:06 notice.log
-rw-r--r--  1 phil  staff      61490 Mar 17 12:06 ntlm.log
-rw-r--r--  1 phil  staff     167022 Mar 17 12:06 ntp.log
-rw-r--r--  1 phil  staff        254 Mar 17 12:06 packet_filter.log
-rw-r--r--  1 phil  staff       3401 Mar 17 12:06 pe.log
-rw-r--r--  1 phil  staff     492001 Mar 17 12:06 rdp.log
-rw-r--r--  1 phil  staff        751 Mar 17 12:06 rfb.log
-rw-r--r--  1 phil  staff       1821 Mar 17 12:06 smb_files.log
-rw-r--r--  1 phil  staff      41364 Mar 17 12:06 smb_mapping.log
-rw-r--r--  1 phil  staff     218107 Mar 17 12:06 smtp.log
-rw-r--r--  1 phil  staff       6937 Mar 17 12:06 snmp.log
-rw-r--r--  1 phil  staff       5415 Mar 17 12:06 ssh.log
-rw-r--r--  1 phil  staff    5861414 Mar 17 12:06 ssl.log
-rw-r--r--  1 phil  staff       1402 Mar 17 12:06 stats.log
-rw-r--r--  1 phil  staff    1427653 Mar 17 12:06 syslog.log
-rw-r--r--  1 phil  staff    2711416 Mar 17 12:06 weird.log
-rw-r--r--  1 phil  staff    4129552 Mar 17 12:06 x509.log
```

I then make `diff`\-friendly versions of the ZSON representations of each set of logs that I can compare them side-by-side. The TSV logs are known to lack the `_write_ts` field, so we `drop` that here to make the `diff` easier. I also `sort` by `ts,_path` to make the outputs as deterministic as possible.

```
$ zq -Z -I ~/work/zq/zeek/shaper.zql "| drop _write_ts | sort -r ts,_path" json_streaming_* > /tmp/zsd-shaped.zson
$ zq -Z "sort -r ts,_path" [!j]* > /tmp/zsd-from-tsv.zson
```

Making a side-by-side `diff` of the two:

```
$ diff -W 260 -y /tmp/zsd-shaped.zson /tmp/zsd-from-tsv.zson > /tmp/diff.txt
```

For starters, there's no "adds" or "deletes" between the two. So far so good.

```
$ grep "  <" /tmp/diff.txt
$ grep "  >" /tmp/diff.txt
```

Alas, there's going to be a lot of diffs, so let's isolate those without context to make this quicker.

```
$ grep "  |" /tmp/diff.txt > /tmp/difflines.txt
```

Let's start picking this apart. The first thing we notice is some precision issues, that are actually a Zeek glitch.

```
$ cat /tmp/difflines.txt 
    ts_delta: 5m9.557840109s,                                                      |        ts_delta: 5m9.55784s,
    percent_lost: 1.5736480629459226e-01                                              |        percent_lost: 1.57365e-01
    duration: 4.053µs,                                                          |        duration: 4µs,
...
```

I started a [discussion](https://github.com/zeek/zeek/discussions/1163) with the Zeek devs on this topic some time ago, but "it is what it is", as seen by comparing the Zeek logs side-by-side:

```
$ cat capture_loss.log | /usr/local/zeek/bin/zeek-cut ts_delta | tail -1
309.557840

$ cat json_streaming_capture_loss.log | tail -1 | jq '.ts_delta'
309.55784010887146
```

Now that we know this, we can sweep aside all these fields of the Zeek `duration` type and see what's left.

```
$ egrep -v "duration:"\|"rtt:"\|"ts_delta:"\|"percent_lost:"\|"precision:"\|"root_delay:"\|"root_disp:" /tmp/difflines.txt
    ref_id: "\\x00\\x00\\x00\\x00",                                                                                           |     ref_id: "\x00\x00\x00\x00",
    ref_id: "\\x00\\x00\\x00\\x00",                                                                                           |     ref_id: "\x00\x00\x00\x00",
    ref_id: "\\x00\\x00\\x00\\x00",                                                                                           |     ref_id: "\x00\x00\x00\x00",
...
```

This is our known issue #1677, so we sweep that field aside along with `query` and `uri` which also show that same symptom.

```
$ egrep -v "duration:"\|"rtt:"\|"ts_delta:"\|"percent_lost:"\|"precision:"\|"root_delay:"\|"root_disp:"\|"ref_id:"\|"query:"\|"uri:" /tmp/difflines.txt
        not_valid_after: 2045-08-06T14:22:37Z,                                                                                |         not_valid_after: 2045-08-06T14:20:00Z,
        not_valid_after: 2045-08-06T14:22:37Z,                                                                                |         not_valid_after: 2045-08-06T14:20:00Z,
        not_valid_after: 2045-08-06T14:22:37Z,                                                                                |         not_valid_after: 2045-08-06T14:20:00Z,
...
```

This looks like another time-related precision issue, but the gap here is surprisingly off by _minutes_. Here's an example of one of those timestamp diffs side-by-side in full context:

```
{                                                                                                                               {
    _path: "x509",                                                                                                                  _path: "x509",
    ts: 2018-03-24T17:36:21.519658Z,                                                                                                ts: 2018-03-24T17:36:21.519658Z,
    id: "Fyt7Gi4ZWiGId0ixng",                                                                                                       id: "Fyt7Gi4ZWiGId0ixng",
    certificate: {                                                                                                                  certificate: {
        version: 3,                                                                                                                     version: 3,
        serial: "C5F8CDF3FFCBBF2D",                                                                                                     serial: "C5F8CDF3FFCBBF2D",
        subject: "CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",                                                        subject: "CN=10.150.0.85,O=Internet Widgit
s Pty Ltd,ST=Some-State,C=AU",
        issuer: "CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",                                                         issuer: "CN=10.150.0.85,O=Internet Widgits
 Pty Ltd,ST=Some-State,C=AU",
        not_valid_before: 2018-03-22T14:22:37Z,                                                                                         not_valid_before: 2018-03-22T14:22:37Z,
        not_valid_after: 2045-08-06T14:22:37Z,                                                                                |         not_valid_after: 2045-08-06T14:20:00Z,
        key_alg: "rsaEncryption",                                                                                                       key_alg: "rsaEncryption",
        sig_alg: "sha256WithRSAEncryption",                                                                                             sig_alg: "sha256WithRSAEncryption",
        key_type: "rsa",                                                                                                                key_type: "rsa",
        key_length: 2048,                                                                                                               key_length: 2048,
        exponent: "65537",                                                                                                              exponent: "65537",
        curve: null                                                                                                                     curve: null
    },                                                                                                                              },
```

Those log entries each of the original Zeek logs:

```
$ cat x509.log | /usr/local/zeek/bin/zeek-cut ts id certificate.not_valid_after | grep Fyt7Gi4ZWiGId0ixng
1521912981.519658    Fyt7Gi4ZWiGId0ixng    2.385642e+09

$ cat json_streaming_x509.log | jq '. | select (.id=="Fyt7Gi4ZWiGId0ixng")'
{
  "_path": "x509",
  "_write_ts": "2018-03-24T17:36:21.519658Z",
  "ts": "2018-03-24T17:36:21.519658Z",
  "id": "Fyt7Gi4ZWiGId0ixng",
  "certificate.version": 3,
  "certificate.serial": "C5F8CDF3FFCBBF2D",
  "certificate.subject": "CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
  "certificate.issuer": "CN=10.150.0.85,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
  "certificate.not_valid_before": "2018-03-22T14:22:37.000000Z",
  "certificate.not_valid_after": "2045-08-06T14:22:37.000000Z",
  "certificate.key_alg": "rsaEncryption",
  "certificate.sig_alg": "sha256WithRSAEncryption",
  "certificate.key_type": "rsa",
  "certificate.key_length": 2048,
  "certificate.exponent": "65537",
  "basic_constraints.ca": true
}
```

Turning `2.385642e+09` into `2385642000` and running it through a [timestamp converter](https://www.timestamp-converter.com/), we see that's equivalent to ISO timestamp `2045-08-06T14:20:00.000Z`. So, indeed, this looks like another precision glitch with Zeek TSV, seemingly aggravated by the fact that it's so ridiculously far in the future. I don't know if it's an open Zeek issue, but I'm happy to sweep that one out of the way for now as well since it's not our fault.

```
$ egrep -v "duration:"\|"rtt:"\|"ts_delta:"\|"percent_lost:"\|"precision:"\|"root_delay:"\|"root_disp:"\|"ref_id:"\|"query:"\|"uri:"\|"not_valid_after:" /tmp/difflines.txt
    xmt_time: 1901-11-09T17:49:10.310305Z,                                                                                    |     xmt_time: 1901-11-09T17:46:40Z,
    xmt_time: 1901-11-09T17:49:10.310305Z,                                                                                    |     xmt_time: 1901-11-09T17:46:40Z,
...
```

Looks like more of the same, but now with timestamps that are ridiculously far in the _past_. Sweeping those aside as well:

```
$ egrep -v "duration:"\|"rtt:"\|"ts_delta:"\|"percent_lost:"\|"precision:"\|"root_delay:"\|"root_disp:"\|"ref_id:"\|"query:"\|"uri:"\|"not_valid_after:"\|"xmt_time:" /tmp/difflines.txt
    client_dig_product_id: "",                                                                                                |     client_dig_product_id: "(empty)",
    client_dig_product_id: "",                                                                                                |     client_dig_product_id: "(empty)",
    client_dig_product_id: "",                                                                                                |     client_dig_product_id: "(empty)",
...
```

This reveals the final mole to be whacked, which I just filed earlier today as #2365. Sweeping _that_ one side, we finally get the diff to run clean:

```
$ egrep -v "duration:"\|"rtt:"\|"ts_delta:"\|"percent_lost:"\|"precision:"\|"root_delay:"\|"root_disp:"\|"ref_id:"\|"query:"\|"uri:"\|"not_valid_after:"\|"xmt_time:"\|"client_dig_product_id:" /tmp/difflines.txt
[no output]
```

In conclusion:

1.  Zeek's precision issues with time are annoying, but, not our fault.
2.  We can address #1677 and #2365 at some point to clean up the remaining known problems on our end with reading Zeek TSV. Those problems are not unique to shaping, though.
3.  With that, I think once we merge the shaper change in this PR we should be ok to replace Brim's use of legacy `types.json` with this new shaper approach.