### PR TITLE
remove ztest support for multiple inputs to in-process tests

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -28,7 +28,7 @@ func testSuccessful(t *testing.T, e string, record string, expect zng.Value) {
 	require.NoError(t, err)
 	zt := &ztest.ZTest{
 		ZQL:    fmt.Sprintf("cut result = %s", e),
-		Input:  []string{record},
+		Input:  record,
 		Output: val + "\n",
 	}
 	t.Run(e, func(t *testing.T) {
@@ -45,7 +45,7 @@ func testError(t *testing.T, e string, record string, expectErr error, descripti
 	}
 	zt := &ztest.ZTest{
 		ZQL:     fmt.Sprintf("cut result = %s", e),
-		Input:   []string{record},
+		Input:   record,
 		Output:  "",
 		ErrorRE: expectErr.Error(),
 	}

--- a/proc/sort/sort_test.go
+++ b/proc/sort/sort_test.go
@@ -199,7 +199,7 @@ func TestSortExternal(t *testing.T) {
 	output := makeTzng(ss)
 	(&ztest.ZTest{
 		ZQL:         "sort s",
-		Input:       []string{input},
+		Input:       input,
 		Output:      output,
 		OutputFlags: "-f tzng",
 	}).Run(t, "", "", "", "")

--- a/zq_test.go
+++ b/zq_test.go
@@ -215,14 +215,12 @@ func findInputs(t *testing.T, dirs map[string]struct{}, script string, isValidIn
 			}
 			// Normalize the diffrent kinds of test inputs into
 			// a single pattern.
-			for _, input := range bundle.Test.Input {
-				if isValidInput(input) {
-					out = append(out, ztest.Bundle{
-						TestName: bundle.TestName,
-						FileName: bundle.FileName,
-						Test:     boomerang(script, input),
-					})
-				}
+			if input := bundle.Test.Input; isValidInput(input) {
+				out = append(out, ztest.Bundle{
+					TestName: bundle.TestName,
+					FileName: bundle.FileName,
+					Test:     boomerang(script, input),
+				})
 			}
 			for _, input := range bundle.Test.Inputs {
 				if input.Data != nil && isValidInput(*input.Data) {

--- a/ztests/suite/input/multiple.yaml
+++ b/ztests/suite/input/multiple.yaml
@@ -1,11 +1,9 @@
 zql: 'count()'
 
-input:
-  - !!binary |
-      9gEFY291bnQDFwIEAv8=
-
-  - !!binary |
-      9gEFY291bnQDFwIEAv8=
+# This is the concatenation of two identical ZNG streams generated with
+# `bash -c '(zq - <<<{a:1}; zq - <<<{a:1}) | base64'`.
+input: !!binary |
+  9gEBYQcXAgQC//YBAWEHFwIEAv8=
 
 output-flags: -f tzng
 


### PR DESCRIPTION
This feature isn't worth its weight. It's only used in one test, and we can write that test without it.