### PR TITLE
allow record index by string as l-value

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -162,7 +162,7 @@ func semBinary(scope *Scope, e *ast.BinaryExpr) (ast.Expr, error) {
 		return nil, err
 	}
 	// If we index a root record with a string constant, then just
-	// extend the path...
+	// extend the path.
 	if op == "[" {
 		if path := isRootIndex(scope, lhs, rhs); path != nil {
 			return path, nil
@@ -191,10 +191,8 @@ func isStringConst(scope *Scope, e ast.Expr) (string, bool) {
 		return p.Text, true
 	}
 	if ref, ok := e.(*ast.Ref); ok {
-		if p := scope.Lookup(ref.Name); p != nil {
-			if c, ok := p.(*ast.Const); ok {
-				return isStringConst(scope, c.Expr)
-			}
+		if c, ok := scope.Lookup(ref.Name).(*ast.Const); ok {
+			return isStringConst(scope, c.Expr)
 		}
 	}
 	return "", false

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -161,10 +161,10 @@ func semBinary(scope *Scope, e *ast.BinaryExpr) (ast.Expr, error) {
 	if err != nil {
 		return nil, err
 	}
-	// If we index a path expression with a string constant, then just
+	// If we index a root record with a string constant, then just
 	// extend the path...
 	if op == "[" {
-		if path := isPathIndex(scope, lhs, rhs); path != nil {
+		if path := isRootIndex(scope, lhs, rhs); path != nil {
 			return path, nil
 		}
 	}
@@ -176,8 +176,8 @@ func semBinary(scope *Scope, e *ast.BinaryExpr) (ast.Expr, error) {
 	}, nil
 }
 
-func isPathIndex(scope *Scope, lhs, rhs ast.Expr) *ast.Path {
-	if path, ok := lhs.(*ast.Path); ok {
+func isRootIndex(scope *Scope, lhs, rhs ast.Expr) *ast.Path {
+	if path, ok := lhs.(*ast.Path); ok && len(path.Name) == 0 {
 		if s, ok := isStringConst(scope, rhs); ok {
 			path.Name = append(path.Name, s)
 			return path
@@ -401,7 +401,7 @@ func semField(scope *Scope, e ast.Expr) (ast.Expr, error) {
 			if err != nil {
 				return nil, err
 			}
-			if path := isPathIndex(scope, lhs, rhs); path != nil {
+			if path := isRootIndex(scope, lhs, rhs); path != nil {
 				return path, nil
 			}
 			return &ast.BinaryExpr{

--- a/compiler/ztests/path-index.yaml
+++ b/compiler/ztests/path-index.yaml
@@ -1,0 +1,7 @@
+zql: 'put .["x.y"]=to_lower(.["x.y"])'
+
+input: |
+  {"x.y":"Hello, World"}
+
+output: |
+  {"x.y":"hello, world"}

--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -433,10 +433,14 @@ func (c *canon) fieldpath(path []string) {
 		return
 	}
 	for k, s := range path {
-		if k != 0 {
-			c.write(".")
+		if zng.IsIdentifier(s) {
+			if k != 0 {
+				c.write(".")
+			}
+			c.write(s)
+		} else {
+			c.write("[%q]", s)
 		}
-		c.write(s)
 	}
 }
 

--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -439,6 +439,9 @@ func (c *canon) fieldpath(path []string) {
 			}
 			c.write(s)
 		} else {
+			if k == 0 {
+				c.write(".")
+			}
 			c.write("[%q]", s)
 		}
 	}


### PR DESCRIPTION
This commit fixes a bug where l-values could not be index operations
with fields referenced as string, e.g., put .["x"] = 123.
The fix is to detect this case in the semantic pass and extend
the field-reference path with the string constant.

Fixes #2326 

