### PR TITLE
fix dot and add type values in zfmt

### DIFF
--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -102,6 +102,10 @@ func (c *canon) expr(e ast.Expr, paren bool) {
 		c.fieldpath(e.Name)
 	case *ast.Ref:
 		c.write("%s", e.Name)
+	case *ast.TypeValue:
+		c.write("type(")
+		c.typ(e.Value)
+		c.write(")")
 	default:
 		c.open("(unknown expr %T)", e)
 		c.close()
@@ -347,6 +351,10 @@ func (c *canon) literal(e ast.Primitive) {
 }
 
 func (c *canon) fieldpath(path []string) {
+	if len(path) == 0 {
+		c.write(".")
+		return
+	}
 	for k, s := range path {
 		if k != 0 {
 			c.write(".")


### PR DESCRIPTION
This commit fixes a bug in canonical zfmt to print "."  instead of
nothing for a root record field path.  It also adds support for
printing type values.

This addresses some but not all of the problems in #2224. 
We can add a number of tests for this stuff when we tackle
the rest of #2224.
