### PR TITLE
clean up zng.Record

### DIFF
--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -29,7 +29,7 @@ type Dir struct {
 	ext     string
 	stderr  io.Writer // XXX use warnings channel
 	opts    zio.WriterOpts
-	writers map[*zng.TypeRecord]zbuf.WriteCloser
+	writers map[zng.Type]zbuf.WriteCloser
 	paths   map[string]zbuf.WriteCloser
 	source  iosrc.Source
 }
@@ -61,7 +61,7 @@ func NewDirWithSource(ctx context.Context, dir iosrc.URI, prefix string, stderr 
 		ext:     e,
 		stderr:  stderr,
 		opts:    opts,
-		writers: make(map[*zng.TypeRecord]zbuf.WriteCloser),
+		writers: make(map[zng.Type]zbuf.WriteCloser),
 		paths:   make(map[string]zbuf.WriteCloser),
 		source:  source,
 	}, nil

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -177,5 +177,5 @@ func (c *Cutter) Eval(rec *zng.Record) (zng.Value, error) {
 	if out == nil {
 		return zng.Value{}, zng.ErrMissing
 	}
-	return zng.Value{out.Type, out.Raw}, nil
+	return out.Value, nil
 }

--- a/expr/dot.go
+++ b/expr/dot.go
@@ -10,7 +10,7 @@ import (
 type RootRecord struct{}
 
 func (r *RootRecord) Eval(rec *zng.Record) (zng.Value, error) {
-	return zng.Value{rec.Alias, rec.Raw}, nil
+	return rec.Value, nil
 }
 
 type DotExpr struct {

--- a/expr/dropper.go
+++ b/expr/dropper.go
@@ -46,7 +46,7 @@ func NewDropper(zctx *resolver.Context, fields []field.Static) *Dropper {
 }
 
 func (d *Dropper) newDropper(r *zng.Record) (*dropper, error) {
-	fields, fieldTypes := complementFields(d.fields, nil, r.Type)
+	fields, fieldTypes := complementFields(d.fields, nil, zng.TypeRecordOf(r.Type))
 	// If the set of dropped fields is equal to the all of record's
 	// fields, then there is no output for this input type.
 	// We return nil to block this input type.

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -24,7 +24,7 @@ func testSuccessful(t *testing.T, e string, record string, expect zng.Value) {
 	bytes := zcode.AppendPrimitive(nil, expect.Bytes)
 	rec := zng.NewRecord(typ, bytes)
 	formatter := zson.NewFormatter(0)
-	val, err := formatter.Format(zng.Value{rec.Type, rec.Raw})
+	val, err := formatter.Format(rec.Value)
 	require.NoError(t, err)
 	zt := &ztest.ZTest{
 		ZQL:    fmt.Sprintf("cut result = %s", e),

--- a/expr/filter.go
+++ b/expr/filter.go
@@ -40,7 +40,7 @@ func EvalAny(eval Boolean, recursive bool) Filter {
 	if !recursive {
 		return func(r *zng.Record) bool {
 			it := r.ZvalIter()
-			for _, c := range r.Type.Columns {
+			for _, c := range r.Columns() {
 				val, _, err := it.Next()
 				if err != nil {
 					return false
@@ -71,7 +71,7 @@ func EvalAny(eval Boolean, recursive bool) Filter {
 		return false
 	}
 	return func(r *zng.Record) bool {
-		return fn(r.Raw, r.Type.Columns)
+		return fn(r.Bytes, r.Columns())
 	}
 }
 
@@ -134,7 +134,7 @@ func SearchRecordString(term string) Filter {
 		// record columns for each unique record type.
 		match, ok := fieldNameCheck[r.Type]
 		if !ok {
-			nameIter.Init(r.Type)
+			nameIter.Init(zng.TypeRecordOf(r.Type))
 			for !nameIter.Done() {
 				if stringSearch(byteconv.UnsafeString(nameIter.Next()), term) {
 					match = true

--- a/expr/filter_test.go
+++ b/expr/filter_test.go
@@ -52,7 +52,7 @@ func runCasesHelper(t *testing.T, tzng string, cases []testcase, expectBufferFil
 			assert.NoError(t, err, "filter: %q", c.filter)
 			if f != nil {
 				assert.Equal(t, c.expected, f(rec),
-					"filter: %q\nrecord:\n%s", c.filter, hex.Dump(rec.Raw))
+					"filter: %q\nrecord:\n%s", c.filter, hex.Dump(rec.Bytes))
 			}
 
 			bf, err := runtime.AsBufferFilter()
@@ -67,8 +67,8 @@ func runCasesHelper(t *testing.T, tzng string, cases []testcase, expectBufferFil
 				// ZNG value message for rec, assembled here.
 				require.Less(t, rec.Type.ID(), 0x40)
 				buf := []byte{byte(rec.Type.ID())}
-				buf = zcode.AppendUvarint(buf, uint64(len(rec.Raw)))
-				buf = append(buf, rec.Raw...)
+				buf = zcode.AppendUvarint(buf, uint64(len(rec.Bytes)))
+				buf = append(buf, rec.Bytes...)
 				assert.Equal(t, expected, bf.Eval(zctx, buf),
 					"filter: %q\nbuffer:\n%s", c.filter, hex.Dump(buf))
 			}

--- a/expr/unflattener.go
+++ b/expr/unflattener.go
@@ -64,7 +64,7 @@ func (u *Unflattener) lookupBuilderAndType(in *zng.TypeRecord) (*builder.ColumnB
 // receiver's configuration.  If the resulting record would be empty, Apply
 // returns nil.
 func (u *Unflattener) Apply(in *zng.Record) (*zng.Record, error) {
-	b, typ, err := u.lookupBuilderAndType(in.Type)
+	b, typ, err := u.lookupBuilderAndType(zng.TypeRecordOf(in.Type))
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (u *Unflattener) Apply(in *zng.Record) (*zng.Record, error) {
 		return in, nil
 	}
 	b.Reset()
-	for iter := in.Raw.Iter(); !iter.Done(); {
+	for iter := in.Bytes.Iter(); !iter.Done(); {
 		zv, con, err := iter.Next()
 		if err != nil {
 			return nil, err
@@ -83,7 +83,7 @@ func (u *Unflattener) Apply(in *zng.Record) (*zng.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	return zng.NewRecordFromType(typ, zbytes), nil
+	return zng.NewRecord(typ, zbytes), nil
 }
 
 func (c *Unflattener) Eval(rec *zng.Record) (zng.Value, error) {
@@ -94,5 +94,5 @@ func (c *Unflattener) Eval(rec *zng.Record) (zng.Value, error) {
 	if out == nil {
 		return zng.Value{}, zng.ErrMissing
 	}
-	return zng.Value{out.Type, out.Raw}, nil
+	return out.Value, nil
 }

--- a/microindex/writer.go
+++ b/microindex/writer.go
@@ -159,7 +159,8 @@ func (w *Writer) Write(rec *zng.Record) error {
 		if err != nil {
 			return err
 		}
-		w.keyType = keys.Type
+		//XXX BUG should preserve typedefs?
+		w.keyType = zng.TypeRecordOf(keys.Type)
 		w.childField = uniqChildField(w.zctx, keys)
 	}
 	return w.writer.write(rec)

--- a/microindex/writer.go
+++ b/microindex/writer.go
@@ -159,7 +159,6 @@ func (w *Writer) Write(rec *zng.Record) error {
 		if err != nil {
 			return err
 		}
-		//XXX BUG should preserve typedefs?
 		w.keyType = zng.TypeRecordOf(keys.Type)
 		w.childField = uniqChildField(w.zctx, keys)
 	}

--- a/ppl/lake/import.go
+++ b/ppl/lake/import.go
@@ -279,7 +279,7 @@ func (dw *tsDirWriter) Write(rec *zng.Record) error {
 	// sorting.
 	rec.CopyBody()
 	dw.records = append(dw.records, rec)
-	dw.addBufSize(int64(len(rec.Raw)))
+	dw.addBufSize(int64(len(rec.Bytes)))
 	dw.touch()
 	if dw.chunkSizeEstimate() > dw.lk.LogSizeThreshold {
 		if err := dw.flush(); err != nil {

--- a/ppl/lake/import.go
+++ b/ppl/lake/import.go
@@ -277,7 +277,7 @@ func (dw *tsDirWriter) Write(rec *zng.Record) error {
 	// and slow down import. We should instead copy the raw record bytes into a
 	// recycled buffer and keep around an array of ts + byte-slice structs for
 	// sorting.
-	rec.CopyBody()
+	rec.CopyBytes()
 	dw.records = append(dw.records, rec)
 	dw.addBufSize(int64(len(rec.Bytes)))
 	dw.touch()

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -60,7 +60,7 @@ func (f *Fuser) Write(rec *zng.Record) error {
 }
 
 func (f *Fuser) stash(rec *zng.Record) error {
-	f.nbytes += len(rec.Raw)
+	f.nbytes += len(rec.Bytes)
 	if f.nbytes >= f.memMaxBytes {
 		var err error
 		f.spiller, err = spill.NewTempFile()

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -243,13 +243,13 @@ func (p *Proc) splice(left, right *zng.Record) (*zng.Record, error) {
 		// stream.
 		return left, nil
 	}
-	typ, err := p.combinedType(left.Type, right.Type)
+	typ, err := p.combinedType(zng.TypeRecordOf(left.Type), zng.TypeRecordOf(right.Type))
 	if err != nil {
 		return nil, err
 	}
-	n := len(left.Raw)
-	bytes := make([]byte, n+len(right.Raw))
-	copy(bytes, left.Raw)
-	copy(bytes[n:], right.Raw)
+	n := len(left.Bytes)
+	bytes := make([]byte, n+len(right.Bytes))
+	copy(bytes, left.Bytes)
+	copy(bytes[n:], right.Bytes)
 	return zng.NewRecord(typ, bytes), nil
 }

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -179,8 +179,8 @@ func (p *ProcTest) Expect(data zbuf.Batch) error {
 		if received.Type != expected.Type {
 			return fmt.Errorf("descriptor mismatch in record %d", i)
 		}
-		if bytes.Compare(received.Raw, expected.Raw) != 0 {
-			return fmt.Errorf("mismatch in record %d: %s vs %s", i, received.Raw, expected.Raw)
+		if bytes.Compare(received.Bytes, expected.Bytes) != 0 {
+			return fmt.Errorf("mismatch in record %d: %s vs %s", i, received.Bytes, expected.Bytes)
 		}
 	}
 
@@ -263,7 +263,7 @@ func TestOneProcWithWarnings(t *testing.T, zngin, zngout string, warnings []stri
 			r1 := recsout.Index(i)
 			r2 := result.Index(i)
 			// XXX could print something a lot pretter if/when this fails.
-			require.Equalf(t, r2.Raw, r1.Raw, "Expected record %d to match", i)
+			require.Equalf(t, r2.Bytes, r1.Bytes, "Expected record %d to match", i)
 		}
 	}
 }
@@ -303,7 +303,7 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 		r1 := batchout.Index(i)
 		r2 := result.Index(i)
 		// XXX could print something a lot pretter if/when this fails.
-		require.Equalf(t, string(r2.Raw), string(r1.Raw), "Expected record %d to match", i)
+		require.Equalf(t, string(r2.Bytes), string(r1.Bytes), "Expected record %d to match", i)
 	}
 }
 
@@ -327,11 +327,11 @@ func TestOneProcUnsorted(t *testing.T, zngin, zngout string, cmd string) {
 
 	require.Equal(t, recsout.Length(), result.Length(), "Got correct number of output records")
 	res := result.Records()
-	sort.Slice(res, func(i, j int) bool { return bytes.Compare(res[i].Raw, res[j].Raw) > 0 })
+	sort.Slice(res, func(i, j int) bool { return bytes.Compare(res[i].Bytes, res[j].Bytes) > 0 })
 	expected := recsout.Records()
-	sort.Slice(expected, func(i, j int) bool { return bytes.Compare(expected[i].Raw, expected[j].Raw) > 0 })
+	sort.Slice(expected, func(i, j int) bool { return bytes.Compare(expected[i].Bytes, expected[j].Bytes) > 0 })
 	for i := 0; i < len(res); i++ {
 		// XXX could print something a lot pretter if/when this fails.
-		require.Equalf(t, expected[i].Raw, res[i].Raw, "Expected record %d to match", i)
+		require.Equalf(t, expected[i].Bytes, res[i].Bytes, "Expected record %d to match", i)
 	}
 }

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -348,17 +348,18 @@ func (p *Proc) put(in *zng.Record) (*zng.Record, error) {
 		p.maybeWarn(err)
 		return in, nil
 	}
-	rule, err := p.lookupRule(in.Type, vals)
+	rule, err := p.lookupRule(zng.TypeRecordOf(in.Type), vals)
 	if err != nil {
 		return nil, err
 	}
 
-	bytes, err := rule.step.build(in.Raw, &p.builder, vals)
+	bytes, err := rule.step.build(in.Bytes, &p.builder, vals)
 	if err != nil {
 		return nil, err
 	}
-	return zng.NewRecordFromType(rule.typ, bytes), nil
+	return zng.NewRecord(rule.typ, bytes), nil
 }
+
 func (p *Proc) Pull() (zbuf.Batch, error) {
 	batch, err := p.parent.Pull()
 	if proc.EOS(batch, err) {

--- a/proc/rename/renamer.go
+++ b/proc/rename/renamer.go
@@ -67,14 +67,14 @@ func (r *Function) computeType(typ *zng.TypeRecord) (*zng.TypeRecord, error) {
 func (r *Function) Apply(in *zng.Record) (*zng.Record, error) {
 	id := in.Type.ID()
 	if _, ok := r.typeMap[id]; !ok {
-		typ, err := r.computeType(in.Type)
+		typ, err := r.computeType(zng.TypeRecordOf(in.Type))
 		if err != nil {
 			return nil, fmt.Errorf("rename: %w", err)
 		}
 		r.typeMap[id] = typ
 	}
 	out := in.Keep()
-	return zng.NewRecord(r.typeMap[id], out.Raw), nil
+	return zng.NewRecord(r.typeMap[id], out.Bytes), nil
 }
 
 func (r *Function) Warning() string { return "" }

--- a/proc/shape/shaper.go
+++ b/proc/shape/shaper.go
@@ -188,7 +188,7 @@ func (s *Shaper) update(rec *zng.Record) {
 	s.typeAnchor[rec.Type] = a
 }
 
-func (s *Shaper) needRecode(typ *zng.TypeRecord) (*zng.TypeRecord, error) {
+func (s *Shaper) needRecode(typ zng.Type) (*zng.TypeRecord, error) {
 	target, ok := s.recode[typ]
 	if !ok {
 		a := s.typeAnchor[typ]
@@ -205,7 +205,7 @@ func (s *Shaper) needRecode(typ *zng.TypeRecord) (*zng.TypeRecord, error) {
 	return target, nil
 }
 
-func (s *Shaper) lookupType(in *zng.TypeRecord) (*zng.TypeRecord, error) {
+func (s *Shaper) lookupType(in zng.Type) (*zng.TypeRecord, error) {
 	a, ok := s.typeAnchor[in]
 	if !ok {
 		return nil, errors.New("Shaper: unencountered type (this is a bug)")
@@ -260,15 +260,12 @@ func (s *Shaper) Read() (*zng.Record, error) {
 	if rec == nil || err != nil {
 		return nil, err
 	}
-	//XXX BUG?  Shaper lookup should be based on the type name not
-	// just the underlying record shape
-	recType := zng.TypeRecordOf(rec.Type)
-	typ, err := s.lookupType(recType)
+	typ, err := s.lookupType(rec.Type)
 	if err != nil {
 		return nil, err
 	}
 	bytes := rec.Bytes
-	targetType, err := s.needRecode(recType)
+	targetType, err := s.needRecode(rec.Type)
 	if err != nil {
 		return nil, err
 	}

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -110,7 +110,7 @@ func (p *Proc) recordsForOneRun() ([]*zng.Record, bool, error) {
 		for i := 0; i < l; i++ {
 			rec := batch.Index(i)
 			p.unseenFieldTracker.update(rec)
-			nbytes += len(rec.Raw)
+			nbytes += len(rec.Bytes)
 			// We're keeping records owned by batch so don't call Unref.
 			recs = append(recs, rec)
 		}
@@ -203,7 +203,7 @@ var intTypes = []zng.Type{
 }
 
 func GuessSortKey(rec *zng.Record) field.Static {
-	typ := rec.Type
+	typ := zng.TypeRecordOf(rec.Type)
 	if fld := firstOf(typ, intTypes); fld != "" {
 		return field.New(fld)
 	}

--- a/proc/sort/unseen.go
+++ b/proc/sort/unseen.go
@@ -24,11 +24,12 @@ func newUnseenFieldTracker(fields []expr.Evaluator) *unseenFieldTracker {
 }
 
 func (u *unseenFieldTracker) update(rec *zng.Record) {
-	if len(u.unseenFields) == 0 || u.seenTypes[rec.Type] {
+	recType := zng.TypeRecordOf(rec.Type)
+	if len(u.unseenFields) == 0 || u.seenTypes[recType] {
 		// Either have seen this type or nothing to unsee anymore.
 		return
 	}
-	u.seenTypes[rec.Type] = true
+	u.seenTypes[recType] = true
 	for field := range u.unseenFields {
 		v, _ := field.Eval(rec)
 		if !v.IsNil() {

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -49,7 +49,7 @@ func (p *Proc) appendUniq(out []*zng.Record, t *zng.Record) []*zng.Record {
 		p.last = t.Keep()
 		p.count = 1
 		return out
-	} else if bytes.Equal(t.Raw, p.last.Raw) {
+	} else if bytes.Equal(t.Bytes, p.last.Bytes) {
 		p.count++
 		return out
 	}

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -44,7 +44,7 @@ func readBatch(zr Reader, n int) (Batch, error) {
 		}
 		// Copy the underlying buffer (if volatile) because call to next
 		// reader.Next() may overwrite said buffer.
-		rec.CopyBody()
+		rec.CopyBytes()
 		recs = append(recs, rec)
 	}
 	if len(recs) == 0 {

--- a/zbuf/mapper.go
+++ b/zbuf/mapper.go
@@ -25,9 +25,7 @@ func (m *Mapper) Read() (*zng.Record, error) {
 	if rec == nil {
 		return nil, nil
 	}
-	//XXX BUG: this should use zng.TypeID(rec.Type) where zng.TypeID
-	// doesn't follow alias.  Or, we should have TypeIDOf()
-	id := rec.Type.ID()
+	id := zng.TypeID(rec.Type)
 	sharedType := m.mapper.Map(id)
 	if sharedType == nil {
 		sharedType, err = m.mapper.Enter(id, rec.Type)
@@ -36,6 +34,5 @@ func (m *Mapper) Read() (*zng.Record, error) {
 		}
 	}
 	rec.Type = sharedType
-	rec.Type = zng.AliasOf(sharedType).(*zng.TypeRecord)
 	return rec, nil
 }

--- a/zbuf/mapper.go
+++ b/zbuf/mapper.go
@@ -25,15 +25,17 @@ func (m *Mapper) Read() (*zng.Record, error) {
 	if rec == nil {
 		return nil, nil
 	}
+	//XXX BUG: this should use zng.TypeID(rec.Type) where zng.TypeID
+	// doesn't follow alias.  Or, we should have TypeIDOf()
 	id := rec.Type.ID()
 	sharedType := m.mapper.Map(id)
 	if sharedType == nil {
-		sharedType, err = m.mapper.Enter(id, rec.Alias)
+		sharedType, err = m.mapper.Enter(id, rec.Type)
 		if err != nil {
 			return nil, err
 		}
 	}
-	rec.Alias = sharedType
+	rec.Type = sharedType
 	rec.Type = zng.AliasOf(sharedType).(*zng.TypeRecord)
 	return rec, nil
 }

--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -50,7 +50,7 @@ func totalOrderCompare(fn expr.CompareFn) expr.CompareFn {
 	return func(a, b *zng.Record) int {
 		cmp := fn(a, b)
 		if cmp == 0 {
-			return bytes.Compare(a.Raw, b.Raw)
+			return bytes.Compare(a.Bytes, b.Bytes)
 		}
 		return cmp
 	}
@@ -97,7 +97,7 @@ func MergeByTs(ctx context.Context, pullers []Puller, order Order) *Merger {
 		if aTs > bTs {
 			return 1
 		}
-		return bytes.Compare(a.Raw, b.Raw)
+		return bytes.Compare(a.Bytes, b.Bytes)
 	}
 	return NewMerger(ctx, pullers, cmp)
 }

--- a/zbuf/peeker_test.go
+++ b/zbuf/peeker_test.go
@@ -35,28 +35,28 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(rec1.Raw, rec2.Raw) {
+	if !bytes.Equal(rec1.Bytes, rec2.Bytes) {
 		t.Error("rec1 != rec2")
 	}
 	rec3, err := peeker.Read()
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(rec1.Raw, rec3.Raw) {
+	if !bytes.Equal(rec1.Bytes, rec3.Bytes) {
 		t.Error("rec1 != rec3")
 	}
 	rec4, err := peeker.Peek()
 	if err != nil {
 		t.Error(err)
 	}
-	if bytes.Equal(rec3.Raw, rec4.Raw) {
+	if bytes.Equal(rec3.Bytes, rec4.Bytes) {
 		t.Error("rec3 == rec4")
 	}
 	rec5, err := peeker.Read()
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(rec4.Raw, rec5.Raw) {
+	if !bytes.Equal(rec4.Bytes, rec5.Bytes) {
 		t.Error("rec4 != rec5")
 	}
 }

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -141,7 +141,7 @@ func (s *scanner) Read() (*zng.Record, error) {
 		atomic.AddInt64(&s.stats.RecordsMatched, 1)
 		// Copy the underlying buffer (if volatile) because next call to
 		// reader.Next() may overwrite said buffer.
-		rec.CopyBody()
+		rec.CopyBytes()
 		return rec, nil
 	}
 }

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -131,13 +131,13 @@ func (s *scanner) Read() (*zng.Record, error) {
 		if err != nil || rec == nil {
 			return nil, err
 		}
-		atomic.AddInt64(&s.stats.BytesRead, int64(len(rec.Raw)))
+		atomic.AddInt64(&s.stats.BytesRead, int64(len(rec.Bytes)))
 		atomic.AddInt64(&s.stats.RecordsRead, 1)
 		if s.span != nano.MaxSpan && !s.span.Contains(rec.Ts()) ||
 			s.filter != nil && !s.filter(rec) {
 			continue
 		}
-		atomic.AddInt64(&s.stats.BytesMatched, int64(len(rec.Raw)))
+		atomic.AddInt64(&s.stats.BytesMatched, int64(len(rec.Bytes)))
 		atomic.AddInt64(&s.stats.RecordsMatched, 1)
 		// Copy the underlying buffer (if volatile) because next call to
 		// reader.Next() may overwrite said buffer.

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -65,9 +65,9 @@ func (w *Writer) Write(rec *zng.Record) error {
 		return err
 	}
 	if w.first == nil {
-		w.first = rec.Type
+		w.first = zng.TypeRecordOf(rec.Type)
 		var hdr []string
-		for _, col := range rec.Type.Columns {
+		for _, col := range rec.Columns() {
 			hdr = append(hdr, col.Name)
 		}
 		if err := w.encoder.Write(hdr); err != nil {
@@ -77,9 +77,10 @@ func (w *Writer) Write(rec *zng.Record) error {
 		return ErrNotDataFrame
 	}
 	var out []string
-	for k, col := range rec.Type.Columns {
+	for k, col := range rec.Columns() {
 		var v string
-		value := rec.Value(k)
+		// O(n^2)
+		value := rec.ValueByColumn(k)
 		if !value.IsUnsetOrNil() {
 			switch col.Type.ID() {
 			case zng.IdTime:

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -246,16 +246,16 @@ func TestNewRawFromJSON(t *testing.T) {
 			r := tzngio.NewReader(strings.NewReader(c.tzng), resolver.NewContext())
 			expected, err := r.Read()
 			require.NoError(t, err)
-			typ := expected.Type
+			typ := zng.TypeRecordOf(expected.Type)
 			ti := &typeInfo{
 				flatDesc:   typ,
 				descriptor: typ,
 				typedVals:  make([]typedVal, len(typ.Columns)),
 				path:       []byte(c.defaultPath),
 			}
-			raw, _, err := ti.newRawFromJSON([]byte(c.json))
+			bytes, _, err := ti.newRawFromJSON([]byte(c.json))
 			require.NoError(t, err)
-			rec := &zng.Record{Type: typ, Raw: raw}
+			rec := zng.NewRecord(typ, bytes)
 			assert.Equal(t, expected.String(), rec.String())
 		})
 	}

--- a/zio/parquetio/writer.go
+++ b/zio/parquetio/writer.go
@@ -32,8 +32,8 @@ func (w *Writer) Close() error {
 
 func (w *Writer) Write(rec *zng.Record) error {
 	if w.typ == nil {
-		w.typ = rec.Type
-		sd, err := newSchemaDefinition(rec.Type)
+		w.typ = zng.TypeRecordOf(rec.Type)
+		sd, err := newSchemaDefinition(w.typ)
 		if err != nil {
 			return err
 		}
@@ -41,7 +41,7 @@ func (w *Writer) Write(rec *zng.Record) error {
 	} else if w.typ != rec.Type {
 		return csvio.ErrNotDataFrame
 	}
-	data, err := newRecordData(rec.Type, rec.Raw)
+	data, err := newRecordData(zng.TypeRecordOf(rec.Type), rec.Bytes)
 	if err != nil {
 		return err
 	}

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -61,8 +61,9 @@ func (w *Writer) Write(r *zng.Record) error {
 			w.nline = 0
 		}
 		// First time, or new descriptor, print header
-		w.writeHeader(r.Type)
-		w.typ = r.Type
+		typ := zng.TypeRecordOf(r.Type)
+		w.writeHeader(typ)
+		w.typ = typ
 	}
 	if w.nline >= w.limit {
 		w.flush()
@@ -70,9 +71,9 @@ func (w *Writer) Write(r *zng.Record) error {
 		w.nline = 0
 	}
 	var out []string
-	for k, col := range r.Type.Columns {
+	for k, col := range r.Columns() {
 		var v string
-		value := r.Value(k)
+		value := r.ValueByColumn(k)
 		if !w.epochDates && col.Type == zng.TypeTime {
 			if !value.IsUnsetOrNil() {
 				ts, err := zng.DecodeTime(value.Bytes)

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -51,9 +51,9 @@ func (w *Writer) Write(rec *zng.Record) error {
 	}
 	var out []string
 	if w.ShowFields || w.ShowTypes || !w.EpochDates {
-		for k, col := range rec.Type.Columns {
+		for k, col := range zng.TypeRecordOf(rec.Type).Columns {
 			var s, v string
-			value := rec.Value(k)
+			value := rec.ValueByColumn(k)
 			if !w.EpochDates && col.Type == zng.TypeTime {
 				if value.IsUnsetOrNil() {
 					v = "-"

--- a/zio/tzngio/reader.go
+++ b/zio/tzngio/reader.go
@@ -208,9 +208,9 @@ func (r *Reader) parseValue(line []byte) (*zng.Record, error) {
 	if !ok {
 		return nil, errors.New("outer type is not a record type")
 	}
-	raw, err := r.parser.Parse(recType, rest)
+	bytes, err := r.parser.Parse(recType, rest)
 	if err != nil {
 		return nil, err
 	}
-	return zng.NewRecordCheckFromType(typ, raw)
+	return zng.NewRecordCheck(typ, bytes)
 }

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -47,7 +47,7 @@ func (w *Writer) Write(r *zng.Record) error {
 		if err := w.writeAliases(r.Type); err != nil {
 			return err
 		}
-		typ := r.Alias
+		typ := r.Type
 		var op string
 		if alias, ok := typ.(*zng.TypeAlias); ok {
 			name = alias.Name
@@ -71,7 +71,7 @@ func (w *Writer) Write(r *zng.Record) error {
 	// zng type.  We should just call StringOf on r.Type here and get rid of
 	// all these write* methods and make sure there is consistency between this
 	// logic and the logic in the StringOfs.  See issue #1417.
-	if err := w.writeContainer(zng.Value{Type: r.Type, Bytes: r.Raw}); err != nil {
+	if err := w.writeContainer(r.Value); err != nil {
 		return err
 	}
 	return w.write("\n")

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -132,7 +132,7 @@ func TestNestedRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	// First check that the descriptor was created correctly
-	cols := record.Type.Columns
+	cols := zng.TypeRecordOf(record.Type).Columns
 	assert.Equal(t, 5, len(cols), "Descriptor has 5 columns")
 	//assert.Equal(t, "_path", cols[0].Name, "Column 0 is _path")
 	assert.Equal(t, "a", cols[0].Name, "Column 0 is a")

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -51,7 +51,7 @@ func (w *Writer) Write(r *zng.Record) error {
 		if err := w.writeHeader(r, path); err != nil {
 			return err
 		}
-		w.typ = r.Type
+		w.typ = zng.TypeRecordOf(r.Type)
 	}
 	values, err := ZeekStrings(r, w.format)
 	if err != nil {
@@ -94,7 +94,7 @@ func (w *Writer) writeHeader(r *zng.Record, path string) error {
 	}
 	if d != w.typ {
 		s += "#fields"
-		for _, col := range d.Columns {
+		for _, col := range zng.TypeRecordOf(d).Columns {
 			if col.Name == "_path" {
 				continue
 			}
@@ -102,7 +102,7 @@ func (w *Writer) writeHeader(r *zng.Record, path string) error {
 		}
 		s += "\n"
 		s += "#types"
-		for _, col := range d.Columns {
+		for _, col := range zng.TypeRecordOf(d).Columns {
 			if col.Name == "_path" {
 				continue
 			}
@@ -128,7 +128,7 @@ func isHighPrecision(ts nano.Ts) bool {
 func ZeekStrings(r *zng.Record, fmt tzngio.OutFmt) ([]string, error) {
 	var ss []string
 	it := r.ZvalIter()
-	for _, col := range r.Type.Columns {
+	for _, col := range zng.TypeRecordOf(r.Type).Columns {
 		val, _, err := it.Next()
 		if err != nil {
 			return nil, err

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -25,10 +25,11 @@ func (s *Stream) Transform(r *zng.Record) (*Record, error) {
 	var typ joe.Object
 	var aliases []Alias
 	if !s.tracker.Seen(id) {
-		aliases = s.encodeAliases(r.Type)
+		//XXX BUG: need to encode any top-level record aliases
+		aliases = s.encodeAliases(zng.TypeRecordOf(r.Type))
 		typ = encodeTypeObj(r.Type)
 	}
-	v, err := encodeAny(r.Type, r.Raw)
+	v, err := encodeAny(r.Type, r.Bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -25,8 +25,7 @@ func (s *Stream) Transform(r *zng.Record) (*Record, error) {
 	var typ joe.Object
 	var aliases []Alias
 	if !s.tracker.Seen(id) {
-		//XXX BUG: need to encode any top-level record aliases
-		aliases = s.encodeAliases(zng.TypeRecordOf(r.Type))
+		aliases = s.encodeAliases(r.Type)
 		typ = encodeTypeObj(r.Type)
 	}
 	v, err := encodeAny(r.Type, r.Bytes)

--- a/zio/zjsonio/values.go
+++ b/zio/zjsonio/values.go
@@ -139,7 +139,7 @@ func encodeContainer(typ zng.Type, val zcode.Bytes) (interface{}, error) {
 	return out, nil
 }
 
-func (s *Stream) encodeAliases(typ *zng.TypeRecord) []Alias {
+func (s *Stream) encodeAliases(typ zng.Type) []Alias {
 	var aliases []Alias
 	for _, alias := range zng.AliasTypes(typ) {
 		id := alias.AliasID()

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -304,11 +304,11 @@ func TestStreams(t *testing.T) {
 
 	rec, rec2Off, err := zr.SkipStream()
 	require.NoError(t, err)
-	assert.Equal(t, recs[2].Raw, rec.Raw)
+	assert.Equal(t, recs[2].Bytes, rec.Bytes)
 
 	rec, rec4Off, err := zr.SkipStream()
 	require.NoError(t, err)
-	assert.Equal(t, recs[4].Raw, rec.Raw)
+	assert.Equal(t, recs[4].Bytes, rec.Bytes)
 
 	zs := zngio.NewSeeker(bytes.NewReader(out.Buffer.Bytes()), resolver.NewContext())
 
@@ -316,17 +316,17 @@ func TestStreams(t *testing.T) {
 	require.NoError(t, err)
 	rec, err = zs.Read()
 	require.NoError(t, err)
-	assert.Equal(t, recs[4].Raw, rec.Raw)
+	assert.Equal(t, recs[4].Bytes, rec.Bytes)
 
 	_, err = zs.Seek(rec2Off)
 	require.NoError(t, err)
 	rec, err = zs.Read()
 	require.NoError(t, err)
-	assert.Equal(t, recs[2].Raw, rec.Raw)
+	assert.Equal(t, recs[2].Bytes, rec.Bytes)
 
 	_, err = zs.Seek(0)
 	require.NoError(t, err)
 	rec, err = zs.Read()
 	require.NoError(t, err)
-	assert.Equal(t, recs[0].Raw, rec.Raw)
+	assert.Equal(t, recs[0].Bytes, rec.Bytes)
 }

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -498,9 +498,9 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 		}
 	}
 	if rec == nil {
-		rec = zng.NewVolatileRecordFromType(sharedType, b)
+		rec = zng.NewVolatileRecord(sharedType, b)
 	} else {
-		*rec = *zng.NewVolatileRecordFromType(sharedType, b)
+		*rec = *zng.NewVolatileRecord(sharedType, b)
 	}
 	if r.validate {
 		if err := rec.TypeCheck(); err != nil {

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -70,9 +70,9 @@ func (s *zngScanner) Pull() (zbuf.Batch, error) {
 			// XXX we don't use rec.CopyBody() here because it will
 			// mark the record volatile but that zng.Record is in
 			// the buffer and will get incorrectly reused.
-			b := make([]byte, len(rec.Raw))
-			copy(b, rec.Raw)
-			rec.Raw = b
+			b := make([]byte, len(rec.Bytes))
+			copy(b, rec.Bytes)
+			rec.Bytes = b
 			batch := newBatch(nil)
 			batch.add(rec)
 			return batch, nil
@@ -124,13 +124,13 @@ func (s *zngScanner) scanBatch() (zbuf.Batch, error) {
 }
 
 func (s *zngScanner) scanOne(rec *zng.Record) (*zng.Record, error) {
-	atomic.AddInt64(&s.stats.BytesRead, int64(len(rec.Raw)))
+	atomic.AddInt64(&s.stats.BytesRead, int64(len(rec.Bytes)))
 	atomic.AddInt64(&s.stats.RecordsRead, 1)
 	if s.span != nano.MaxSpan && !s.span.Contains(rec.Ts()) ||
 		s.filter != nil && !s.filter(rec) {
 		return nil, nil
 	}
-	atomic.AddInt64(&s.stats.BytesMatched, int64(len(rec.Raw)))
+	atomic.AddInt64(&s.stats.BytesMatched, int64(len(rec.Bytes)))
 	atomic.AddInt64(&s.stats.RecordsMatched, 1)
 	return rec, nil
 }

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -104,11 +104,11 @@ func (w *Writer) LastSOS() int64 {
 
 func (w *Writer) Write(r *zng.Record) error {
 	// First send any typedefs for unsent types.
-	typ := w.encoder.Lookup(r.Alias)
+	typ := w.encoder.Lookup(r.Type)
 	if typ == nil {
 		var b []byte
 		var err error
-		b, typ, err = w.encoder.Encode(w.buffer[:0], r.Alias)
+		b, typ, err = w.encoder.Encode(w.buffer[:0], r.Type)
 		if err != nil {
 			return err
 		}
@@ -136,10 +136,10 @@ func (w *Writer) Write(r *zng.Record) error {
 		dst = append(dst, zng.CtrlValueEscape)
 		dst = zcode.AppendUvarint(dst, uint64(id-zng.CtrlValueEscape))
 	}
-	dst = zcode.AppendUvarint(dst, uint64(len(r.Raw)))
+	dst = zcode.AppendUvarint(dst, uint64(len(r.Bytes)))
 	// XXX instead of copying write we should do two writes... so we don't
 	// copy the bulk of the data an extra time here when we don't need to.
-	dst = append(dst, r.Raw...)
+	dst = append(dst, r.Bytes...)
 	w.buffer = dst
 	if err := w.write(dst); err != nil {
 		return err

--- a/zng/builder.go
+++ b/zng/builder.go
@@ -44,9 +44,7 @@ func (b *Builder) Build(zvs ...zcode.Bytes) *Record {
 	// Note that t.rec.nonvolatile is false so anything downstream
 	// will have to copy the record and we can re-use the record value
 	// between subsequent calls.
-	b.rec.Type = b.Type
-	b.rec.Alias = b.Type
-	b.rec.Raw = b.Bytes()
+	b.rec.Value = Value{b.Type, b.Bytes()}
 	return &b.rec
 }
 

--- a/zng/builder.go
+++ b/zng/builder.go
@@ -20,7 +20,7 @@ func NewBuilder(typ *TypeRecord) *Builder {
 	return &Builder{Type: typ}
 }
 
-// Build encodes the top-level zcode.Bytes values as the Raw field
+// Build encodes the top-level zcode.Bytes values as the Bytes field
 // of a record and sets that field and the Type field of the passed-in record.
 // XXX This currently only works for zvals that are properly formatted for
 // the top-level scan of the record, e.g., if a field is record[id:[record:[orig_h:ip]]

--- a/zng/builder_test.go
+++ b/zng/builder_test.go
@@ -37,7 +37,7 @@ func TestBuilder(t *testing.T) {
 	b0 := zng.NewBuilder(t0)
 	ip := net.ParseIP("1.2.3.4")
 	rec := b0.Build(zng.EncodeIP(ip))
-	assert.Equal(t, r0.Raw, rec.Raw)
+	assert.Equal(t, r0.Bytes, rec.Bytes)
 
 	t1, err := zctx.LookupTypeRecord([]zng.Column{
 		{"a", zng.TypeInt64},
@@ -47,7 +47,7 @@ func TestBuilder(t *testing.T) {
 	assert.NoError(t, err)
 	b1 := zng.NewBuilder(t1)
 	rec = b1.Build(zng.EncodeInt(1), zng.EncodeInt(2), zng.EncodeInt(3))
-	assert.Equal(t, r1.Raw, rec.Raw)
+	assert.Equal(t, r1.Bytes, rec.Bytes)
 
 	subrec, err := zctx.LookupTypeRecord([]zng.Column{{"x", zng.TypeInt64}})
 	assert.NoError(t, err)
@@ -68,13 +68,13 @@ func TestBuilder(t *testing.T) {
 	var rb zcode.Builder
 	rb.AppendPrimitive(zng.EncodeInt(3))
 	rec = b2.Build(zng.EncodeInt(7), rb.Bytes())
-	assert.Equal(t, r2.Raw, rec.Raw)
+	assert.Equal(t, r2.Bytes, rec.Bytes)
 
 	//rec, err = b2.Parse("7", "3")
 	//assert.NoError(t, err)
-	//assert.Equal(t, r2.Raw, rec.Raw)
+	//assert.Equal(t, r2.Bytes, rec.Bytes)
 
 	//rec, err = b2.Parse("7")
 	//assert.Equal(t, err, zng.ErrIncomplete)
-	//assert.Equal(t, r3.Raw, rec.Raw)
+	//assert.Equal(t, r3.Bytes, rec.Bytes)
 }

--- a/zng/flattener/flattener.go
+++ b/zng/flattener/flattener.go
@@ -71,7 +71,7 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 	id := r.Type.ID()
 	flatType := f.mapper.Map(id)
 	if flatType == nil {
-		cols := FlattenColumns(r.Type.Columns)
+		cols := FlattenColumns(r.Columns())
 		var err error
 		flatType, err = f.zctx.LookupTypeRecord(cols)
 		if err != nil {
@@ -85,7 +85,7 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 	if r.Type == flatType {
 		return r, nil
 	}
-	zv, err := recode(nil, r.Type, r.Raw)
+	zv, err := recode(nil, zng.TypeRecordOf(r.Type), r.Bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -40,50 +40,21 @@ func (r *RecordTypeError) Unwrap() error { return r.Err }
 // operations on zeek data can work with either serialized data or native
 // zng.Records by accessing data via the Record methods.
 type Record struct {
-	Type        *TypeRecord
-	Alias       Type
+	Value
 	nonvolatile bool
-	// Raw is the serialization format for records.  A raw value comprises a
-	// sequence of zvals, one per descriptor column.  The descriptor is stored
-	// outside of the raw serialization but is needed to interpret the raw values.
-	Raw     zcode.Bytes
-	ts      nano.Ts
-	tsValid bool
+	ts          nano.Ts
+	tsValid     bool
 }
 
-func NewRecord(typ *TypeRecord, raw zcode.Bytes) *Record {
+func NewRecord(typ Type, bytes zcode.Bytes) *Record {
 	return &Record{
-		Type:        typ,
-		Alias:       typ,
+		Value:       Value{typ, bytes},
 		nonvolatile: true,
-		Raw:         raw,
 	}
 }
 
-func NewRecordFromType(typ Type, raw zcode.Bytes) *Record {
-	return &Record{
-		Type:        AliasOf(typ).(*TypeRecord),
-		Alias:       typ,
-		nonvolatile: true,
-		Raw:         raw,
-	}
-}
-
-func NewRecordCheck(typ *TypeRecord, raw zcode.Bytes) (*Record, error) {
+func NewRecordCheck(typ Type, raw zcode.Bytes) (*Record, error) {
 	r := NewRecord(typ, raw)
-	if err := r.TypeCheck(); err != nil {
-		return nil, err
-	}
-	return r, nil
-}
-
-func NewRecordCheckFromType(typ Type, raw zcode.Bytes) (*Record, error) {
-	r := &Record{
-		Type:        AliasOf(typ).(*TypeRecord),
-		Alias:       typ,
-		nonvolatile: true,
-		Raw:         raw,
-	}
 	if err := r.TypeCheck(); err != nil {
 		return nil, err
 	}
@@ -96,25 +67,15 @@ func NewRecordCheckFromType(typ Type, raw zcode.Bytes) (*Record, error) {
 // into a reusable buffer allowing the scanner to filter these records
 // without having their body copied to safe memory, i.e., when the scanner
 // matches a record, it will call Keep() to make a safe copy.
-func NewVolatileRecord(typ *TypeRecord, raw zcode.Bytes) *Record {
+func NewVolatileRecord(typ Type, bytes zcode.Bytes) *Record {
 	return &Record{
-		Type:  typ,
-		Alias: typ,
-		Raw:   raw,
-	}
-}
-
-func NewVolatileRecordFromType(typ Type, raw zcode.Bytes) *Record {
-	return &Record{
-		Type:  AliasOf(typ).(*TypeRecord),
-		Alias: typ,
-		Raw:   raw,
+		Value: Value{typ, bytes},
 	}
 }
 
 // ZvalIter returns a zcode.Iter iterator over the receiver's values.
 func (r *Record) ZvalIter() zcode.Iter {
-	return r.Raw.Iter()
+	return r.Bytes.Iter()
 }
 
 // FieldIter returns a fieldIter iterator over the receiver's values.
@@ -122,7 +83,7 @@ func (r *Record) FieldIter() fieldIter {
 	return fieldIter{
 		stack: []iterInfo{iterInfo{
 			iter: r.ZvalIter(),
-			typ:  r.Type,
+			typ:  TypeRecordOf(r.Type),
 		}},
 	}
 }
@@ -131,43 +92,35 @@ func (r *Record) Keep() *Record {
 	if r.nonvolatile {
 		return r
 	}
-	raw := make(zcode.Bytes, len(r.Raw))
-	copy(raw, r.Raw)
+	bytes := make(zcode.Bytes, len(r.Bytes))
+	copy(bytes, r.Bytes)
 	return &Record{
-		Type:        r.Type,
-		Alias:       r.Alias,
+		Value:       Value{r.Type, bytes},
 		nonvolatile: true,
-		Raw:         raw,
 		ts:          r.ts,
 		tsValid:     r.tsValid,
 	}
 }
 
+//XXX change to CopyBytes
 func (r *Record) CopyBody() {
 	if r.nonvolatile {
 		return
 	}
-	body := make(zcode.Bytes, len(r.Raw))
-	copy(body, r.Raw)
-	r.Raw = body
+	bytes := make(zcode.Bytes, len(r.Bytes))
+	copy(bytes, r.Bytes)
+	r.Bytes = bytes
 	r.nonvolatile = true
 }
 
 func (r *Record) HasField(field string) bool {
-	return r.Type.HasField(field)
-}
-
-func (r *Record) Bytes() []byte {
-	if r.Raw == nil {
-		panic("this shouldn't happen")
-	}
-	return r.Raw
+	return TypeRecordOf(r.Type).HasField(field)
 }
 
 // Walk traverses a record in depth-first order, calling a
 // RecordVisitor on the way.
 func (r *Record) Walk(rv Visitor) error {
-	return walkRecord(r.Type, r.Raw, rv)
+	return walkRecord(TypeRecordOf(r.Type), r.Bytes, rv)
 }
 
 // TypeCheck checks that the value coding in Raw is structurally consistent
@@ -236,7 +189,7 @@ func checkEnum(typ *TypeEnum, body zcode.Bytes) error {
 // result is nil without error, then that columnn is unset in this record value.
 func (r *Record) Slice(column int) (zcode.Bytes, error) {
 	var zv zcode.Bytes
-	for i, it := 0, r.Raw.Iter(); i <= column; i++ {
+	for i, it := 0, r.Bytes.Iter(); i <= column; i++ {
 		if it.Done() {
 			return nil, ErrMissing
 		}
@@ -249,14 +202,18 @@ func (r *Record) Slice(column int) (zcode.Bytes, error) {
 	return zv, nil
 }
 
+func (r *Record) Columns() []Column {
+	return TypeRecordOf(r.Type).Columns
+}
+
 // Value returns the indicated column as a Value.  If the column doesn't
 // exist or another error occurs, the nil Value is returned.
-func (r *Record) Value(col int) Value {
+func (r *Record) ValueByColumn(col int) Value {
 	zv, err := r.Slice(col)
 	if err != nil {
 		return Value{}
 	}
-	return Value{r.Type.Columns[col].Type, zv}
+	return Value{r.Columns()[col].Type, zv}
 }
 
 func (r *Record) ValueByField(field string) (Value, error) {
@@ -264,15 +221,15 @@ func (r *Record) ValueByField(field string) (Value, error) {
 	if !ok {
 		return Value{}, ErrMissing
 	}
-	return r.Value(col), nil
+	return r.ValueByColumn(col), nil
 }
 
 func (r *Record) ColumnOfField(field string) (int, bool) {
-	return r.Type.ColumnOfField(field)
+	return TypeRecordOf(r.Type).ColumnOfField(field)
 }
 
 func (r *Record) TypeOfColumn(col int) Type {
-	return r.Type.Columns[col].Type
+	return TypeRecordOf(r.Type).Columns[col].Type
 }
 
 func (r *Record) Access(field string) (Value, error) {
@@ -280,7 +237,7 @@ func (r *Record) Access(field string) (Value, error) {
 	if !ok {
 		return Value{}, ErrMissing
 	}
-	return r.Value(col), nil
+	return r.ValueByColumn(col), nil
 }
 
 func (r *Record) AccessString(field string) (string, error) {
@@ -372,10 +329,10 @@ func (r *Record) Ts() nano.Ts {
 }
 
 func (r *Record) String() string {
-	return Value{r.Type, r.Raw}.String()
+	return r.Value.String()
 }
 
 // MarshalJSON implements json.Marshaler.
 func (r *Record) MarshalJSON() ([]byte, error) {
-	return Value{r.Alias, r.Raw}.MarshalJSON()
+	return r.Value.MarshalJSON()
 }

--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -102,8 +102,7 @@ func (r *Record) Keep() *Record {
 	}
 }
 
-//XXX change to CopyBytes
-func (r *Record) CopyBody() {
+func (r *Record) CopyBytes() {
 	if r.nonvolatile {
 		return
 	}

--- a/zng/recordval_test.go
+++ b/zng/recordval_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 func TestRecordTypeCheck(t *testing.T) {
-	r := zng.Record{
-		Type: zng.NewTypeRecord(0, []zng.Column{
+	r := zng.NewRecord(
+		zng.NewTypeRecord(0, []zng.Column{
 			zng.NewColumn("f", zng.NewTypeSet(0, zng.TypeString)),
 		}),
-	}
+		nil)
 	t.Run("set/error/duplicate-element", func(t *testing.T) {
 		var b zcode.Builder
 		b.BeginContainer()
@@ -28,7 +28,7 @@ func TestRecordTypeCheck(t *testing.T) {
 		b.AppendPrimitive([]byte("dup"))
 		// Don't normalize.
 		b.EndContainer()
-		r.Raw = b.Bytes()
+		r.Bytes = b.Bytes()
 		assert.EqualError(t, r.TypeCheck(), "<set element> (set[string]): duplicate element")
 	})
 	t.Run("set/error/unsorted-elements", func(t *testing.T) {
@@ -39,7 +39,7 @@ func TestRecordTypeCheck(t *testing.T) {
 		b.AppendPrimitive([]byte("b"))
 		// Don't normalize.
 		b.EndContainer()
-		r.Raw = b.Bytes()
+		r.Bytes = b.Bytes()
 		assert.EqualError(t, r.TypeCheck(), "<set element> (set[string]): elements not sorted")
 	})
 	t.Run("set/primitive-elements", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestRecordTypeCheck(t *testing.T) {
 		b.AppendPrimitive([]byte("a"))
 		b.TransformContainer(zng.NormalizeSet)
 		b.EndContainer()
-		r.Raw = b.Bytes()
+		r.Bytes = b.Bytes()
 		assert.NoError(t, r.TypeCheck())
 	})
 	t.Run("set/complex-elements", func(t *testing.T) {
@@ -64,14 +64,13 @@ func TestRecordTypeCheck(t *testing.T) {
 		}
 		b.TransformContainer(zng.NormalizeSet)
 		b.EndContainer()
-		r := zng.Record{
-			Type: zng.NewTypeRecord(0, []zng.Column{
+		r := zng.NewRecord(
+			zng.NewTypeRecord(0, []zng.Column{
 				zng.NewColumn("f", zng.NewTypeSet(0, zng.NewTypeRecord(0, []zng.Column{
 					zng.NewColumn("g", zng.TypeString),
 				}))),
 			}),
-			Raw: b.Bytes(),
-		}
+			b.Bytes())
 		assert.NoError(t, r.TypeCheck())
 	})
 

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -22,9 +22,9 @@ func TestContextAddColumns(t *testing.T) {
 	r, err = ctx.AddColumns(r, cols, []zng.Value{zng.NewTime(ts), zng.NewString("S2")})
 	require.NoError(t, err)
 	assert.EqualValues(t, 123456000000, r.Ts())
-	assert.EqualValues(t, zng.NewString("S1"), r.Value(0))
-	assert.EqualValues(t, zng.NewTime(ts), r.Value(1))
-	assert.EqualValues(t, zng.NewString("S2"), r.Value(2))
+	assert.EqualValues(t, zng.NewString("S1"), r.ValueByColumn(0))
+	assert.EqualValues(t, zng.NewTime(ts), r.ValueByColumn(1))
+	assert.EqualValues(t, zng.NewString("S2"), r.ValueByColumn(2))
 	zv, _ := r.Slice(4)
 	assert.Nil(t, zv)
 }

--- a/zng/type.go
+++ b/zng/type.go
@@ -385,3 +385,10 @@ func ReferencedID(typ Type) int {
 	}
 	return typ.ID()
 }
+
+func TypeID(typ Type) int {
+	if alias, ok := typ.(*TypeAlias); ok {
+		return alias.id
+	}
+	return typ.ID()
+}

--- a/zson/context.go
+++ b/zson/context.go
@@ -208,7 +208,7 @@ func (c *Context) LookupTypeAlias(name string, target zng.Type) (*zng.TypeAlias,
 // If any of the newly provided columns already exists in the specified value,
 // an error is returned.
 func (c *Context) AddColumns(r *zng.Record, newCols []zng.Column, vals []zng.Value) (*zng.Record, error) {
-	oldCols := r.Type.Columns
+	oldCols := zng.TypeRecordOf(r.Type).Columns
 	outCols := make([]zng.Column, len(oldCols), len(oldCols)+len(newCols))
 	copy(outCols, oldCols)
 	for _, col := range newCols {
@@ -217,8 +217,8 @@ func (c *Context) AddColumns(r *zng.Record, newCols []zng.Column, vals []zng.Val
 		}
 		outCols = append(outCols, col)
 	}
-	zv := make(zcode.Bytes, len(r.Raw))
-	copy(zv, r.Raw)
+	zv := make(zcode.Bytes, len(r.Bytes))
+	copy(zv, r.Bytes)
 	for _, val := range vals {
 		zv = val.Encode(zv)
 	}

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -50,7 +50,7 @@ func (f *Formatter) pop() {
 
 func (f *Formatter) FormatRecord(rec *zng.Record) (string, error) {
 	f.builder.Reset()
-	if err := f.formatValueAndDecorate(rec.Alias, rec.Raw); err != nil {
+	if err := f.formatValueAndDecorate(rec.Type, rec.Bytes); err != nil {
 		return "", err
 	}
 	return f.builder.String(), nil

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -499,7 +499,7 @@ func UnmarshalZNG(zv zng.Value, v interface{}) error {
 }
 
 func UnmarshalZNGRecord(rec *zng.Record, v interface{}) error {
-	return NewZNGUnmarshaler().decodeAny(zng.Value{rec.Alias, rec.Raw}, reflect.ValueOf(v))
+	return NewZNGUnmarshaler().decodeAny(rec.Value, reflect.ValueOf(v))
 }
 
 func incompatTypeError(zt zng.Type, v reflect.Value) error {

--- a/zson/reader.go
+++ b/zson/reader.go
@@ -49,5 +49,5 @@ func (r *Reader) Read() (*zng.Record, error) {
 	if _, ok := zng.AliasOf(zv.Type).(*zng.TypeRecord); !ok {
 		return nil, fmt.Errorf("top-level ZSON value not a record: %s", zv.Type.ZSON())
 	}
-	return zng.NewRecordFromType(zv.Type, zv.Bytes), nil
+	return zng.NewRecord(zv.Type, zv.Bytes), nil
 }

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -28,7 +28,7 @@ func NewAssembler(a *Assembly, seeker Seeker) (*Assembler, error) {
 	assembler.columns = make([]*column.Record, len(a.schemas))
 	for k := 0; k < len(a.schemas); k++ {
 		rec := a.columns[k]
-		zv := zng.Value{rec.Type, rec.Raw}
+		zv := rec.Value
 		record_col := &column.Record{}
 		if err := record_col.UnmarshalZNG(a.schemas[k], zv, seeker); err != nil {
 			return nil, err

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -65,8 +65,7 @@ func NewCutAssembler(zctx *resolver.Context, fields []string, object *Object) (*
 	cnt := 0
 	for k, schema := range a.schemas {
 		var err error
-		rec := a.columns[k]
-		zv := zng.Value{rec.Type, rec.Raw}
+		zv := a.columns[k].Value
 		topcol := &column.Record{}
 		if err := topcol.UnmarshalZNG(a.schemas[k], zv, object.seeker); err != nil {
 			return nil, err

--- a/zst/object.go
+++ b/zst/object.go
@@ -134,11 +134,12 @@ func (o *Object) readAssembly() (*Assembly, error) {
 		if rec == nil {
 			return nil, errors.New("no reassembly records found in zst file")
 		}
-		zv := rec.Value(0)
+		zv := rec.ValueByColumn(0)
 		if zv.Bytes != nil {
 			break
 		}
-		assembly.schemas = append(assembly.schemas, rec.Type)
+		//XXX BUG: need to preserve top-level type
+		assembly.schemas = append(assembly.schemas, zng.TypeRecordOf(rec.Type))
 	}
 	var err error
 	assembly.root, err = rec.Access("root")

--- a/zst/object.go
+++ b/zst/object.go
@@ -138,7 +138,7 @@ func (o *Object) readAssembly() (*Assembly, error) {
 		if zv.Bytes != nil {
 			break
 		}
-		//XXX BUG: need to preserve top-level type
+		//XXX See issue #2439: Wneed to preserve top-level type here.
 		assembly.schemas = append(assembly.schemas, zng.TypeRecordOf(rec.Type))
 	}
 	var err error

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -101,7 +101,7 @@ func (w *Writer) Write(rec *zng.Record) error {
 	inputID := rec.Type.ID()
 	schemaID, ok := w.schemaMap[inputID]
 	if !ok {
-		recType, err := w.zctx.TranslateTypeRecord(rec.Type)
+		recType, err := w.zctx.TranslateTypeRecord(zng.TypeRecordOf(rec.Type))
 		if err != nil {
 			return err
 		}
@@ -114,10 +114,10 @@ func (w *Writer) Write(rec *zng.Record) error {
 	if err := w.root.Write(int32(schemaID)); err != nil {
 		return err
 	}
-	if err := w.schemas[schemaID].Write(rec.Raw); err != nil {
+	if err := w.schemas[schemaID].Write(rec.Bytes); err != nil {
 		return err
 	}
-	w.footprint += len(rec.Raw)
+	w.footprint += len(rec.Bytes)
 	if w.footprint >= w.skewThresh {
 		w.footprint = 0
 		return w.flush(false)


### PR DESCRIPTION
This commit cleans up zng.Record by recognizing that a zng.Record
is a special case of a zng.Value.  It replaces the type pointers and
Raw field with an embedded zng.Value.  This is the first step toward
improving the batch model as described in issue #1762.

Closes #1801