### PR TITLE
Change casting description in doc

### DIFF
--- a/zql/docs/data-types/README.md
+++ b/zql/docs/data-types/README.md
@@ -5,7 +5,7 @@ in progress. In the meantime, here's a few tips to get started with.
 
 * Values read in by `zq` are stored internally and treated in expressions using one of the data types described in the [Primitive Types](../../../zng/docs/spec.md#3-primitive-types) section of the ZNG spec.
 * See the [Equivalent Types](../../../zng/docs/zeek-compat.md#equivalent-types) table for details on which ZNG data types correspond to the [data types](https://docs.zeek.org/en/current/script-reference/types.html) that appear in Zeek logs.
-* ZQL allows for [type casting](https://en.wikipedia.org/wiki/Type_conversion) by specifying a destination ZNG data type followed by the value to be converted to that type.
+* ZQL allows for [type casting](https://en.wikipedia.org/wiki/Type_conversion) by specifying a destination ZNG data type followed by the value to be converted to that type, enclosed in parentheses.
 
 #### Example:
 

--- a/zql/docs/data-types/README.md
+++ b/zql/docs/data-types/README.md
@@ -5,7 +5,7 @@ in progress. In the meantime, here's a few tips to get started with.
 
 * Values read in by `zq` are stored internally and treated in expressions using one of the data types described in the [Primitive Types](../../../zng/docs/spec.md#3-primitive-types) section of the ZNG spec.
 * See the [Equivalent Types](../../../zng/docs/zeek-compat.md#equivalent-types) table for details on which ZNG data types correspond to the [data types](https://docs.zeek.org/en/current/script-reference/types.html) that appear in Zeek logs.
-* ZQL provides a [type casting](https://en.wikipedia.org/wiki/Type_conversion) syntax using `:` followed by a ZNG data type.
+* ZQL allows for [type casting](https://en.wikipedia.org/wiki/Type_conversion) by specifying a destination ZNG data type followed by the value to be converted to that type.
 
 #### Example:
 


### PR DESCRIPTION
#2427 changed the doc example to match the new casting syntax, but the text up above still needs this update.