### PR TITLE
add missing(), has(), and nameof()

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -386,7 +386,7 @@ func compileShaper(zctx *resolver.Context, scope *Scope, node ast.Call) (*expr.S
 }
 
 func compileCall(zctx *resolver.Context, scope *Scope, call ast.Call) (expr.Evaluator, error) {
-	// For now, we special case stateful functions here.  We shuold generalize this
+	// For now, we special case stateful functions here.  We should generalize this
 	// as we will add many more stateful functions and also resolve this
 	// the changes to create running aggegation functions from reducers.
 	// XXX See issue #1259.
@@ -426,7 +426,7 @@ func compileCall(zctx *resolver.Context, scope *Scope, call ast.Call) (expr.Eval
 	nargs := len(call.Args)
 	fn, root, err := function.New(zctx.Context, call.Name, nargs)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", call.Name, err)
+		return nil, fmt.Errorf("%s(): %w", call.Name, err)
 	}
 	args := call.Args
 	if root {
@@ -434,7 +434,7 @@ func compileCall(zctx *resolver.Context, scope *Scope, call ast.Call) (expr.Eval
 	}
 	exprs, err := compileExprs(zctx, scope, args)
 	if err != nil {
-		return nil, fmt.Errorf("%s: bad argument: %w", call.Name, err)
+		return nil, fmt.Errorf("%s(): bad argument: %w", call.Name, err)
 	}
 	return expr.NewCall(zctx, fn, exprs), nil
 }

--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -403,9 +403,21 @@ func compileCall(zctx *resolver.Context, scope *Scope, call ast.Call) (expr.Eval
 	case call.Name == "exists":
 		exprs, err := compileExprs(zctx, scope, call.Args)
 		if err != nil {
-			return nil, fmt.Errorf("exists: bad argument: %w", err)
+			return nil, fmt.Errorf("exists(): bad argument: %w", err)
 		}
 		return expr.NewExists(zctx, exprs), nil
+	case call.Name == "missing":
+		exprs, err := compileExprs(zctx, scope, call.Args)
+		if err != nil {
+			return nil, fmt.Errorf("missing(): bad argument: %w", err)
+		}
+		return expr.NewMissing(exprs), nil
+	case call.Name == "has":
+		exprs, err := compileExprs(zctx, scope, call.Args)
+		if err != nil {
+			return nil, fmt.Errorf("has(): bad argument: %w", err)
+		}
+		return expr.NewHas(exprs), nil
 	case call.Name == "unflatten":
 		return expr.NewUnflattener(zctx), nil
 	case isShaperFunc(call.Name):

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -760,6 +760,48 @@ func (e *Exists) Eval(rec *zng.Record) (zng.Value, error) {
 	return zng.True, nil
 }
 
+type Missing struct {
+	exprs []Evaluator
+}
+
+func NewMissing(exprs []Evaluator) *Missing {
+	return &Missing{exprs}
+}
+
+func (m *Missing) Eval(rec *zng.Record) (zng.Value, error) {
+	for _, e := range m.exprs {
+		_, err := e.Eval(rec)
+		if err != nil {
+			if err == zng.ErrMissing {
+				return zng.True, nil
+			}
+			return zng.Value{}, err
+		}
+	}
+	return zng.False, nil
+}
+
+type Has struct {
+	exprs []Evaluator
+}
+
+func NewHas(exprs []Evaluator) *Has {
+	return &Has{exprs}
+}
+
+func (h *Has) Eval(rec *zng.Record) (zng.Value, error) {
+	for _, e := range h.exprs {
+		_, err := e.Eval(rec)
+		if err != nil {
+			if err == zng.ErrMissing {
+				return zng.False, nil
+			}
+			return zng.Value{}, err
+		}
+	}
+	return zng.True, nil
+}
+
 func NewCast(expr Evaluator, typ zng.Type) (Evaluator, error) {
 	// XXX should handle alias casts... need type context.
 	// compile is going to need a local type context to create literals

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -770,8 +770,7 @@ func NewMissing(exprs []Evaluator) *Missing {
 
 func (m *Missing) Eval(rec *zng.Record) (zng.Value, error) {
 	for _, e := range m.exprs {
-		_, err := e.Eval(rec)
-		if err != nil {
+		if _, err := e.Eval(rec); err != nil {
 			if err == zng.ErrMissing {
 				return zng.True, nil
 			}
@@ -791,8 +790,7 @@ func NewHas(exprs []Evaluator) *Has {
 
 func (h *Has) Eval(rec *zng.Record) (zng.Value, error) {
 	for _, e := range h.exprs {
-		_, err := e.Eval(rec)
-		if err != nil {
+		if _, err := e.Eval(rec); err != nil {
 			if err == zng.ErrMissing {
 				return zng.False, nil
 			}

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -163,7 +163,6 @@ func (*nameOf) Call(args []zng.Value) (zng.Value, error) {
 	typ := args[0].Type
 	if alias, ok := typ.(*zng.TypeAlias); ok {
 		// XXX GC
-		//fmt.Println("NAMEOF", typ.ZSON())
 		return zng.Value{zng.TypeString, zng.EncodeString(alias.Name)}, nil
 	}
 	return zng.Value{}, zng.ErrMissing

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -85,6 +85,8 @@ func New(zctx *zson.Context, name string, narg int) (Interface, bool, error) {
 		f = &trunc{}
 	case "typeof":
 		f = &typeOf{zctx}
+	case "nameof":
+		f = &nameOf{}
 	case "fields":
 		typ := zctx.LookupTypeArray(zng.TypeString)
 		f = &fields{zctx: zctx, typ: typ}
@@ -153,6 +155,18 @@ type typeOf struct {
 func (t *typeOf) Call(args []zng.Value) (zng.Value, error) {
 	typ := args[0].Type
 	return t.zctx.LookupTypeValue(typ), nil
+}
+
+type nameOf struct{}
+
+func (*nameOf) Call(args []zng.Value) (zng.Value, error) {
+	typ := args[0].Type
+	if alias, ok := typ.(*zng.TypeAlias); ok {
+		// XXX GC
+		//fmt.Println("NAMEOF", typ.ZSON())
+		return zng.Value{zng.TypeString, zng.EncodeString(alias.Name)}, nil
+	}
+	return zng.Value{}, zng.ErrMissing
 }
 
 type isErr struct{}

--- a/expr/ztests/has.yaml
+++ b/expr/ztests/has.yaml
@@ -1,0 +1,10 @@
+zql: has(x)
+
+input: |
+  {x:1}
+  {y:1}
+  {x:"foo",y:1,z:2}
+
+output: |
+  {x:1}
+  {x:"foo",y:1,z:2}

--- a/expr/ztests/missing.yaml
+++ b/expr/ztests/missing.yaml
@@ -1,0 +1,15 @@
+zql: put missingX=missing(x),missingType=missing(nameof(.))
+
+input: |
+  {x:1}
+  {x:1} (=foo)
+  {y:1}
+  {x:"foo",y:1,z:2}
+  {x:"foo",y:1,z:2} (=bar)
+
+output: |
+  {x:1,missingX:false,missingType:true}
+  {x:1,missingX:false,missingType:false}
+  {y:1,missingX:true,missingType:true}
+  {x:"foo",y:1,z:2,missingX:false,missingType:true}
+  {x:"foo",y:1,z:2,missingX:false,missingType:false}


### PR DESCRIPTION
This commit adds some sorely needed functions that will be useful for
data discovery, exploration, classification, and shaping.  missing()
returns true iff any of the arguments are missing.  has() returns
true iff all of the arguments are not missing.  nameof() returns
the type name of the single expression if the type is an alias;
otherwise, it returns missing.