### PR TITLE
preserve outer record type names in shaping and put .

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -382,7 +382,7 @@ func compileShaper(zctx *resolver.Context, scope *Scope, node ast.Call) (*expr.S
 	if err != nil {
 		return nil, err
 	}
-	return expr.NewShaper(zctx, field, ev, shaperOps(node.Name))
+	return expr.NewShaperFromTypeExpr(zctx, field, ev, shaperOps(node.Name))
 }
 
 func compileCall(zctx *resolver.Context, scope *Scope, call ast.Call) (expr.Evaluator, error) {

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -81,7 +81,7 @@ func (c *Cutter) Apply(in *zng.Record) (*zng.Record, error) {
 			}
 			return nil, err
 		}
-		recType, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord)
+		recType, ok := zng.AliasOf(zv.Type).(*zng.TypeRecord)
 		if !ok {
 			return nil, errors.New("cannot cut a non-record to .")
 		}

--- a/expr/dot.go
+++ b/expr/dot.go
@@ -31,7 +31,7 @@ func NewDotExpr(f field.Static) Evaluator {
 }
 
 func accessField(record zng.Value, field string) (zng.Value, error) {
-	recType, ok := zng.AliasedType(record.Type).(*zng.TypeRecord)
+	recType, ok := zng.AliasOf(record.Type).(*zng.TypeRecord)
 	if !ok {
 		return zng.Value{}, zng.ErrMissing
 	}

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -129,12 +129,12 @@ func (i *In) Eval(rec *zng.Record) (zng.Value, error) {
 	if err != nil {
 		return container, err
 	}
-	if typ := zng.AliasedType(container.Type); typ == zng.TypeNet {
+	if typ := zng.AliasOf(container.Type); typ == zng.TypeNet {
 		n, err := zng.DecodeNet(container.Bytes)
 		if err != nil {
 			return zng.Value{}, err
 		}
-		if typ := zng.AliasedType(elem.Type); typ != zng.TypeIP {
+		if typ := zng.AliasOf(elem.Type); typ != zng.TypeIP {
 			return zng.Value{}, ErrIncompatibleTypes
 		}
 		a, err := zng.DecodeIP(elem.Bytes)

--- a/expr/function/fields.go
+++ b/expr/function/fields.go
@@ -15,7 +15,7 @@ type fields struct {
 func fieldNames(typ *zng.TypeRecord) []string {
 	var out []string
 	for _, c := range typ.Columns {
-		if typ, ok := zng.AliasedType(c.Type).(*zng.TypeRecord); ok {
+		if typ, ok := zng.AliasOf(c.Type).(*zng.TypeRecord); ok {
 			for _, subfield := range fieldNames(typ) {
 				out = append(out, c.Name+"."+subfield)
 			}
@@ -41,7 +41,7 @@ func (f *fields) Call(args []zng.Value) (zng.Value, error) {
 }
 
 func isRecordType(zv zng.Value, zctx *zson.Context) *zng.TypeRecord {
-	if typ, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord); ok {
+	if typ, ok := zng.AliasOf(zv.Type).(*zng.TypeRecord); ok {
 		return typ
 	}
 	if zv.Type == zng.TypeType {
@@ -53,7 +53,7 @@ func isRecordType(zv zng.Value, zctx *zson.Context) *zng.TypeRecord {
 		if err != nil {
 			return nil
 		}
-		if typ, ok := zng.AliasedType(typ).(*zng.TypeRecord); ok {
+		if typ, ok := zng.AliasOf(typ).(*zng.TypeRecord); ok {
 			return typ
 		}
 	}

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -131,7 +131,7 @@ func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
 	if zv.Bytes == nil {
 		return zng.Value{zng.TypeInt64, nil}, nil
 	}
-	switch zng.AliasedType(args[0].Type).(type) {
+	switch zng.AliasOf(args[0].Type).(type) {
 	case *zng.TypeArray, *zng.TypeSet:
 		len, err := zv.ContainerLength()
 		if err != nil {

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -294,7 +294,7 @@ type join struct {
 
 func (j *join) Call(args []zng.Value) (zng.Value, error) {
 	zsplits := args[0]
-	typ, ok := zng.AliasedType(zsplits.Type).(*zng.TypeArray)
+	typ, ok := zng.AliasOf(zsplits.Type).(*zng.TypeArray)
 	if !ok {
 		return zng.NewErrorf("argument to join() is not an array"), nil
 	}

--- a/expr/generator.go
+++ b/expr/generator.go
@@ -79,7 +79,7 @@ func (f *FilterMethod) Next() (zng.Value, error) {
 		if err != nil {
 			return zng.Value{}, err
 		}
-		if zng.AliasedType(b.Type) != zng.TypeBool {
+		if zng.AliasOf(b.Type) != zng.TypeBool {
 			return zng.NewErrorf("not a boolean"), nil
 		}
 		if zng.IsTrue(b.Bytes) {

--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -347,7 +347,7 @@ func (s *Shaper) createShapeSpec(inType *zng.TypeRecord) (shapeSpec, error) {
 	if typ.ID() == s.typ.ID() {
 		// If the underlying records are the same, then use the
 		// spec record as it might be an alias and the intention
-		// would be to case to the named type.
+		// would be to cast to the named type.
 		final = s.typ
 	} else {
 		final = typ

--- a/expr/slice.go
+++ b/expr/slice.go
@@ -54,7 +54,7 @@ func (s *Slice) Eval(rec *zng.Record) (zng.Value, error) {
 	if err != nil {
 		return elem, err
 	}
-	if _, ok := zng.AliasedType(elem.Type).(*zng.TypeArray); !ok {
+	if _, ok := zng.AliasOf(elem.Type).(*zng.TypeArray); !ok {
 		return zng.NewErrorf("sliced value is not an array"), nil
 	}
 	if elem.Bytes == nil {

--- a/expr/ztests/shape-rec-alias.yaml
+++ b/expr/ztests/shape-rec-alias.yaml
@@ -1,0 +1,9 @@
+zql: |
+  type person = {name:string,likes:string,age:int64}
+  put .=cast(.,type(person))
+
+input: |
+  {name:"steve",likes:"spicy",age:"52"}
+
+output: |
+  {name:"steve",likes:"spicy",age:52} (=person)

--- a/pkg/stringsearch/fieldnamefinder.go
+++ b/pkg/stringsearch/fieldnamefinder.go
@@ -55,7 +55,7 @@ func (f *FieldNameFinder) Find(zctx *resolver.Context, buf []byte) bool {
 		if err != nil {
 			return true
 		}
-		tr, ok := zng.AliasedType(t).(*zng.TypeRecord)
+		tr, ok := zng.AliasOf(t).(*zng.TypeRecord)
 		if !ok {
 			return true
 		}
@@ -97,7 +97,7 @@ func (f *FieldNameIter) Next() []byte {
 		info := &f.stack[len(f.stack)-1]
 		col := info.columns[info.offset]
 		f.buf = append(f.buf, "."+col.Name...)
-		t, ok := zng.AliasedType(col.Type).(*zng.TypeRecord)
+		t, ok := zng.AliasOf(col.Type).(*zng.TypeRecord)
 		if !ok || len(t.Columns) == 0 {
 			break
 		}

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -97,7 +97,7 @@ func (f *Fuser) finish() error {
 		}
 	}
 
-	f.shaper, err = expr.NewShaperType(f.zctx, &expr.RootRecord{}, uber.Type, expr.Fill|expr.Order)
+	f.shaper, err = expr.NewShaper(f.zctx, &expr.RootRecord{}, uber.Type, expr.Fill|expr.Order)
 	if err != nil {
 		return err
 	}

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -91,7 +91,7 @@ func (f *Fuser) finish() error {
 	}
 	for _, typ := range typesInOrder(f.types) {
 		if typ != nil {
-			if err = uber.Mixin(zng.AliasedType(typ).(*zng.TypeRecord)); err != nil {
+			if err = uber.Mixin(zng.AliasOf(typ).(*zng.TypeRecord)); err != nil {
 				return err
 			}
 		}

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -218,7 +218,6 @@ func (p *Proc) deriveSteps(inType *zng.TypeRecord, vals []zng.Value) (step, zng.
 		if zng.TypeRecordOf(typ) == nil {
 			return step{}, nil, fmt.Errorf("put .=x: cannot put a non-record to .")
 		}
-		//typ, err := p.pctx.Zctx.LookupTypeRecord(recVal.Columns)
 		return step{op: root, index: 0}, typ, nil
 	}
 	return p.deriveRecordSteps(field.NewRoot(), inType.Columns, vals)

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -35,7 +35,7 @@ type Proc struct {
 // Such changes aren't typically expected but are possible in the expression
 // language.
 type putRule struct {
-	typ         *zng.TypeRecord
+	typ         zng.Type
 	clauseTypes []zng.Type
 	step        step
 }
@@ -211,15 +211,15 @@ func findOverwriteClause(path field.Static, clauses []expr.Assignment) (int, fie
 	return -1, nil, false
 }
 
-func (p *Proc) deriveSteps(inType *zng.TypeRecord, vals []zng.Value) (step, *zng.TypeRecord, error) {
+func (p *Proc) deriveSteps(inType *zng.TypeRecord, vals []zng.Value) (step, zng.Type, error) {
 	// special case: assign to root (put .=x)
 	if p.clauses[0].LHS.IsRoot() {
-		recVal, ok := vals[0].Type.(*zng.TypeRecord)
-		if !ok {
+		typ := vals[0].Type
+		if zng.TypeRecordOf(typ) == nil {
 			return step{}, nil, fmt.Errorf("put .=x: cannot put a non-record to .")
 		}
-		typ, err := p.pctx.Zctx.LookupTypeRecord(recVal.Columns)
-		return step{op: root, index: 0}, typ, err
+		//typ, err := p.pctx.Zctx.LookupTypeRecord(recVal.Columns)
+		return step{op: root, index: 0}, typ, nil
 	}
 	return p.deriveRecordSteps(field.NewRoot(), inType.Columns, vals)
 }
@@ -358,7 +358,7 @@ func (p *Proc) put(in *zng.Record) (*zng.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	return zng.NewRecord(rule.typ, bytes), nil
+	return zng.NewRecordFromType(rule.typ, bytes), nil
 }
 func (p *Proc) Pull() (zbuf.Batch, error) {
 	batch, err := p.parent.Pull()

--- a/proc/shape/shaper.go
+++ b/proc/shape/shaper.go
@@ -37,7 +37,7 @@ type integer struct {
 }
 
 func nulltype(t zng.Type) bool {
-	return zng.AliasedType(t) == zng.TypeNull
+	return zng.AliasOf(t) == zng.TypeNull
 }
 
 func (a *anchor) match(cols []zng.Column) bool {

--- a/proc/shape/ztests/shape-bstring.yaml
+++ b/proc/shape/ztests/shape-bstring.yaml
@@ -1,11 +1,9 @@
 zql: |
-  type types = {
-    bstring: bstring
-  }
-  put . = shape(types)
+  type custom = {bstring: bstring}
+  put . = shape(custom)
 
 input: |
   { bstring:"this is a bstring" }
 
 output: |
-  {bstring:"this is a bstring" (bstring)} (=0)
+  {bstring:"this is a bstring" (bstring)} (=custom)

--- a/zbuf/mapper.go
+++ b/zbuf/mapper.go
@@ -34,6 +34,6 @@ func (m *Mapper) Read() (*zng.Record, error) {
 		}
 	}
 	rec.Alias = sharedType
-	rec.Type = zng.AliasedType(sharedType).(*zng.TypeRecord)
+	rec.Type = zng.AliasOf(sharedType).(*zng.TypeRecord)
 	return rec, nil
 }

--- a/zio/ndjsonio/inferparser.go
+++ b/zio/ndjsonio/inferparser.go
@@ -67,7 +67,7 @@ func (p *inferParser) parseObject(b []byte) (zng.Value, error) {
 		return zng.Value{}, err
 	}
 	for _, v := range zngValues {
-		columnBuilder.Append(v.Bytes, zng.IsContainerType(zng.AliasedType(v.Type)))
+		columnBuilder.Append(v.Bytes, zng.IsContainerType(zng.AliasOf(v.Type)))
 	}
 	zbytes, err := columnBuilder.Encode()
 	if err != nil {

--- a/zio/tzngio/builder.go
+++ b/zio/tzngio/builder.go
@@ -50,7 +50,7 @@ func (b *builder) parseRecord(typ *zng.TypeRecord, in []string) ([]string, error
 			continue
 		}
 
-		switch v := zng.AliasedType(col.Type).(type) {
+		switch v := zng.AliasOf(col.Type).(type) {
 		case *zng.TypeRecord:
 			b.BeginContainer()
 			in, err = b.parseRecord(v, in)
@@ -86,7 +86,7 @@ func (b *builder) parseRecord(typ *zng.TypeRecord, in []string) ([]string, error
 }
 
 func (b *builder) parseArray(typ *zng.TypeArray, in string) error {
-	inner := zng.InnerType(zng.AliasedType(typ))
+	inner := zng.InnerType(zng.AliasOf(typ))
 	if len(in) == 0 {
 		return nil
 	}
@@ -126,7 +126,7 @@ func (b *builder) parseArray(typ *zng.TypeArray, in string) error {
 }
 
 func (b *builder) parseSet(typ *zng.TypeSet, in string) error {
-	inner := zng.InnerType(zng.AliasedType(typ))
+	inner := zng.InnerType(zng.AliasOf(typ))
 	if len(in) == 0 {
 		return nil
 	}

--- a/zio/tzngio/parser.go
+++ b/zio/tzngio/parser.go
@@ -55,7 +55,7 @@ const (
 // ParseContainer parses the given byte array representing a container
 // in the zng format.
 func (p *Parser) ParseContainer(typ zng.Type, b []byte) ([]byte, error) {
-	realType := zng.AliasedType(typ)
+	realType := zng.AliasOf(typ)
 	// This is hokey.
 	var keyType, valType zng.Type
 	if typ, ok := realType.(*zng.TypeMap); ok {
@@ -111,7 +111,7 @@ func (p *Parser) ParseContainer(typ zng.Type, b []byte) ([]byte, error) {
 // ParseField parses the given byte array representing any value
 // in the zng format.
 func (p *Parser) ParseField(typ zng.Type, b []byte) ([]byte, error) {
-	realType := zng.AliasedType(typ)
+	realType := zng.AliasOf(typ)
 	var err error
 	var index int
 	if len(b) >= 2 && b[0] == '-' && b[1] == ';' {

--- a/zio/tzngio/reader.go
+++ b/zio/tzngio/reader.go
@@ -204,7 +204,7 @@ func (r *Reader) parseValue(line []byte) (*zng.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	recType, ok := zng.AliasedType(typ).(*zng.TypeRecord)
+	recType, ok := zng.AliasOf(typ).(*zng.TypeRecord)
 	if !ok {
 		return nil, errors.New("outer type is not a record type")
 	}

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -98,7 +98,7 @@ func (w *Writer) write(s string) error {
 }
 
 func (w *Writer) writeUnion(parent zng.Value) error {
-	utyp := zng.AliasedType(parent.Type).(*zng.TypeUnion)
+	utyp := zng.AliasOf(parent.Type).(*zng.TypeUnion)
 	inner, index, v, err := utyp.SplitZng(parent.Bytes)
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (w *Writer) writeUnion(parent zng.Value) error {
 	}
 
 	value := zng.Value{inner, v}
-	if zng.IsContainerType(zng.AliasedType(inner)) {
+	if zng.IsContainerType(zng.AliasOf(inner)) {
 		if err := w.writeContainer(value); err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func (w *Writer) writeContainer(parent zng.Value) error {
 		w.write("-;")
 		return nil
 	}
-	realType := zng.AliasedType(parent.Type)
+	realType := zng.AliasOf(parent.Type)
 	if _, ok := realType.(*zng.TypeUnion); ok {
 		return w.writeUnion(parent)
 	}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -481,7 +481,7 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 	if typ == nil || err != nil {
 		return nil, zng.ErrTypeIDInvalid
 	}
-	if _, ok := zng.AliasedType(typ).(*zng.TypeRecord); !ok {
+	if _, ok := zng.AliasOf(typ).(*zng.TypeRecord); !ok {
 		// An "id" of a top-level zng value not conforming with a
 		// record type is valid zng data but not supported by zq.
 		// This can also happen when trying to parse random non-zng

--- a/zng/alias.go
+++ b/zng/alias.go
@@ -40,10 +40,10 @@ func (t *TypeAlias) ZSONOf(zv zcode.Bytes) string {
 	return t.Type.ZSONOf(zv)
 }
 
-func AliasedType(typ Type) Type {
-	alias, isAlias := typ.(*TypeAlias)
-	if isAlias {
-		return AliasedType(alias.Type)
+func AliasOf(typ Type) Type {
+	alias, ok := typ.(*TypeAlias)
+	if ok {
+		return AliasOf(alias.Type)
 	}
 	return typ
 }

--- a/zng/fielditer.go
+++ b/zng/fielditer.go
@@ -40,7 +40,7 @@ func (r *fieldIter) Next() ([]string, Value, error) {
 	col := info.typ.Columns[info.offset]
 	fullname := append(info.field, col.Name)
 
-	recType, isRecord := AliasedType(col.Type).(*TypeRecord)
+	recType, isRecord := AliasOf(col.Type).(*TypeRecord)
 	if isRecord {
 		if !container {
 			return nil, Value{}, ErrMismatch

--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -62,7 +62,7 @@ func NewRecord(typ *TypeRecord, raw zcode.Bytes) *Record {
 
 func NewRecordFromType(typ Type, raw zcode.Bytes) *Record {
 	return &Record{
-		Type:        AliasedType(typ).(*TypeRecord),
+		Type:        AliasOf(typ).(*TypeRecord),
 		Alias:       typ,
 		nonvolatile: true,
 		Raw:         raw,
@@ -79,7 +79,7 @@ func NewRecordCheck(typ *TypeRecord, raw zcode.Bytes) (*Record, error) {
 
 func NewRecordCheckFromType(typ Type, raw zcode.Bytes) (*Record, error) {
 	r := &Record{
-		Type:        AliasedType(typ).(*TypeRecord),
+		Type:        AliasOf(typ).(*TypeRecord),
 		Alias:       typ,
 		nonvolatile: true,
 		Raw:         raw,
@@ -106,7 +106,7 @@ func NewVolatileRecord(typ *TypeRecord, raw zcode.Bytes) *Record {
 
 func NewVolatileRecordFromType(typ Type, raw zcode.Bytes) *Record {
 	return &Record{
-		Type:  AliasedType(typ).(*TypeRecord),
+		Type:  AliasOf(typ).(*TypeRecord),
 		Alias: typ,
 		Raw:   raw,
 	}
@@ -288,7 +288,7 @@ func (r *Record) AccessString(field string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch AliasedType(v.Type).(type) {
+	switch AliasOf(v.Type).(type) {
 	case *TypeOfString, *TypeOfBstring:
 		return DecodeString(v.Bytes)
 	default:
@@ -301,7 +301,7 @@ func (r *Record) AccessBool(field string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if _, ok := AliasedType(v.Type).(*TypeOfBool); !ok {
+	if _, ok := AliasOf(v.Type).(*TypeOfBool); !ok {
 		return false, ErrTypeMismatch
 	}
 	return DecodeBool(v.Bytes)
@@ -312,7 +312,7 @@ func (r *Record) AccessInt(field string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	switch AliasedType(v.Type).(type) {
+	switch AliasOf(v.Type).(type) {
 	case *TypeOfUint8:
 		b, err := DecodeUint(v.Bytes)
 		return int64(b), err
@@ -336,7 +336,7 @@ func (r *Record) AccessIP(field string) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := AliasedType(v.Type).(*TypeOfIP); !ok {
+	if _, ok := AliasOf(v.Type).(*TypeOfIP); !ok {
 		return nil, ErrTypeMismatch
 	}
 	return DecodeIP(v.Bytes)
@@ -347,7 +347,7 @@ func (r *Record) AccessTime(field string) (nano.Ts, error) {
 	if err != nil {
 		return 0, err
 	}
-	if _, ok := AliasedType(v.Type).(*TypeOfTime); !ok {
+	if _, ok := AliasOf(v.Type).(*TypeOfTime); !ok {
 		return 0, ErrTypeMismatch
 	}
 	return DecodeTime(v.Bytes)

--- a/zng/type.go
+++ b/zng/type.go
@@ -312,8 +312,13 @@ func IsUnionType(typ Type) bool {
 }
 
 func IsRecordType(typ Type) bool {
-	_, ok := AliasedType(typ).(*TypeRecord)
+	_, ok := AliasOf(typ).(*TypeRecord)
 	return ok
+}
+
+func TypeRecordOf(typ Type) *TypeRecord {
+	t, _ := AliasOf(typ).(*TypeRecord)
+	return t
 }
 
 func IsContainerType(typ Type) bool {
@@ -379,15 +384,4 @@ func ReferencedID(typ Type) int {
 		return typ.Type.ID()
 	}
 	return typ.ID()
-}
-
-func TypeRecordOf(typ Type) *TypeRecord {
-	for {
-		alias, ok := typ.(*TypeAlias)
-		if !ok {
-			typ, _ := typ.(*TypeRecord)
-			return typ
-		}
-		typ = alias.Type
-	}
 }

--- a/zng/type.go
+++ b/zng/type.go
@@ -380,3 +380,14 @@ func ReferencedID(typ Type) int {
 	}
 	return typ.ID()
 }
+
+func TypeRecordOf(typ Type) *TypeRecord {
+	for {
+		alias, ok := typ.(*TypeAlias)
+		if !ok {
+			typ, _ := typ.(*TypeRecord)
+			return typ
+		}
+		typ = alias.Type
+	}
+}

--- a/zng/walk.go
+++ b/zng/walk.go
@@ -85,7 +85,7 @@ func walkArray(typ *TypeArray, body zcode.Bytes, visit Visitor) error {
 	if body == nil {
 		return nil
 	}
-	inner := InnerType(AliasedType(typ))
+	inner := InnerType(AliasOf(typ))
 	it := body.Iter()
 	for !it.Done() {
 		body, container, err := it.Next()
@@ -144,7 +144,7 @@ func walkSet(typ *TypeSet, body zcode.Bytes, visit Visitor) error {
 	if body == nil {
 		return nil
 	}
-	inner := AliasedType(InnerType(typ))
+	inner := AliasOf(InnerType(typ))
 	it := body.Iter()
 	for !it.Done() {
 		body, container, err := it.Next()
@@ -165,8 +165,8 @@ func walkMap(typ *TypeMap, body zcode.Bytes, visit Visitor) error {
 	if body == nil {
 		return nil
 	}
-	keyType := AliasedType(typ.KeyType)
-	valType := AliasedType(typ.ValType)
+	keyType := AliasOf(typ.KeyType)
+	valType := AliasOf(typ.ValType)
 	it := body.Iter()
 	for !it.Done() {
 		body, container, err := it.Next()

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -126,7 +126,7 @@ func (a Analyzer) convertValue(zctx *Context, val ast.Value, parent zng.Type) (V
 		if err != nil {
 			return nil, err
 		}
-		if union, ok := zng.AliasedType(parent).(*zng.TypeUnion); ok {
+		if union, ok := zng.AliasOf(parent).(*zng.TypeUnion); ok {
 			v, err = a.convertUnion(zctx, v, union, parent)
 		}
 		return v, err
@@ -138,7 +138,7 @@ func (a Analyzer) typeCheck(cast, parent zng.Type) error {
 	if parent == nil || cast == parent {
 		return nil
 	}
-	if _, ok := zng.AliasedType(parent).(*zng.TypeUnion); ok {
+	if _, ok := zng.AliasOf(parent).(*zng.TypeUnion); ok {
 		// We let unions through this type check with no further checking
 		// as any union incompability will be caught in convertAnyValue().
 		return nil
@@ -166,7 +166,7 @@ func (a Analyzer) convertAny(zctx *Context, val ast.Any, cast zng.Type) (Value, 
 	// If we're casting something to a union, then the thing inside needs to
 	// describe itself and we can convert the inner value to a union value when
 	// we know its type (so we can code the selector).
-	if union, ok := zng.AliasedType(cast).(*zng.TypeUnion); ok {
+	if union, ok := zng.AliasOf(cast).(*zng.TypeUnion); ok {
 		v, err := a.convertAny(zctx, val, nil)
 		if err != nil {
 			return nil, err
@@ -253,7 +253,7 @@ func (a Analyzer) convertRecord(zctx *Context, val *ast.Record, cast zng.Type) (
 	var fields []Value
 	var err error
 	if cast != nil {
-		recType, ok := zng.AliasedType(cast).(*zng.TypeRecord)
+		recType, ok := zng.AliasOf(cast).(*zng.TypeRecord)
 		if !ok {
 			return nil, fmt.Errorf("record decorator not of type record: %T", cast)
 		}
@@ -306,7 +306,7 @@ func arrayElemCast(cast zng.Type) (zng.Type, error) {
 	if cast == nil {
 		return nil, nil
 	}
-	if arrayType, ok := zng.AliasedType(cast).(*zng.TypeArray); ok {
+	if arrayType, ok := zng.AliasOf(cast).(*zng.TypeArray); ok {
 		return arrayType.Type, nil
 	}
 	return nil, errors.New("array decorator not of type array")
@@ -420,7 +420,7 @@ func differentTypes(vals []Value) []zng.Type {
 func (a Analyzer) convertSet(zctx *Context, set *ast.Set, cast zng.Type) (Value, error) {
 	var elemType zng.Type
 	if cast != nil {
-		setType, ok := zng.AliasedType(cast).(*zng.TypeSet)
+		setType, ok := zng.AliasOf(cast).(*zng.TypeSet)
 		if !ok {
 			return nil, fmt.Errorf("set decorator not of type set: %T", cast)
 		}
@@ -477,7 +477,7 @@ func (a Analyzer) convertEnum(zctx *Context, val *ast.Enum, cast zng.Type) (Valu
 	if cast == nil {
 		return nil, fmt.Errorf("identifier %q must be enum and requires decorator", val.Name)
 	}
-	enum, ok := zng.AliasedType(cast).(*zng.TypeEnum)
+	enum, ok := zng.AliasOf(cast).(*zng.TypeEnum)
 	if !ok {
 		return nil, fmt.Errorf("identifier %q is enum and incompatible with type %q", val.Name, cast.ZSON())
 	}
@@ -496,7 +496,7 @@ func (a Analyzer) convertEnum(zctx *Context, val *ast.Enum, cast zng.Type) (Valu
 func (a Analyzer) convertMap(zctx *Context, m *ast.Map, cast zng.Type) (Value, error) {
 	var keyType, valType zng.Type
 	if cast != nil {
-		typ, ok := zng.AliasedType(cast).(*zng.TypeMap)
+		typ, ok := zng.AliasOf(cast).(*zng.TypeMap)
 		if !ok {
 			return nil, errors.New("map decorator not of type map")
 		}
@@ -536,7 +536,7 @@ func (a Analyzer) convertMap(zctx *Context, m *ast.Map, cast zng.Type) (Value, e
 
 func (a Analyzer) convertTypeValue(zctx *Context, tv *ast.TypeValue, cast zng.Type) (Value, error) {
 	if cast != nil {
-		if _, ok := zng.AliasedType(cast).(*zng.TypeOfType); !ok {
+		if _, ok := zng.AliasOf(cast).(*zng.TypeOfType); !ok {
 			return nil, fmt.Errorf("cannot apply decorator (%q) to a type value", cast.ZSON())
 		}
 	}

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -63,7 +63,7 @@ func (b *Builder) buildValue(val Value) error {
 }
 
 func (b *Builder) BuildPrimitive(val *Primitive) error {
-	switch zng.AliasedType(val.Type).(type) {
+	switch zng.AliasOf(val.Type).(type) {
 	case *zng.TypeOfUint8, *zng.TypeOfUint16, *zng.TypeOfUint32, *zng.TypeOfUint64:
 		v, err := strconv.ParseUint(val.Text, 10, 64)
 		if err != nil {

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -617,7 +617,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 	case reflect.String:
 		// XXX We bundle string, bstring, type, error all into string.
 		// See issue #1853.
-		switch zng.AliasedType(zv.Type) {
+		switch zng.AliasOf(zv.Type) {
 		case zng.TypeString, zng.TypeBstring, zng.TypeType, zng.TypeError:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -630,7 +630,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 		v.SetString(x)
 		return err
 	case reflect.Bool:
-		if zng.AliasedType(zv.Type) != zng.TypeBool {
+		if zng.AliasOf(zv.Type) != zng.TypeBool {
 			return incompatTypeError(zv.Type, v)
 		}
 		if zv.Bytes == nil {
@@ -641,7 +641,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 		v.SetBool(x)
 		return err
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		switch zng.AliasedType(zv.Type) {
+		switch zng.AliasOf(zv.Type) {
 		case zng.TypeInt8, zng.TypeInt16, zng.TypeInt32, zng.TypeInt64:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -654,7 +654,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 		v.SetInt(x)
 		return err
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		switch zng.AliasedType(zv.Type) {
+		switch zng.AliasOf(zv.Type) {
 		case zng.TypeUint8, zng.TypeUint16, zng.TypeUint32, zng.TypeUint64:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -668,7 +668,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 		return err
 	case reflect.Float32, reflect.Float64:
 		// TODO: zng.TypeFloat32 when it lands
-		switch zng.AliasedType(zv.Type) {
+		switch zng.AliasOf(zv.Type) {
 		case zng.TypeFloat64:
 		default:
 			return incompatTypeError(zv.Type, v)
@@ -686,7 +686,7 @@ func (u *UnmarshalZNGContext) decodeAny(zv zng.Value, v reflect.Value) error {
 }
 
 func (u *UnmarshalZNGContext) decodeIP(zv zng.Value, v reflect.Value) error {
-	if zng.AliasedType(zv.Type) != zng.TypeIP {
+	if zng.AliasOf(zv.Type) != zng.TypeIP {
 		return incompatTypeError(zv.Type, v)
 	}
 	if zv.Bytes == nil {
@@ -699,7 +699,7 @@ func (u *UnmarshalZNGContext) decodeIP(zv zng.Value, v reflect.Value) error {
 }
 
 func (u *UnmarshalZNGContext) decodeRecord(zv zng.Value, sval reflect.Value) error {
-	recType, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord)
+	recType, ok := zng.AliasOf(zv.Type).(*zng.TypeRecord)
 	if !ok {
 		return errors.New("not a record")
 	}
@@ -730,7 +730,7 @@ func (u *UnmarshalZNGContext) decodeRecord(zv zng.Value, sval reflect.Value) err
 }
 
 func (u *UnmarshalZNGContext) decodeArray(zv zng.Value, arrVal reflect.Value) error {
-	arrType, ok := zng.AliasedType(zv.Type).(*zng.TypeArray)
+	arrType, ok := zng.AliasOf(zv.Type).(*zng.TypeArray)
 	if !ok {
 		return errors.New("not an array")
 	}

--- a/zson/reader.go
+++ b/zson/reader.go
@@ -46,7 +46,7 @@ func (r *Reader) Read() (*zng.Record, error) {
 	}
 	// ZSON can represent value streams that aren't records,
 	// but we handle only top-level records here.
-	if _, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord); !ok {
+	if _, ok := zng.AliasOf(zv.Type).(*zng.TypeRecord); !ok {
 		return nil, fmt.Errorf("top-level ZSON value not a record: %s", zv.Type.ZSON())
 	}
 	return zng.NewRecordFromType(zv.Type, zv.Bytes), nil


### PR DESCRIPTION
This commit fixes a bug where the type name of top-level records
was lost in shaping and in "put .".  The fix is to use zng.Type
instead of zng.TypeRecord where relevant and assert that said Type
is a TypeRecord optionally behind an alias.

Fixes #2379