### PR TITLE
proc: warn about Function.Apply errors in applier.Pull

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -26,29 +26,32 @@ func testSuccessful(t *testing.T, e string, record string, expect zng.Value) {
 	formatter := zson.NewFormatter(0)
 	val, err := formatter.Format(rec.Value)
 	require.NoError(t, err)
-	zt := &ztest.ZTest{
+	runZTest(t, e, &ztest.ZTest{
 		Zed:    fmt.Sprintf("cut result = %s", e),
 		Input:  record,
 		Output: val + "\n",
-	}
-	t.Run(e, func(t *testing.T) {
-		t.Parallel()
-		if err := zt.RunInternal(""); err != nil {
-			t.Fatal(err)
-		}
 	})
 }
 
-func testError(t *testing.T, e string, record string, expectErr error, description string) {
+func testError(t *testing.T, e string, expectErr error, description string) {
+	runZTest(t, e, &ztest.ZTest{
+		Zed:     fmt.Sprintf("cut result = %s", e),
+		ErrorRE: expectErr.Error(),
+	})
+}
+
+func testWarning(t *testing.T, e string, record string, expectErr error, description string) {
 	if record == "" {
 		record = "{}"
 	}
-	zt := &ztest.ZTest{
-		Zed:     fmt.Sprintf("cut result = %s", e),
-		Input:   record,
-		Output:  "",
-		ErrorRE: expectErr.Error(),
-	}
+	runZTest(t, e, &ztest.ZTest{
+		Zed:      fmt.Sprintf("cut result = %s", e),
+		Input:    record,
+		Warnings: fmt.Sprintf("cut: %s\ncut: no record found with columns <not a field>\n", expectErr),
+	})
+}
+
+func runZTest(t *testing.T, e string, zt *ztest.ZTest) {
 	t.Run(e, func(t *testing.T) {
 		t.Parallel()
 		if err := zt.RunInternal(""); err != nil {
@@ -232,33 +235,33 @@ func TestCompareNumbers(t *testing.T) {
 #0:record[x:%s,s:string,bs:bstring,i:ip,n:net]
 0:[1;hello;world;10.1.1.1;10.1.0.0/16;]`, typ)
 
-		testError(t, "x = s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
-		testError(t, "x != s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
-		testError(t, "x < s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
-		testError(t, "x <= s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
-		testError(t, "x > s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
-		testError(t, "x >= s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x = s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x != s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x < s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x <= s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x > s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x >= s", record, expr.ErrIncompatibleTypes, "comparing integer and string")
 
-		testError(t, "x = bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
-		testError(t, "x != bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
-		testError(t, "x < bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
-		testError(t, "x <= bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
-		testError(t, "x > bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
-		testError(t, "x >= bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
+		testWarning(t, "x = bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
+		testWarning(t, "x != bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
+		testWarning(t, "x < bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
+		testWarning(t, "x <= bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
+		testWarning(t, "x > bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
+		testWarning(t, "x >= bs", record, expr.ErrIncompatibleTypes, "comparing integer and bstring")
 
-		testError(t, "x = i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
-		testError(t, "x != i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
-		testError(t, "x < i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
-		testError(t, "x <= i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
-		testError(t, "x > i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
-		testError(t, "x >= i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
+		testWarning(t, "x = i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
+		testWarning(t, "x != i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
+		testWarning(t, "x < i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
+		testWarning(t, "x <= i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
+		testWarning(t, "x > i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
+		testWarning(t, "x >= i", record, expr.ErrIncompatibleTypes, "comparing integer and ip")
 
-		testError(t, "x = n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
-		testError(t, "x != n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
-		testError(t, "x < n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
-		testError(t, "x <= n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
-		testError(t, "x > n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
-		testError(t, "x >= n", record, expr.ErrIncompatibleTypes, "comparing integer and string")
+		testWarning(t, "x = n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
+		testWarning(t, "x != n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
+		testWarning(t, "x < n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
+		testWarning(t, "x <= n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
+		testWarning(t, "x > n", record, expr.ErrIncompatibleTypes, "comparing integer and net")
+		testWarning(t, "x >= n", record, expr.ErrIncompatibleTypes, "comparing integer and string")
 	}
 
 	// Test comparison between signed and unsigned and also
@@ -359,7 +362,7 @@ func TestCompareNonNumbers(t *testing.T) {
 			for _, op := range allOperators {
 				exp := fmt.Sprintf("%s = %s", t1.field, t2.field)
 				desc := fmt.Sprintf("compare %s %s %s", t1.typ, op, t2.typ)
-				testError(t, exp, record, expr.ErrIncompatibleTypes, desc)
+				testWarning(t, exp, record, expr.ErrIncompatibleTypes, desc)
 			}
 		}
 	}
@@ -554,14 +557,14 @@ func TestArithmetic(t *testing.T) {
 	testSuccessful(t, `"hello" + " world"`, record, zstring("hello world"))
 
 	// Test string arithmetic other than + fails
-	testError(t, `"hello" - " world"`, record, expr.ErrIncompatibleTypes, "subtracting strings")
-	testError(t, `"hello" * " world"`, record, expr.ErrIncompatibleTypes, "multiplying strings")
-	testError(t, `"hello" / " world"`, record, expr.ErrIncompatibleTypes, "dividing strings")
+	testWarning(t, `"hello" - " world"`, record, expr.ErrIncompatibleTypes, "subtracting strings")
+	testWarning(t, `"hello" * " world"`, record, expr.ErrIncompatibleTypes, "multiplying strings")
+	testWarning(t, `"hello" / " world"`, record, expr.ErrIncompatibleTypes, "dividing strings")
 
 	// Test that addition fails on an unsupported type
-	testError(t, "10.1.1.1 + 1", record, expr.ErrIncompatibleTypes, "adding ip and integer")
-	testError(t, "10.1.1.1 + 3.14159", record, expr.ErrIncompatibleTypes, "adding ip and float")
-	testError(t, `10.1.1.1 + "foo"`, record, expr.ErrIncompatibleTypes, "adding ip and string")
+	testWarning(t, "10.1.1.1 + 1", record, expr.ErrIncompatibleTypes, "adding ip and integer")
+	testWarning(t, "10.1.1.1 + 3.14159", record, expr.ErrIncompatibleTypes, "adding ip and float")
+	testWarning(t, `10.1.1.1 + "foo"`, record, expr.ErrIncompatibleTypes, "adding ip and string")
 }
 
 func TestArrayIndex(t *testing.T) {
@@ -594,7 +597,7 @@ func TestConditional(t *testing.T) {
 
 	testSuccessful(t, `x = 0 ? "zero" : "not zero"`, record, zstring("not zero"))
 	testSuccessful(t, `x = 1 ? "one" : "not one"`, record, zstring("one"))
-	testError(t, `x ? "x" : "not x"`, record, expr.ErrIncompatibleTypes, "conditional with non-boolean condition")
+	testWarning(t, `x ? "x" : "not x"`, record, expr.ErrIncompatibleTypes, "conditional with non-boolean condition")
 
 	// Ensure that the unevaluated clause doesn't generate errors
 	// (field y doesn't exist but it shouldn't be evaluated)
@@ -605,47 +608,47 @@ func TestConditional(t *testing.T) {
 func TestCasts(t *testing.T) {
 	// Test casts to byte
 	testSuccessful(t, "uint8(10)", "", zng.Value{zng.TypeUint8, zng.EncodeUint(10)})
-	testError(t, "uint8(-1)", "", expr.ErrBadCast, "out of range cast to uint8")
-	testError(t, "uint8(300)", "", expr.ErrBadCast, "out of range cast to uint8")
-	testError(t, `uint8("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint8")
+	testWarning(t, "uint8(-1)", "", expr.ErrBadCast, "out of range cast to uint8")
+	testWarning(t, "uint8(300)", "", expr.ErrBadCast, "out of range cast to uint8")
+	testWarning(t, `uint8("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint8")
 
 	// Test casts to int16
 	testSuccessful(t, "int16(10)", "", zng.Value{zng.TypeInt16, zng.EncodeInt(10)})
-	testError(t, "int16(-33000)", "", expr.ErrBadCast, "out of range cast to int16")
-	testError(t, "int16(33000)", "", expr.ErrBadCast, "out of range cast to int16")
-	testError(t, `int16("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to int16")
+	testWarning(t, "int16(-33000)", "", expr.ErrBadCast, "out of range cast to int16")
+	testWarning(t, "int16(33000)", "", expr.ErrBadCast, "out of range cast to int16")
+	testWarning(t, `int16("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to int16")
 
 	// Test casts to uint16
 	testSuccessful(t, "uint16(10)", "", zng.Value{zng.TypeUint16, zng.EncodeUint(10)})
-	testError(t, "uint16(-1)", "", expr.ErrBadCast, "out of range cast to uint16")
-	testError(t, "uint16(66000)", "", expr.ErrBadCast, "out of range cast to uint16")
-	testError(t, `uint16("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint16")
+	testWarning(t, "uint16(-1)", "", expr.ErrBadCast, "out of range cast to uint16")
+	testWarning(t, "uint16(66000)", "", expr.ErrBadCast, "out of range cast to uint16")
+	testWarning(t, `uint16("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint16")
 
 	// Test casts to int32
 	testSuccessful(t, "int32(10)", "", zng.Value{zng.TypeInt32, zng.EncodeInt(10)})
-	testError(t, "int32(-2200000000)", "", expr.ErrBadCast, "out of range cast to int32")
-	testError(t, "int32(2200000000)", "", expr.ErrBadCast, "out of range cast to int32")
-	testError(t, `int32("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to int32")
+	testWarning(t, "int32(-2200000000)", "", expr.ErrBadCast, "out of range cast to int32")
+	testWarning(t, "int32(2200000000)", "", expr.ErrBadCast, "out of range cast to int32")
+	testWarning(t, `int32("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to int32")
 
 	// Test casts to uint32
 	testSuccessful(t, "uint32(10)", "", zng.Value{zng.TypeUint32, zng.EncodeUint(10)})
-	testError(t, "uint32(-1)", "", expr.ErrBadCast, "out of range cast to uint32")
-	testError(t, "uint8(4300000000)", "", expr.ErrBadCast, "out of range cast to uint32")
-	testError(t, `uint32("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint32")
+	testWarning(t, "uint32(-1)", "", expr.ErrBadCast, "out of range cast to uint32")
+	testWarning(t, "uint8(4300000000)", "", expr.ErrBadCast, "out of range cast to uint32")
+	testWarning(t, `uint32("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint32")
 
 	// Test casts to uint64
 	testSuccessful(t, "uint64(10)", "", zuint64(10))
-	testError(t, "uint64(-1)", "", expr.ErrBadCast, "out of range cast to uint64")
-	testError(t, `uint64("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint64")
+	testWarning(t, "uint64(-1)", "", expr.ErrBadCast, "out of range cast to uint64")
+	testWarning(t, `uint64("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to uint64")
 
 	// Test casts to float64
 	testSuccessful(t, "float64(10)", "", zfloat64(10))
-	testError(t, `float64("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to float64")
+	testWarning(t, `float64("foo")`, "", expr.ErrBadCast, "cannot cast incompatible type to float64")
 
 	// Test casts to ip
 	testSuccessful(t, `ip("1.2.3.4")`, "", zip(t, "1.2.3.4"))
-	testError(t, "ip(1234)", "", expr.ErrBadCast, "cast of invalid ip address fails")
-	testError(t, `ip("not an address")`, "", expr.ErrBadCast, "cast of invalid ip address fails")
+	testWarning(t, "ip(1234)", "", expr.ErrBadCast, "cast of invalid ip address fails")
+	testWarning(t, `ip("not an address")`, "", expr.ErrBadCast, "cast of invalid ip address fails")
 
 	// Test casts to time
 	ts := zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1589126400_000_000_000))}
@@ -661,8 +664,8 @@ func TestCasts(t *testing.T) {
 	testSuccessful(t, `float64("5.5")`, "", zfloat64(5.5))
 	testSuccessful(t, `ip("1.2.3.4")`, "", zaddr("1.2.3.4"))
 
-	testError(t, "ip(1)", "", expr.ErrBadCast, "ip cast non-ip arg")
-	testError(t, `int64("abc")`, "", expr.ErrBadCast, "int64 cast with non-parseable string")
-	testError(t, `float64("abc")`, "", expr.ErrBadCast, "float64 cast with non-parseable string")
-	testError(t, `ip("abc")`, "", expr.ErrBadCast, "ip cast with non-parseable string")
+	testWarning(t, "ip(1)", "", expr.ErrBadCast, "ip cast non-ip arg")
+	testWarning(t, `int64("abc")`, "", expr.ErrBadCast, "int64 cast with non-parseable string")
+	testWarning(t, `float64("abc")`, "", expr.ErrBadCast, "float64 cast with non-parseable string")
+	testWarning(t, `ip("abc")`, "", expr.ErrBadCast, "ip cast with non-parseable string")
 }

--- a/expr/functions_test.go
+++ b/expr/functions_test.go
@@ -10,13 +10,17 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
+func namedErrBadArgument(name string) error {
+	return fmt.Errorf("%s: %w", name, function.ErrBadArgument)
+}
+
 func zaddr(addr string) zng.Value {
 	parsed := net.ParseIP(addr)
 	return zng.Value{zng.TypeIP, zng.EncodeIP(parsed)}
 }
 
 func TestBadFunction(t *testing.T) {
-	testError(t, "notafunction()", "", function.ErrNoSuchFunction, "calling nonexistent function")
+	testError(t, "notafunction()", function.ErrNoSuchFunction, "calling nonexistent function")
 }
 
 func TestAbs(t *testing.T) {
@@ -30,9 +34,9 @@ func TestAbs(t *testing.T) {
 	testSuccessful(t, "abs(3.2)", record, zfloat64(3.2))
 	testSuccessful(t, "abs(u)", record, zuint64(50))
 
-	testError(t, "abs()", record, function.ErrTooFewArgs, "abs with no args")
-	testError(t, "abs(1, 2)", record, function.ErrTooManyArgs, "abs with too many args")
-	testError(t, `abs("hello")`, record, function.ErrBadArgument, "abs with non-number")
+	testError(t, "abs()", function.ErrTooFewArgs, "abs with no args")
+	testError(t, "abs(1, 2)", function.ErrTooManyArgs, "abs with too many args")
+	testWarning(t, `abs("hello")`, record, namedErrBadArgument("abs"), "abs with non-number")
 }
 
 func TestSqrt(t *testing.T) {
@@ -44,9 +48,9 @@ func TestSqrt(t *testing.T) {
 	testSuccessful(t, "sqrt(f)", record, zfloat64(2.5))
 	testSuccessful(t, "sqrt(i)", record, zfloat64(3.0))
 
-	testError(t, "sqrt()", record, function.ErrTooFewArgs, "sqrt with no args")
-	testError(t, "sqrt(1, 2)", record, function.ErrTooManyArgs, "sqrt with too many args")
-	testError(t, "sqrt(-1)", record, function.ErrBadArgument, "sqrt of negative")
+	testError(t, "sqrt()", function.ErrTooFewArgs, "sqrt with no args")
+	testError(t, "sqrt(1, 2)", function.ErrTooManyArgs, "sqrt with too many args")
+	testWarning(t, "sqrt(-1)", record, namedErrBadArgument("sqrt"), "sqrt of negative")
 }
 
 func TestMinMax(t *testing.T) {
@@ -63,8 +67,8 @@ func TestMinMax(t *testing.T) {
 	testSuccessful(t, "max(3, 2, 1)", record, zint64(3))
 
 	// Fails with no arguments
-	testError(t, "min()", record, function.ErrTooFewArgs, "min with no args")
-	testError(t, "max()", record, function.ErrTooFewArgs, "max with no args")
+	testError(t, "min()", function.ErrTooFewArgs, "min with no args")
+	testError(t, "max()", function.ErrTooFewArgs, "max with no args")
 
 	// Mixed types work
 	testSuccessful(t, "min(i, 2, 3)", record, zuint64(1))
@@ -77,10 +81,10 @@ func TestMinMax(t *testing.T) {
 	testSuccessful(t, "max(2.0, -1)", record, zfloat64(2))
 
 	// Fails on invalid types
-	testError(t, `min("hello", 2)`, record, function.ErrBadArgument, "min() on string")
-	testError(t, `max("hello", 2)`, record, function.ErrBadArgument, "max() on string")
-	testError(t, `min(1.2.3.4, 2)`, record, function.ErrBadArgument, "min() on ip")
-	testError(t, `max(1.2.3.4, 2)`, record, function.ErrBadArgument, "max() on ip")
+	testWarning(t, `min("hello", 2)`, record, function.ErrBadArgument, "min() on string")
+	testWarning(t, `max("hello", 2)`, record, function.ErrBadArgument, "max() on string")
+	testWarning(t, `min(1.2.3.4, 2)`, record, function.ErrBadArgument, "min() on ip")
+	testWarning(t, `max(1.2.3.4, 2)`, record, function.ErrBadArgument, "max() on ip")
 
 }
 
@@ -93,12 +97,12 @@ func TestCeilFloorRound(t *testing.T) {
 	testSuccessful(t, "floor(5)", "", zint64(5))
 	testSuccessful(t, "round(5)", "", zint64(5))
 
-	testError(t, "ceil()", "", function.ErrTooFewArgs, "ceil() with no args")
-	testError(t, "ceil(1, 2)", "", function.ErrTooManyArgs, "ceil() with too many args")
-	testError(t, "floor()", "", function.ErrTooFewArgs, "floor() with no args")
-	testError(t, "floor(1, 2)", "", function.ErrTooManyArgs, "floor() with too many args")
-	testError(t, "round()", "", function.ErrTooFewArgs, "round() with no args")
-	testError(t, "round(1, 2)", "", function.ErrTooManyArgs, "round() with too many args")
+	testError(t, "ceil()", function.ErrTooFewArgs, "ceil() with no args")
+	testError(t, "ceil(1, 2)", function.ErrTooManyArgs, "ceil() with too many args")
+	testError(t, "floor()", function.ErrTooFewArgs, "floor() with no args")
+	testError(t, "floor(1, 2)", function.ErrTooManyArgs, "floor() with too many args")
+	testError(t, "round()", function.ErrTooFewArgs, "round() with no args")
+	testError(t, "round(1, 2)", function.ErrTooManyArgs, "round() with too many args")
 }
 
 func TestLogPow(t *testing.T) {
@@ -111,14 +115,14 @@ func TestLogPow(t *testing.T) {
 	testSuccessful(t, "pow(10, 2)", "", zfloat64(100))
 	testSuccessful(t, "pow(4.0, 1.5)", "", zfloat64(8))
 
-	testError(t, "log()", "", function.ErrTooFewArgs, "log() with no args")
-	testError(t, "log(2, 3)", "", function.ErrTooManyArgs, "log() with too many args")
-	testError(t, "log(0)", "", function.ErrBadArgument, "log() of 0")
-	testError(t, "log(-1)", "", function.ErrBadArgument, "log() of negative number")
+	testError(t, "log()", function.ErrTooFewArgs, "log() with no args")
+	testError(t, "log(2, 3)", function.ErrTooManyArgs, "log() with too many args")
+	testWarning(t, "log(0)", "", namedErrBadArgument("log"), "log() of 0")
+	testWarning(t, "log(-1)", "", namedErrBadArgument("log"), "log() of negative number")
 
-	testError(t, "pow()", "", function.ErrTooFewArgs, "pow() with no args")
-	testError(t, "pow(2, 3, r)", "", function.ErrTooManyArgs, "pow() with too many args")
-	testError(t, "pow(-1, 0.5)", "", function.ErrBadArgument, "pow() with invalid arguments")
+	testError(t, "pow()", function.ErrTooFewArgs, "pow() with no args")
+	testError(t, "pow(2, 3, r)", function.ErrTooManyArgs, "pow() with too many args")
+	testWarning(t, "pow(-1, 0.5)", "", namedErrBadArgument("pow"), "pow() with invalid arguments")
 }
 
 func TestMod(t *testing.T) {
@@ -131,28 +135,28 @@ func TestMod(t *testing.T) {
 	testSuccessful(t, "mod(8, 5)", record, zint64(3))
 	testSuccessful(t, "mod(8, u)", record, zint64(3))
 
-	testError(t, "mod()", record, function.ErrTooFewArgs, "mod() with no args")
-	testError(t, "mod(1, 2, 3)", record, function.ErrTooManyArgs, "mod() with too many args")
-	testError(t, "mod(3.2, 2)", record, function.ErrBadArgument, "mod() with float64 arg")
+	testError(t, "mod()", function.ErrTooFewArgs, "mod() with no args")
+	testError(t, "mod(1, 2, 3)", function.ErrTooManyArgs, "mod() with too many args")
+	testWarning(t, "mod(3.2, 2)", record, namedErrBadArgument("mod"), "mod() with float64 arg")
 }
 
 func TestOtherStrFuncs(t *testing.T) {
 	testSuccessful(t, `replace("bann", "n", "na")`, "", zstring("banana"))
-	testError(t, `replace("foo", "bar")`, "", function.ErrTooFewArgs, "replace() with too few args")
-	testError(t, `replace("foo", "bar", "baz", "blort")`, "", function.ErrTooManyArgs, "replace() with too many args")
-	testError(t, `replace("foo", "o", 5)`, "", function.ErrBadArgument, "replace() with non-string arg")
+	testError(t, `replace("foo", "bar")`, function.ErrTooFewArgs, "replace() with too few args")
+	testError(t, `replace("foo", "bar", "baz", "blort")`, function.ErrTooManyArgs, "replace() with too many args")
+	testWarning(t, `replace("foo", "o", 5)`, "", namedErrBadArgument("replace"), "replace() with non-string arg")
 
 	testSuccessful(t, `to_lower("BOO")`, "", zstring("boo"))
-	testError(t, `to_lower()`, "", function.ErrTooFewArgs, "toLower() with no args")
-	testError(t, `to_lower("BOO", "HOO")`, "", function.ErrTooManyArgs, "toLower() with too many args")
+	testError(t, `to_lower()`, function.ErrTooFewArgs, "toLower() with no args")
+	testError(t, `to_lower("BOO", "HOO")`, function.ErrTooManyArgs, "toLower() with too many args")
 
 	testSuccessful(t, `to_upper("boo")`, "", zstring("BOO"))
-	testError(t, `to_upper()`, "", function.ErrTooFewArgs, "toUpper() with no args")
-	testError(t, `to_upper("boo", "hoo")`, "", function.ErrTooManyArgs, "toUpper() with too many args")
+	testError(t, `to_upper()`, function.ErrTooFewArgs, "toUpper() with no args")
+	testError(t, `to_upper("boo", "hoo")`, function.ErrTooManyArgs, "toUpper() with too many args")
 
 	testSuccessful(t, `trim("  hi  there   ")`, "", zstring("hi  there"))
-	testError(t, `trim()`, "", function.ErrTooFewArgs, "trim() with no args")
-	testError(t, `trim("  hi  ", "  there  ")`, "", function.ErrTooManyArgs, "trim() with too many args")
+	testError(t, `trim()`, function.ErrTooFewArgs, "trim() with no args")
+	testError(t, `trim("  hi  ", "  there  ")`, function.ErrTooManyArgs, "trim() with too many args")
 }
 
 func TestLen(t *testing.T) {
@@ -163,9 +167,9 @@ func TestLen(t *testing.T) {
 	testSuccessful(t, "len(s)", record, zint64(3))
 	testSuccessful(t, "len(a)", record, zint64(3))
 
-	testError(t, "len()", record, function.ErrTooFewArgs, "len() with no args")
-	testError(t, `len("foo", "bar")`, record, function.ErrTooManyArgs, "len() with too many args")
-	testError(t, "len(5)", record, function.ErrBadArgument, "len() with non-container arg")
+	testError(t, "len()", function.ErrTooFewArgs, "len() with no args")
+	testError(t, `len("foo", "bar")`, function.ErrTooManyArgs, "len() with too many args")
+	testWarning(t, "len(5)", record, namedErrBadArgument("len"), "len() with non-container arg")
 
 	record = `
 #0:record[s:string,bs:bstring,bs2:bstring]
@@ -194,6 +198,6 @@ func TestTime(t *testing.T) {
 
 	testSuccessful(t, "trunc(1590506867.967, 1)", "", zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1590506867 * 1_000_000_000))})
 
-	testError(t, "iso()", "", function.ErrTooFewArgs, "iso() with no args")
-	testError(t, `iso("abc", "def")`, "", function.ErrTooManyArgs, "iso() with too many args")
+	testError(t, "iso()", function.ErrTooFewArgs, "iso() with no args")
+	testError(t, `iso("abc", "def")`, function.ErrTooManyArgs, "iso() with too many args")
 }

--- a/expr/ztests/cut-to-root-error-non-record.yaml
+++ b/expr/ztests/cut-to-root-error-non-record.yaml
@@ -4,4 +4,6 @@ input: |
   #0:record[a:int32]
   0:[1;]
 
-errorRE: cannot cut a non-record to \.
+warnings: |
+  cut: cannot cut a non-record to .
+  cut: no record found with columns a

--- a/proc/apply.go
+++ b/proc/apply.go
@@ -17,6 +17,7 @@ type applier struct {
 	pctx     *Context
 	parent   Interface
 	function Function
+	warned   map[string]bool
 }
 
 func FromFunction(pctx *Context, parent Interface, f Function) *applier {
@@ -24,12 +25,7 @@ func FromFunction(pctx *Context, parent Interface, f Function) *applier {
 		pctx:     pctx,
 		parent:   parent,
 		function: f,
-	}
-}
-
-func (a *applier) warn() {
-	if s := a.function.Warning(); s != "" {
-		a.pctx.Warnings <- fmt.Sprintf("%s: %s", a.function, s)
+		warned:   map[string]bool{},
 	}
 }
 
@@ -37,18 +33,19 @@ func (a *applier) Pull() (zbuf.Batch, error) {
 	for {
 		batch, err := a.parent.Pull()
 		if EOS(batch, err) {
-			a.warn()
+			if s := a.function.Warning(); s != "" {
+				a.maybeWarn(s)
+			}
 			return nil, err
 		}
 		recs := make([]*zng.Record, 0, batch.Length())
 		for k := 0; k < batch.Length(); k++ {
 			in := batch.Index(k)
-
 			out, err := a.function.Apply(in)
 			if err != nil {
-				return nil, err
+				a.maybeWarn(err.Error())
+				continue
 			}
-
 			if out != nil {
 				recs = append(recs, out)
 			}
@@ -57,6 +54,13 @@ func (a *applier) Pull() (zbuf.Batch, error) {
 		if len(recs) > 0 {
 			return zbuf.Array(recs), nil
 		}
+	}
+}
+
+func (a *applier) maybeWarn(s string) {
+	if !a.warned[s] {
+		a.pctx.Warnings <- fmt.Sprintf("%s: %s", a.function, s)
+		a.warned[s] = true
 	}
 }
 

--- a/proc/rename/renamer.go
+++ b/proc/rename/renamer.go
@@ -5,8 +5,6 @@
 package rename
 
 import (
-	"fmt"
-
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zng"
@@ -69,7 +67,7 @@ func (r *Function) Apply(in *zng.Record) (*zng.Record, error) {
 	if _, ok := r.typeMap[id]; !ok {
 		typ, err := r.computeType(zng.TypeRecordOf(in.Type))
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", r, err)
+			return nil, err
 		}
 		r.typeMap[id] = typ
 	}

--- a/ztests/suite/rename/rename-error-dupe.yaml
+++ b/ztests/suite/rename/rename-error-dupe.yaml
@@ -4,4 +4,5 @@ input: |
   #0:record[foo:string,goo:string]
   0:[foo1;goo1;]
 
-errorRE: "rename: duplicate field foo"
+warnings: |
+  rename: duplicate field foo


### PR DESCRIPTION
proc.applier.Pull returns errors from proc.Function.Apply, effectively  
making them fatal when they needn't be. Send warnings for these errors  
instead of returning them.

Closes #1982.