### PR TITLE
revert json encoding of nano.Duration

### DIFF
--- a/pkg/nano/duration.go
+++ b/pkg/nano/duration.go
@@ -103,19 +103,15 @@ func writeFixedPoint(b *strings.Builder, ns, scale int64) {
 }
 
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
+	return json.Marshal(Ts(d))
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
+	var ts Ts
+	if err := json.Unmarshal(b, &ts); err != nil {
 		return err
 	}
-	v, err := ParseDuration(s)
-	if err != nil {
-		return err
-	}
-	*d = v
+	*d = Duration(ts)
 	return nil
 }
 


### PR DESCRIPTION
This commit reverts the way we marshal and unmarshal nano.Durations
so that we don't have to change the API used by the app whereever
a nano.Span was used.  It readopts the old format of {sec:float64,ns:float64}
to serialized durations.