### PR TITLE
Add zbuf.Reader post records method

### DIFF
--- a/zio/zngio/io.go
+++ b/zio/zngio/io.go
@@ -1,0 +1,35 @@
+package zngio
+
+import (
+	"io"
+
+	"github.com/brimsec/zq/zbuf"
+)
+
+type ioreader struct {
+	reader io.Reader
+	writer *io.PipeWriter
+}
+
+func IOReader(r zbuf.Reader, opts WriterOpts) io.ReadCloser {
+	pr, pw := io.Pipe()
+	i := &ioreader{reader: pr, writer: pw}
+	go i.run(r, NewWriter(pw, opts))
+	return i
+}
+
+func (i *ioreader) run(r zbuf.Reader, w zbuf.Writer) {
+	err := zbuf.Copy(w, r)
+	if err != nil {
+		i.writer.CloseWithError(err)
+	}
+	i.writer.Close()
+}
+
+func (i *ioreader) Read(b []byte) (int, error) {
+	return i.reader.Read(b)
+}
+
+func (i *ioreader) Close() error {
+	return i.writer.Close()
+}


### PR DESCRIPTION
Add a method for client.Connection that allows users to pass a stream of
records to be ingested into zqd. These changes are needed for the load command
in the upcoming brimcap repo.

Add zngio.IOReader that uses a zngio.Writer to transform a zbuf.Reader into an
io.Reader.