### PR TITLE
allow typedefs to be redefined

### DIFF
--- a/zng/docs/zson.md
+++ b/zng/docs/zson.md
@@ -233,11 +233,11 @@ throughout.  That said, external type definitions _may_ vary and an implementati
 must properly handle changing external name by updating the binding between
 the type name and the new type for all subsequent values in the sequence.
 
-> Handling type definition conflicts outside of the scope of ZSON, but an implementation
+> Handling type definition conflicts is outside of the scope of ZSON, but an implementation
 > may police all external definitions so that "type conflicts" are rejected with
-> an error, or it may arrange to name types with a version number, e.g., example.0,
-> example.1, etc then have operators that understand that example.* are all variations
-> of a commonly named type "example."
+> an error, or it may arrange to name types with a version number (e.g., example.0,
+> example.1, etc.), and then have operators that understand that example.* are all variations
+> of a commonly named type "example".
 
 > Note that the semantics of type definitions allows an implementation to "reset" the type
 > context at any point in the sequence causing it to re-emit tyepdefs for each type used

--- a/zng/docs/zson.md
+++ b/zng/docs/zson.md
@@ -1,16 +1,12 @@
 # ZSON - ZNG Structured Object-record Notation
 
-> ### DRAFT 12/2/20
+> ### DRAFT 3/21/21
 > ### Note: This specification is in BETA development.
-> We plan to have a final form established by Spring 2021.
+> We plan to have a final form established soon.
 >
 > ZSON is intended as a literal superset of JSON and NDJSON syntax.
 > If there is anything in this document that conflicts with this goal,
 > please let us know and we will address it.
->
-> Regarding the state of the implementation of the ZSON format in zq:
-> * An input reader is not yet implemented,
-> * End-of-sequence markers are not yet conveyed in the writer.
 
 * [1. Introduction](#1-introduction)
   + [1.1 Some Examples](#11-some-examples)
@@ -166,10 +162,8 @@ the decorator implies the missing names, e.g.,
 
 ## 2. The ZSON Data Model
 
-ZSON data is defined as an ordered sequence of one or more typed data values
-separated at any point or not at all by an end-of-sequence marker `.`.
-Each sequence implies a type context as described below and the `.` marker causes
-a new type context to be established for subsequent elements of the sequence.
+ZSON data is defined as an ordered sequence of one or more typed data values.
+A sequence implies a type context as described below.
 
 Each value's type is either a "primitive type", a "complex type", the "type type",
 or the "null type".
@@ -219,9 +213,7 @@ Type definitions embedded in the data sequence bind a name to a type
 so that later values can refer to their type by name instead of explicitly
 enumerating the type of every element.  A collection of bindings from name to
 type is called a "type context."  As bindings are read from a sequence, they
-create the sequence's type context.  The context may be reset at any point in
-the sequence, implying that a new binding must be defined from that point on
-for each unique use of a type.
+create the sequence's type context.
 
 A type name is either internal or external.  Internal names are used exclusively
 to organize the types in the type context within the data sequence itself and have
@@ -236,9 +228,23 @@ Internal type names are represented by integers while external names are
 represented by identifiers.  When ZSON data is organized into a sequence
 comprised of two or more subsequences where each subsequence has its own
 type context, the internal names may be "reused" across type contexts to refer
-to different types but external names must have the same type value across
-subsequences.  It is a "type mismatch" error if an external name has different
-type values across subsequences.
+to different types but external names should generally have the same type value
+throughout.  That said, external type definitions _may_ vary and an implementation
+must properly handle changing external name by updating the binding between
+the type name and the new type for all subsequent values in the sequence.
+
+> Handling type definition conflicts outside of the scope of ZSON, but an implementation
+> may police all external definitions so that "type conflicts" are rejected with
+> an error, or it may arrange to name types with a version number, e.g., example.0,
+> example.1, etc then have operators that understand that example.* are all variations
+> of a commonly named type "example."
+
+> Note that the semantics of type definitions allows an implementation to "reset" the type
+> context at any point in the sequence causing it to re-emit tyepdefs for each type used
+> thereafter, thus creating a seekable synchronization point in a ZSON data stream.  That said,
+> an implementation would typically not do this for a ZSON sequence but use similar
+> patterns in ZNG and ZST to have seekable data footprints that are far more
+> efficient than ZSON.
 
 ## 3. The ZSON Format
 

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -153,9 +153,6 @@ func (a Analyzer) enterTypeDef(zctx *Context, name string, typ zng.Type) (*zng.T
 		if alias, err = zctx.LookupTypeAlias(name, typ); err != nil {
 			return nil, err
 		}
-		if existing, ok := a[name]; ok && existing != alias {
-			return nil, fmt.Errorf("type %q redefined from %q to %q", name, existing.ZSON(), typ.ZSON())
-		}
 		typ = alias
 	}
 	a[name] = typ

--- a/zson/context.go
+++ b/zson/context.go
@@ -190,17 +190,11 @@ func (c *Context) LookupTypeDef(name string) *zng.TypeAlias {
 }
 
 func (c *Context) LookupTypeAlias(name string, target zng.Type) (*zng.TypeAlias, error) {
-	tmp := zng.TypeAlias{Name: name, Type: target}
-	key := tmp.ZSON()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if typ, ok := c.toType[key]; ok {
-		alias := typ.(*zng.TypeAlias)
-		if zng.SameType(alias.Type, target) {
+	if alias, ok := c.typedefs[name]; ok {
+		if alias.Type == target {
 			return alias, nil
-		} else {
-			// XXX This should go.  See issue #2202.
-			return nil, ErrAliasExists
 		}
 	}
 	typ := zng.NewTypeAlias(c.nextIDWithLock(), name, target)

--- a/zson/ztests/dynamic-typedef-zng.yaml
+++ b/zson/ztests/dynamic-typedef-zng.yaml
@@ -1,0 +1,14 @@
+script: |
+  zq -B - | zq -z -
+
+inputs:
+  - name: stdin
+    data: &data |
+      {x:1} (=foo)
+      {x:2} (foo)
+      {x:"hello"} (=foo)
+      {x:"world"} (foo)
+
+outputs:
+  - name: stdout
+    data: *data

--- a/zson/ztests/dynamic-typedef.yaml
+++ b/zson/ztests/dynamic-typedef.yaml
@@ -1,0 +1,9 @@
+zql: "*"
+
+input: &input |
+  {x:1} (=foo)
+  {x:2} (foo)
+  {x:"hello"} (=foo)
+  {x:"world"} (foo)
+
+output: *input


### PR DESCRIPTION
This commit relaxes the constraint that type names cannot be redefined
to a different type.  This follows the Z design principle of dealing
with whatever the user or client throws at the system as best we can.

The problem of schema versioning is outside the scope of the ZSON
format and can be solved at a higher layer with the appropriate Z
building blocks.

We also removed the end-of-sequence concept from the ZSON spec as
it is not relevant here as the definitions of type contexts and
redefinable types allows an implementation to create a seekable output.

Closes #1568