### PR TITLE
ztest: Fix zq lookup

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -646,7 +646,7 @@ func lookupzq(path string) (string, error) {
 		if err == nil {
 			return zq, nil
 		}
-		if !errors.Is(err, exec.ErrNotFound) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return "", err
 		}
 	}


### PR DESCRIPTION
When checking if a path is an executable exec will return a wrapped
os.ErrNotExist error and NOT a wrapped exec.ErrNotFound. Fix this.