### PR TITLE
fix locking bug in zson context

### DIFF
--- a/expr/ztests/is-late-binding.yaml
+++ b/expr/ztests/is-late-binding.yaml
@@ -1,0 +1,11 @@
+zql: is(type(foo))
+
+input: |
+  {x:1}
+  {x:2} (=foo)
+  {x:3}
+  {x:4} (foo)
+
+output: |
+  {x:2} (=foo)
+  {x:4} (foo)

--- a/zson/context.go
+++ b/zson/context.go
@@ -254,11 +254,10 @@ func (c *Context) LookupByName(zson string) (zng.Type, error) {
 	// each component of a nested type.
 	c.mu.Unlock()
 	typ, err := ParseType(c, zson)
+	c.mu.Lock()
 	if err != nil {
-		c.mu.Lock()
 		return nil, err
 	}
-	c.mu.Lock()
 	// ParseType will ensure the canonical zson is in the toType table,
 	// but the zson argument here may be any conforming zson type string.
 	// Since this string may appear repeatedly (e.g., type values

--- a/zson/context.go
+++ b/zson/context.go
@@ -255,6 +255,7 @@ func (c *Context) LookupByName(zson string) (zng.Type, error) {
 	c.mu.Unlock()
 	typ, err := ParseType(c, zson)
 	if err != nil {
+		c.mu.Lock()
 		return nil, err
 	}
 	c.mu.Lock()


### PR DESCRIPTION
This commit fixes a bug where unlock was called on an unlocked lock.

This was triggered when a typedef name was accessed that did
not yet exist.  We added a test to exercise this path with an
issue() function that looks for a type that is not defuned until
the second record in the input.