### PR TITLE
Simplify Suricata shaper

### DIFF
--- a/ppl/zqd/ingest/pcap.go
+++ b/ppl/zqd/ingest/pcap.go
@@ -43,7 +43,7 @@ type PcapOp interface {
 var suricataShaper = compiler.MustParseProc(
 	`type alert = {event_type:bstring,src_ip:ip,src_port:port=(uint16),dest_ip:ip,dest_port:port=(uint16),vlan:[uint16],proto:bstring,app_proto:bstring,alert:{severity:uint16,signature:bstring,category:bstring,action:bstring,signature_id:uint64,gid:uint64,rev:uint64,metadata:{signature_severity:[bstring],former_category:[bstring],attack_target:[bstring],deployment:[bstring],affected_product:[bstring],created_at:[bstring],performance_impact:[bstring],updated_at:[bstring],malware_family:[bstring],tag:[bstring]}},flow_id:uint64,pcap_cnt:uint64,timestamp:time,tx_id:uint64,icmp_code:uint64,icmp_type:uint64,tunnel:{src_ip:ip,src_port:port=(uint16),dest_ip:ip,dest_port:port=(uint16),proto:bstring,depth:uint64},community_id:bstring}
 
-put timestamp=iso(timestamp) | put . = shape(alert) | rename ts=timestamp
+put . = shape(alert) | rename ts=timestamp
 `)
 
 type ClearableStore interface {


### PR DESCRIPTION
This is a change similar spirit to what I did with the Zeek shaper in #2368. I tested this out by extracting the modified shaper from the Go and running it at the shell to confirm it creates ZSON that's byte-for-byte equivalent to the ones output from the prior shaper config as shown in the verification of #1871 

```
$ zq -Z -I suricata-shaper-simplified.zed '| sort -r ts' eve.json > eve-shaped-simplified.zson

$ ls -l
-rw-r--r--    1 phil  staff   4948159547 Mar 23 07:49 eve-shaped-simplified.zson
-rw-r--r--    1 phil  staff   4948159547 Mar 22 13:32 eve-shaped.zson

$ diff eve-shaped-simplified.zson eve-shaped.zson
[no output]
```