### PR TITLE
disable postpcap-suricata flaky test

### DIFF
--- a/ppl/zqd/ztests/archivestore/postpcap-suricata.yaml
+++ b/ppl/zqd/ztests/archivestore/postpcap-suricata.yaml
@@ -1,3 +1,5 @@
+skip: true
+
 script: |
   source services.sh
   zapi -h $ZQD_HOST -s testsp postpcap -k archivestore -f alerts.pcap >/dev/null


### PR DESCRIPTION
This test is flaky and many of us spend wasted emotion and time looking through the logs of a failed test only to discover postpcap-suricata was the culprit.  This test will be resurrected in `brimcap` so we can disable it here for now...

