### PR TITLE
import charm

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -7,11 +7,11 @@ import (
 	"os"
 
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/terminal"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zio/zstio"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 type Flags struct {
@@ -84,7 +84,7 @@ func (f *Flags) Init() error {
 	if f.outputFile == "-" {
 		f.outputFile = ""
 	}
-	if f.outputFile == "" && f.Format == "zng" && IsTerminal(os.Stdout) && !f.forceBinary {
+	if f.outputFile == "" && f.Format == "zng" && terminal.IsTerminalFile(os.Stdout) && !f.forceBinary {
 		return errors.New("writing binary zng data to terminal; override with -B or use -z for ZSON.")
 	}
 	return nil
@@ -94,7 +94,7 @@ func (f *Flags) InitWithFormat(format string) error {
 	if f.outputFile == "-" {
 		f.outputFile = ""
 	}
-	if f.outputFile == "" && f.Format == "zng" && IsTerminal(os.Stdout) && !f.forceBinary {
+	if f.outputFile == "" && f.Format == "zng" && terminal.IsTerminalFile(os.Stdout) && !f.forceBinary {
 		return errors.New("writing binary zng data to terminal; override with -B or use -z for ZSON.")
 	}
 	return nil
@@ -117,8 +117,4 @@ func (f *Flags) Open(ctx context.Context) (zbuf.WriteCloser, error) {
 		return nil, err
 	}
 	return w, nil
-}
-
-func IsTerminal(f *os.File) bool {
-	return terminal.IsTerminal(int(f.Fd()))
 }

--- a/cmd/ast/ast.go
+++ b/cmd/ast/ast.go
@@ -15,9 +15,9 @@ import (
 	"github.com/brimsec/zq/compiler/ast"
 	"github.com/brimsec/zq/compiler/parser"
 	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zfmt"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
 	"github.com/peterh/liner"
 )
 

--- a/cmd/microindex/convert/command.go
+++ b/cmd/microindex/convert/command.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Convert = &charm.Spec{

--- a/cmd/microindex/convert/command.go
+++ b/cmd/microindex/convert/command.go
@@ -8,11 +8,11 @@ import (
 	"github.com/brimsec/zq/cmd/microindex/root"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Convert = &charm.Spec{

--- a/cmd/microindex/create/command.go
+++ b/cmd/microindex/create/command.go
@@ -9,11 +9,11 @@ import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/cmd/microindex/create/command.go
+++ b/cmd/microindex/create/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/cmd/microindex/lookup/command.go
+++ b/cmd/microindex/lookup/command.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Lookup = &charm.Spec{

--- a/cmd/microindex/lookup/command.go
+++ b/cmd/microindex/lookup/command.go
@@ -9,10 +9,10 @@ import (
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/microindex/root"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Lookup = &charm.Spec{

--- a/cmd/microindex/root/command.go
+++ b/cmd/microindex/root/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/cli"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var MicroIndex = &charm.Spec{

--- a/cmd/microindex/section/command.go
+++ b/cmd/microindex/section/command.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"os"
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/microindex/root"
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Section = &charm.Spec{
@@ -46,10 +44,6 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.IntVar(&c.section, "s", -1, "include the indicated section in the output")
 	c.outputFlags.SetFlags(f)
 	return c, nil
-}
-
-func isTerminal(f *os.File) bool {
-	return terminal.IsTerminal(int(f.Fd()))
 }
 
 func (c *Command) Run(args []string) error {

--- a/cmd/microindex/section/command.go
+++ b/cmd/microindex/section/command.go
@@ -8,9 +8,9 @@ import (
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/microindex/root"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Section = &charm.Spec{

--- a/cmd/microindex/seek/command.go
+++ b/cmd/microindex/seek/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Seek = &charm.Spec{

--- a/cmd/microindex/seek/command.go
+++ b/cmd/microindex/seek/command.go
@@ -10,11 +10,11 @@ import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Seek = &charm.Spec{

--- a/cmd/pcap/cut/command.go
+++ b/cmd/pcap/cut/command.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap/pcapio"
-	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/fs"
 )
 
 var Cut = &charm.Spec{

--- a/cmd/pcap/cut/command.go
+++ b/cmd/pcap/cut/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/brimsec/zq/pkg/fs"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Cut = &charm.Spec{

--- a/cmd/pcap/index/command.go
+++ b/cmd/pcap/index/command.go
@@ -11,7 +11,7 @@ import (
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/fs"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Index = &charm.Spec{

--- a/cmd/pcap/index/command.go
+++ b/cmd/pcap/index/command.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap"
-	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/fs"
 )
 
 var Index = &charm.Spec{

--- a/cmd/pcap/info/command.go
+++ b/cmd/pcap/info/command.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap/pcapio"
-	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/fs"
 )
 
 var Info = &charm.Spec{

--- a/cmd/pcap/info/command.go
+++ b/cmd/pcap/info/command.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/brimsec/zq/pkg/fs"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Info = &charm.Spec{

--- a/cmd/pcap/root/command.go
+++ b/cmd/pcap/root/command.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/brimsec/zq/cli"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Pcap = &charm.Spec{

--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Slice = &charm.Spec{

--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -12,9 +12,9 @@ import (
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pcap/pcapio"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Slice = &charm.Spec{

--- a/cmd/pcap/ts/command.go
+++ b/cmd/pcap/ts/command.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/brimsec/zq/pkg/fs"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Ts = &charm.Spec{

--- a/cmd/pcap/ts/command.go
+++ b/cmd/pcap/ts/command.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/brimsec/zq/cmd/pcap/root"
 	"github.com/brimsec/zq/pcap/pcapio"
-	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/fs"
 )
 
 var Ts = &charm.Spec{

--- a/cmd/zapi/cmd/auth/command.go
+++ b/cmd/zapi/cmd/auth/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Auth = &charm.Spec{

--- a/cmd/zapi/cmd/auth/login.go
+++ b/cmd/zapi/cmd/auth/login.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/cmd/auth/devauth"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/pkg/browser"
 )
 

--- a/cmd/zapi/cmd/auth/logout.go
+++ b/cmd/zapi/cmd/auth/logout.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Logout = &charm.Spec{

--- a/cmd/zapi/cmd/auth/method.go
+++ b/cmd/zapi/cmd/auth/method.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Method = &charm.Spec{

--- a/cmd/zapi/cmd/auth/store.go
+++ b/cmd/zapi/cmd/auth/store.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Store = &charm.Spec{

--- a/cmd/zapi/cmd/auth/verify.go
+++ b/cmd/zapi/cmd/auth/verify.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Verify = &charm.Spec{

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -13,13 +13,13 @@ import (
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/cli"
 	"github.com/brimsec/zq/cli/outputflags"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/terminal"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zson"
 	"github.com/kballard/go-shellquote"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Get *charm.Spec

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -13,13 +13,13 @@ import (
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/cli"
 	"github.com/brimsec/zq/cli/outputflags"
+	"github.com/brimsec/zq/pkg/terminal"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zson"
 	"github.com/kballard/go-shellquote"
-	"github.com/mccanne/charm"
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Get *charm.Spec
@@ -56,7 +56,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	}
 
 	// If not a terminal make nofancy on by default.
-	c.NoFancy = !terminal.IsTerminal(int(os.Stdout.Fd()))
+	c.NoFancy = !terminal.IsTerminalFile(os.Stdout)
 
 	defaultHost := "localhost:9867"
 	f.StringVar(&c.Host, "h", defaultHost, "<host[:port]>")

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -19,7 +19,7 @@ import (
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Get = &charm.Spec{

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -16,10 +16,10 @@ import (
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/compiler"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Get = &charm.Spec{

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/compiler"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/cmd/zapi/cmd/index/find.go
+++ b/cmd/zapi/cmd/index/find.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Find = &charm.Spec{

--- a/cmd/zapi/cmd/index/find.go
+++ b/cmd/zapi/cmd/index/find.go
@@ -7,9 +7,9 @@ import (
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Find = &charm.Spec{

--- a/cmd/zapi/cmd/index/index.go
+++ b/cmd/zapi/cmd/index/index.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Index = &charm.Spec{

--- a/cmd/zapi/cmd/info/info.go
+++ b/cmd/zapi/cmd/info/info.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Info = &charm.Spec{

--- a/cmd/zapi/cmd/info/info.go
+++ b/cmd/zapi/cmd/info/info.go
@@ -12,8 +12,8 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
-	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/nano"
 )
 
 var Info = &charm.Spec{

--- a/cmd/zapi/cmd/info/ls.go
+++ b/cmd/zapi/cmd/info/ls.go
@@ -6,10 +6,10 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zson"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Ls = &charm.Spec{

--- a/cmd/zapi/cmd/info/ls.go
+++ b/cmd/zapi/cmd/info/ls.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zson"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Ls = &charm.Spec{

--- a/cmd/zapi/cmd/intake/command.go
+++ b/cmd/zapi/cmd/intake/command.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 	"github.com/brimsec/zq/zson"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Intake = &charm.Spec{

--- a/cmd/zapi/cmd/intake/command.go
+++ b/cmd/zapi/cmd/intake/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 	"github.com/brimsec/zq/zson"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Intake = &charm.Spec{

--- a/cmd/zapi/cmd/intake/ls.go
+++ b/cmd/zapi/cmd/intake/ls.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Ls = &charm.Spec{

--- a/cmd/zapi/cmd/intake/new.go
+++ b/cmd/zapi/cmd/intake/new.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var NewSpec = &charm.Spec{

--- a/cmd/zapi/cmd/intake/post.go
+++ b/cmd/zapi/cmd/intake/post.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Post = &charm.Spec{

--- a/cmd/zapi/cmd/intake/post.go
+++ b/cmd/zapi/cmd/intake/post.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/iosrc"
 )
 
 var Post = &charm.Spec{

--- a/cmd/zapi/cmd/intake/rm.go
+++ b/cmd/zapi/cmd/intake/rm.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Rm = &charm.Spec{

--- a/cmd/zapi/cmd/intake/update.go
+++ b/cmd/zapi/cmd/intake/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Update = &charm.Spec{

--- a/cmd/zapi/cmd/new/new.go
+++ b/cmd/zapi/cmd/new/new.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var NewSpec = &charm.Spec{

--- a/cmd/zapi/cmd/post/path.go
+++ b/cmd/zapi/cmd/post/path.go
@@ -13,9 +13,9 @@ import (
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/display"
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var PostPath = &charm.Spec{

--- a/cmd/zapi/cmd/post/path.go
+++ b/cmd/zapi/cmd/post/path.go
@@ -15,7 +15,7 @@ import (
 	"github.com/brimsec/zq/cmd/zapi/format"
 	"github.com/brimsec/zq/pkg/display"
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var PostPath = &charm.Spec{

--- a/cmd/zapi/cmd/post/pcap.go
+++ b/cmd/zapi/cmd/post/pcap.go
@@ -14,8 +14,8 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
-	"github.com/brimsec/zq/pkg/display"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/display"
 )
 
 var PostPcap = &charm.Spec{

--- a/cmd/zapi/cmd/post/pcap.go
+++ b/cmd/zapi/cmd/post/pcap.go
@@ -15,7 +15,7 @@ import (
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
 	"github.com/brimsec/zq/pkg/display"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var PostPcap = &charm.Spec{

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
 	"github.com/brimsec/zq/pkg/display"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Post = &charm.Spec{

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -11,8 +11,8 @@ import (
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
-	"github.com/brimsec/zq/pkg/display"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/pkg/display"
 )
 
 var Post = &charm.Spec{

--- a/cmd/zapi/cmd/rename/rename.go
+++ b/cmd/zapi/cmd/rename/rename.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Rename = &charm.Spec{

--- a/cmd/zapi/cmd/repl/repl.go
+++ b/cmd/zapi/cmd/repl/repl.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/repl"
 	"github.com/brimsec/zq/pkg/units"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Repl = &charm.Spec{

--- a/cmd/zapi/cmd/repl/repl.go
+++ b/cmd/zapi/cmd/repl/repl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/pkg/repl"
 	"github.com/brimsec/zq/pkg/units"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Repl = &charm.Spec{

--- a/cmd/zapi/cmd/rm/rm.go
+++ b/cmd/zapi/cmd/rm/rm.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Rm = &charm.Spec{

--- a/cmd/zapi/cmd/version/command.go
+++ b/cmd/zapi/cmd/version/command.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Version = &charm.Spec{

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -13,12 +13,12 @@ import (
 	"github.com/brimsec/zq/cli/procflags"
 	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/s3io"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zq = &charm.Spec{

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -18,7 +18,7 @@ import (
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zq = &charm.Spec{

--- a/cmd/zsontypes/zsontypes.go
+++ b/cmd/zsontypes/zsontypes.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/brimsec/zq/cli/inputflags"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zio/ndjsonio/compat"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var ZsonTypes = &charm.Spec{

--- a/cmd/zsontypes/zsontypes.go
+++ b/cmd/zsontypes/zsontypes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var ZsonTypes = &charm.Spec{

--- a/cmd/zst/create/command.go
+++ b/cmd/zst/create/command.go
@@ -8,9 +8,9 @@ import (
 	"github.com/brimsec/zq/cli/inputflags"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/cmd/zst/create/command.go
+++ b/cmd/zst/create/command.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimsec/zq/cmd/zst/root"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/cmd/zst/cut/command.go
+++ b/cmd/zst/cut/command.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Cut = &charm.Spec{

--- a/cmd/zst/cut/command.go
+++ b/cmd/zst/cut/command.go
@@ -11,7 +11,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Cut = &charm.Spec{

--- a/cmd/zst/inspect/command.go
+++ b/cmd/zst/inspect/command.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Inspect = &charm.Spec{

--- a/cmd/zst/inspect/command.go
+++ b/cmd/zst/inspect/command.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Inspect = &charm.Spec{

--- a/cmd/zst/read/command.go
+++ b/cmd/zst/read/command.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"os"
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zst/root"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
-	"github.com/mccanne/charm"
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Read = &charm.Spec{
@@ -43,10 +41,6 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	c.outputFlags.SetFlags(f)
 	return c, nil
-}
-
-func isTerminal(f *os.File) bool {
-	return terminal.IsTerminal(int(f.Fd()))
 }
 
 func (c *Command) Run(args []string) error {

--- a/cmd/zst/read/command.go
+++ b/cmd/zst/read/command.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Read = &charm.Spec{

--- a/cmd/zst/root/command.go
+++ b/cmd/zst/root/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/cli"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zst = &charm.Spec{

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/terminal"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 func NewFile(ctx context.Context, path string, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
@@ -31,9 +31,7 @@ func NewFile(ctx context.Context, path string, opts zio.WriterOpts) (zbuf.WriteC
 
 func IsTerminal(w io.Writer) bool {
 	if f, ok := w.(*os.File); ok {
-		if terminal.IsTerminal(int(f.Fd())) {
-			return true
-		}
+		return terminal.IsTerminalFile(f)
 	}
 	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -38,9 +38,9 @@ require (
 	go.temporal.io/server v1.6.3
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
-	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210105210732-16f7687f5001
+	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6
 	golang.org/x/text v0.3.4
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20210106172901-c476de37821d

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3
+	github.com/kr/text v0.2.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/peterh/liner v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -775,8 +775,9 @@ golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=
 golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 h1:EC6+IGYTjPpRfv9a2b/6Puw0W+hLtAhkV1tPsXhutqs=
+golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,6 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3 h1:Sj9zugMeJDXrKpOZgiQXhm0Z87vPF2QfUMWE41lwcRQ=
-github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3/go.mod h1:R47PUgWIRA4UrwFWKI6vgAEWHXPYWUg3iAtyXB8yKNU=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -608,7 +606,6 @@ go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
@@ -746,7 +743,6 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/charm/charm.go
+++ b/pkg/charm/charm.go
@@ -1,0 +1,91 @@
+// Package charm is minimilast CLI framework inspired by cobra and urfave/cli.
+package charm
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+)
+
+var ErrNoRun = errors.New("no run method")
+
+type Constructor func(Command, *flag.FlagSet) (Command, error)
+
+type Command interface {
+	Run([]string) error
+}
+
+type Spec struct {
+	Name          string
+	Usage         string
+	Short         string
+	Long          string
+	New           Constructor
+	Hidden        bool
+	HiddenFlags   string
+	RedactedFlags string
+	Empty         *Spec
+	children      []*Spec
+	parent        *Spec
+}
+
+func (c *Spec) Add(child *Spec) {
+	c.children = append(c.children, child)
+	child.parent = c
+}
+
+func (c *Spec) lookupSub(name string) *Spec {
+	for _, child := range c.children {
+		if name == child.Name {
+			return child
+		}
+	}
+	return nil
+}
+
+func parseFlags(flags *flag.FlagSet, args []string) ([]string, error) {
+	var usage bool
+	flags.Usage = func() {
+		usage = true
+	}
+	if err := flags.Parse(args); err != nil {
+		if usage {
+			s := strings.Join(args, " ")
+			err = fmt.Errorf("unknown flag: \"%s\"", s)
+		}
+		return nil, err
+	}
+	return flags.Args(), nil
+}
+
+func (s *Spec) Exec(parent Command, args []string) error {
+	cmd, err := newInstance(parent, s)
+	if err != nil {
+		return err
+	}
+	return cmd.run(args)
+}
+
+// ExecRoot execute this command spec, which must be a root spec.
+// It returns the root command that was created.
+func (s *Spec) ExecRoot(args []string) (Command, error) {
+	cmd, err := newInstance(nil, s)
+	if err != nil {
+		return nil, err
+	}
+	return cmd.command, cmd.run(args)
+}
+
+//XXX
+func (c *Spec) Prefix() string {
+	return c.Name + ": "
+}
+
+func (c *Spec) Root() *Spec {
+	p := c
+	for p.parent != nil {
+		p = p.parent
+	}
+	return p
+}

--- a/pkg/charm/help.go
+++ b/pkg/charm/help.go
@@ -1,0 +1,213 @@
+package charm
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/brimsec/zq/pkg/terminal"
+	"github.com/kr/text"
+)
+
+var Help = &Spec{
+	Name:  "help",
+	Usage: "help [command]",
+	Short: "display help for a command",
+	Long: `
+For help on the top-level command just type "help".
+For help on a subcommand, type "help command" where command is the name of
+the command.  For help on command nested further, type "help cmd1 cmd2" and
+so forth.`,
+	HiddenFlags: "v",
+	New: func(parent Command, f *flag.FlagSet) (Command, error) {
+		c := &HelpCommand{}
+		f.BoolVar(&c.vflag, "v", false, "show hidden commands and flags")
+		return c, nil
+	},
+}
+
+type HelpCommand struct {
+	vflag bool
+}
+
+// splitFlags is like strings.Split with a comma and also trims whitespace
+func splitFlags(flags string) []string {
+	var out []string
+	for _, flag := range strings.Split(flags, ",") {
+		out = append(out, strings.TrimSpace(flag))
+	}
+	return out
+}
+
+// flagMap creates a map that maps a name to a boolean based on the existence
+// of that name in the comma-separated string of flags.  Whitespace is removed
+// from each name in the flags list.  A map that contains no entries is returned
+// for an empty string.
+func flagMap(flags string) map[string]bool {
+	hidden := make(map[string]bool)
+	for _, flag := range splitFlags(flags) {
+		hidden[flag] = true
+	}
+	return hidden
+}
+
+func (c *HelpCommand) search(args []string) ([]*instance, error) {
+	//XXX parent of root can be custom...
+	parent, err := newInstance(nil, Help.Root())
+	if err != nil {
+		return nil, err
+	}
+	sequence := ""
+	var instances []*instance
+	instances = append(instances, parent)
+	for _, arg := range args {
+		sequence = sequence + " " + arg
+		subcmd := parent.spec.lookupSub(arg)
+		if subcmd == nil {
+			if len(args) == 1 {
+				return nil, fmt.Errorf("no such command: %s", arg)
+			} else {
+				return nil, fmt.Errorf("no such command:%s", sequence)
+			}
+		}
+		child, err := newInstance(parent.command, subcmd)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, child)
+		parent = child
+	}
+	return instances, nil
+}
+
+func (c *HelpCommand) Prepare(f *flag.FlagSet) {}
+
+func (c *HelpCommand) Run(args []string) error {
+	inst, err := c.search(args)
+	if err != nil {
+		return err
+	}
+	c.help(inst)
+	return nil
+}
+
+func formatParagraph(body, tab string, lineWidth int) string {
+	paragraphs := strings.Split(body, "\n\n")
+	var chunks []string
+	for _, paragraph := range paragraphs {
+		var chunk string
+		if len(paragraph) < lineWidth {
+			chunk = strings.TrimRight(paragraph, " \t\n")
+		} else {
+			paragraph = strings.TrimSpace(paragraph)
+			paragraph = text.Wrap(paragraph, lineWidth)
+			lines := strings.Split(paragraph, "\n")
+			chunk = strings.Join(lines, "\n"+tab)
+		}
+		chunks = append(chunks, chunk)
+	}
+	body = strings.Join(chunks, "\n\n"+tab)
+	body = strings.TrimRight(body, " \t\n")
+	return tab + body + "\n\n"
+}
+
+const tab = "    "
+
+func header(heading string) string {
+	boldOn := "\033[1m"
+	boldOff := "\033[0m"
+	return boldOn + heading + boldOff
+}
+
+func helpItem(heading, body string) {
+	hdr := header(heading)
+	body = hdr + "\n" + tab + body + "\n\n"
+	fmt.Fprint(os.Stderr, body)
+}
+
+func helpDesc(heading, body string) {
+	hdr := header(heading)
+	body = tab + body + "\n\n"
+	w := terminal.Width()
+	lineWidth := w - len(tab) - 5
+	if len(body) > lineWidth {
+		body = formatParagraph(body, tab, lineWidth)
+	}
+	fmt.Fprint(os.Stderr, hdr+"\n"+body)
+}
+
+func helpList(heading string, lines []string) {
+	hdr := header(heading)
+	body := strings.Join(lines, "\n"+tab)
+	body = hdr + "\n" + tab + body + "\n\n"
+	fmt.Fprint(os.Stderr, body)
+}
+
+func optionSection(body []string) []string {
+	if len(body) == 0 {
+		return []string{"no flags for this command"}
+	}
+	return body
+}
+
+func (c *HelpCommand) getCommands(target *Spec, vflag bool) []string {
+	var lines []string
+	for _, cmd := range target.children {
+		name := cmd.Name
+		if cmd.Hidden {
+			if vflag {
+				name = "[" + name + "]"
+			} else {
+				continue
+			}
+		}
+		line := name + " - " + cmd.Short
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func buildOptions(path []*instance, parentCmd string, vflag bool) []string {
+	n := len(path)
+	if n == 1 {
+		options := path[0].options(vflag)
+		if len(options) == 0 {
+			options = []string{"no flags for this command"}
+		}
+		return options
+	}
+	pathCmd := path[0].spec.Name
+	if parentCmd != "" {
+		pathCmd = parentCmd + " " + pathCmd
+	}
+	childOptions := buildOptions(path[1:], parentCmd, vflag)
+	options := path[0].options(vflag)
+	if len(options) == 0 {
+		return childOptions
+	}
+	// add a line separator then add the command path in parens as the header
+	// for the next set of flags
+	childOptions = append(childOptions, "")
+	childOptions = append(childOptions, "["+pathCmd+" flags]")
+	for _, option := range options {
+		childOptions = append(childOptions, option)
+	}
+	return childOptions
+}
+
+func optionsSection(path []*instance, vflag bool) []string {
+	return buildOptions(path, "", vflag)
+}
+
+func (c *HelpCommand) help(path []*instance) {
+	spec := path[len(path)-1].spec
+	name := spec.Name + " - " + spec.Short
+	helpItem("NAME", name)
+	helpDesc("USAGE", spec.Usage)
+	helpList("OPTIONS", optionsSection(path, c.vflag))
+	if len(spec.children) > 0 {
+		helpList("COMMANDS", c.getCommands(spec, c.vflag))
+	}
+	helpDesc("DESCRIPTION", spec.Long)
+}

--- a/pkg/charm/instance.go
+++ b/pkg/charm/instance.go
@@ -1,0 +1,88 @@
+package charm
+
+import (
+	"flag"
+	"fmt"
+)
+
+// instance represents a command that has been created but not run.
+// It's options and defaults may be queried with the options method and
+// the command can be run with the run method.
+type instance struct {
+	spec    *Spec
+	command Command
+	flags   *flag.FlagSet
+}
+
+func newInstance(parent Command, spec *Spec) (*instance, error) {
+	if spec.New == nil {
+		return nil, fmt.Errorf("command '%s': New function is nil", spec.Name)
+	}
+	flags := flag.NewFlagSet(spec.Name, flag.ContinueOnError)
+	cmd, err := spec.New(parent, flags)
+	if err != nil {
+		return nil, err
+	}
+	return &instance{spec, cmd, flags}, nil
+}
+
+// run runs this instance of the command.
+func (i *instance) run(args []string) error {
+	// set up the flags even if there aren't any args to parse
+	// since we need to establish default state in the command objects
+	rest, err := parseFlags(i.flags, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) == 0 {
+		empty := i.spec.Empty
+		if empty == nil {
+			// call current command with no args
+			err = i.command.Run(rest)
+			if err == ErrNoRun {
+				err = fmt.Errorf("%s: no sub-command supplied", i.spec.Name)
+			}
+			return err
+		}
+		// Otherwise, this is an empty sub-command that has an empty spec,
+		// so invoke the spec with the current command as the parent.
+		return empty.Exec(i.command, rest)
+	}
+	// otherwise there are more stuff after the flags so
+	// look for a subcommand
+	child := i.spec.lookupSub(rest[0])
+	if child == nil {
+		// no command found so call the current command with the args
+		err = i.command.Run(rest)
+		if err == ErrNoRun {
+			err = fmt.Errorf("%s: no such sub-command: %s", i.spec.Name, rest[0])
+		}
+		return err
+	}
+	// we found a subcommand so execute it recursively and
+	// drop the cmd name from the args
+	return child.Exec(i.command, rest[1:])
+}
+
+// options returns a formatted slice of strings ready for printing as
+// help for this instance of a command.
+func (i *instance) options(vflag bool) []string {
+	hidden := flagMap(i.spec.HiddenFlags)
+	redacted := flagMap(i.spec.RedactedFlags)
+	var body []string
+	i.flags.VisitAll(func(f *flag.Flag) {
+		name := "-" + f.Name
+		if hidden[f.Name] {
+			if !vflag {
+				return
+			}
+			name = "[" + name + "]"
+		}
+		line := name + " " + f.Usage
+		if f.DefValue != "" && !redacted[f.Name] {
+			line = fmt.Sprintf("%s (default \"%s\")", line, f.DefValue)
+		}
+		body = append(body, line)
+	})
+	return body
+}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -1,0 +1,22 @@
+package terminal
+
+import (
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func IsTerminalFile(f *os.File) bool {
+	return terminal.IsTerminal(int(f.Fd()))
+}
+
+// Width returns the width in columns of the terminal that is the standard
+// input.  Width returns 80 if the standard input is not a terminal or its size
+// cannot be determined.
+func Width() int {
+	width, _, err := terminal.GetSize(int(os.Stdin.Fd()))
+	if err != nil {
+		return 80
+	}
+	return width
+}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -3,18 +3,18 @@ package terminal
 import (
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func IsTerminalFile(f *os.File) bool {
-	return terminal.IsTerminal(int(f.Fd()))
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // Width returns the width in columns of the terminal that is the standard
 // input.  Width returns 80 if the standard input is not a terminal or its size
 // cannot be determined.
 func Width() int {
-	width, _, err := terminal.GetSize(int(os.Stdin.Fd()))
+	width, _, err := term.GetSize(int(os.Stdin.Fd()))
 	if err != nil {
 		return 80
 	}

--- a/ppl/cmd/gentoken/gentoken.go
+++ b/ppl/cmd/gentoken/gentoken.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 )
 
 var CLI = &charm.Spec{

--- a/ppl/cmd/gentoken/gentoken.go
+++ b/ppl/cmd/gentoken/gentoken.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/ppl/zqd/auth"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var CLI = &charm.Spec{

--- a/ppl/cmd/pgctl/migrate/command.go
+++ b/ppl/cmd/pgctl/migrate/command.go
@@ -5,13 +5,13 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/ppl/cmd/pgctl/root"
 	"github.com/brimsec/zq/ppl/zqd/db/postgresdb"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Migrate = &charm.Spec{

--- a/ppl/cmd/pgctl/migrate/command.go
+++ b/ppl/cmd/pgctl/migrate/command.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Migrate = &charm.Spec{

--- a/ppl/cmd/pgctl/rmtestdb/command.go
+++ b/ppl/cmd/pgctl/rmtestdb/command.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimsec/zq/ppl/cmd/pgctl/root"
 	"github.com/brimsec/zq/ppl/zqd/db/postgresdb"
 	"github.com/go-pg/pg/v10"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var RmTestDB = &charm.Spec{

--- a/ppl/cmd/pgctl/rmtestdb/command.go
+++ b/ppl/cmd/pgctl/rmtestdb/command.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/pgctl/root"
 	"github.com/brimsec/zq/ppl/zqd/db/postgresdb"
 	"github.com/go-pg/pg/v10"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var RmTestDB = &charm.Spec{

--- a/ppl/cmd/pgctl/root/command.go
+++ b/ppl/cmd/pgctl/root/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/cli"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var CLI = &charm.Spec{

--- a/ppl/cmd/pgctl/testdb/command.go
+++ b/ppl/cmd/pgctl/testdb/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
 

--- a/ppl/cmd/pgctl/testdb/command.go
+++ b/ppl/cmd/pgctl/testdb/command.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/ppl/cmd/pgctl/root"
 	"github.com/brimsec/zq/ppl/zqd/db/postgresdb"
@@ -13,7 +14,6 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/brimsec/zq/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
 

--- a/ppl/cmd/zar/compact/command.go
+++ b/ppl/cmd/zar/compact/command.go
@@ -5,9 +5,9 @@ import (
 	"flag"
 	"os"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Compact = &charm.Spec{

--- a/ppl/cmd/zar/compact/command.go
+++ b/ppl/cmd/zar/compact/command.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Compact = &charm.Spec{

--- a/ppl/cmd/zar/find/command.go
+++ b/ppl/cmd/zar/find/command.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Find = &charm.Spec{

--- a/ppl/cmd/zar/find/command.go
+++ b/ppl/cmd/zar/find/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/ppl/lake/index"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Find = &charm.Spec{

--- a/ppl/cmd/zar/import/command.go
+++ b/ppl/cmd/zar/import/command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimsec/zq/cli/inputflags"
 	"github.com/brimsec/zq/cli/procflags"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/pkg/units"
@@ -14,7 +15,6 @@ import (
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Import = &charm.Spec{

--- a/ppl/cmd/zar/import/command.go
+++ b/ppl/cmd/zar/import/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Import = &charm.Spec{

--- a/ppl/cmd/zar/index/command.go
+++ b/ppl/cmd/zar/index/command.go
@@ -3,8 +3,8 @@ package index
 import (
 	"flag"
 
-	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/ppl/cmd/zar/root"
 )
 
 var Index = &charm.Spec{

--- a/ppl/cmd/zar/index/command.go
+++ b/ppl/cmd/zar/index/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Index = &charm.Spec{

--- a/ppl/cmd/zar/index/create.go
+++ b/ppl/cmd/zar/index/create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/ppl/cmd/zar/index/create.go
+++ b/ppl/cmd/zar/index/create.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/brimsec/zq/cli/procflags"
 	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Create = &charm.Spec{

--- a/ppl/cmd/zar/index/drop.go
+++ b/ppl/cmd/zar/index/drop.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
-	"github.com/brimsec/zq/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
 

--- a/ppl/cmd/zar/index/drop.go
+++ b/ppl/cmd/zar/index/drop.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
 

--- a/ppl/cmd/zar/index/ls.go
+++ b/ppl/cmd/zar/index/ls.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
 

--- a/ppl/cmd/zar/index/ls.go
+++ b/ppl/cmd/zar/index/ls.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 
 	"github.com/brimsec/zq/cli/outputflags"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/index"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 	"github.com/segmentio/ksuid"
 )
 

--- a/ppl/cmd/zar/ls/command.go
+++ b/ppl/cmd/zar/ls/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/chunk"
 	"github.com/brimsec/zq/ppl/lake/index"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Ls = &charm.Spec{

--- a/ppl/cmd/zar/ls/command.go
+++ b/ppl/cmd/zar/ls/command.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/chunk"
 	"github.com/brimsec/zq/ppl/lake/index"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Ls = &charm.Spec{

--- a/ppl/cmd/zar/map/command.go
+++ b/ppl/cmd/zar/map/command.go
@@ -21,7 +21,7 @@ import (
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Map = &charm.Spec{

--- a/ppl/cmd/zar/map/command.go
+++ b/ppl/cmd/zar/map/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/signalctx"
@@ -21,7 +22,6 @@ import (
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Map = &charm.Spec{

--- a/ppl/cmd/zar/rm/command.go
+++ b/ppl/cmd/zar/rm/command.go
@@ -9,12 +9,12 @@ import (
 	"path"
 	"strings"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/chunk"
 	"github.com/brimsec/zq/zqe"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Rm = &charm.Spec{

--- a/ppl/cmd/zar/rm/command.go
+++ b/ppl/cmd/zar/rm/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/ppl/lake/chunk"
 	"github.com/brimsec/zq/zqe"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Rm = &charm.Spec{

--- a/ppl/cmd/zar/rmdirs/command.go
+++ b/ppl/cmd/zar/rmdirs/command.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var RmDirs = &charm.Spec{

--- a/ppl/cmd/zar/rmdirs/command.go
+++ b/ppl/cmd/zar/rmdirs/command.go
@@ -5,9 +5,9 @@ import (
 	"flag"
 	"os"
 
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var RmDirs = &charm.Spec{

--- a/ppl/cmd/zar/root/command.go
+++ b/ppl/cmd/zar/root/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/cli"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zar = &charm.Spec{

--- a/ppl/cmd/zar/stat/command.go
+++ b/ppl/cmd/zar/stat/command.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Stat = &charm.Spec{

--- a/ppl/cmd/zar/stat/command.go
+++ b/ppl/cmd/zar/stat/command.go
@@ -7,12 +7,12 @@ import (
 	"os"
 
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Stat = &charm.Spec{

--- a/ppl/cmd/zar/zq/command.go
+++ b/ppl/cmd/zar/zq/command.go
@@ -16,7 +16,7 @@ import (
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zq = &charm.Spec{

--- a/ppl/cmd/zar/zq/command.go
+++ b/ppl/cmd/zar/zq/command.go
@@ -11,12 +11,12 @@ import (
 	"github.com/brimsec/zq/cli/searchflags"
 	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/ppl/lake"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zq = &charm.Spec{

--- a/ppl/cmd/zqd/listen/command.go
+++ b/ppl/cmd/zqd/listen/command.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cli"
+	"github.com/brimsec/zq/pkg/charm"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/httpd"
 	"github.com/brimsec/zq/pkg/rlimit"
@@ -23,7 +24,6 @@ import (
 	"github.com/brimsec/zq/ppl/zqd"
 	"github.com/brimsec/zq/ppl/zqd/pcapanalyzer"
 	"github.com/brimsec/zq/proc/sort"
-	"github.com/brimsec/zq/pkg/charm"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v3"

--- a/ppl/cmd/zqd/listen/command.go
+++ b/ppl/cmd/zqd/listen/command.go
@@ -23,7 +23,7 @@ import (
 	"github.com/brimsec/zq/ppl/zqd"
 	"github.com/brimsec/zq/ppl/zqd/pcapanalyzer"
 	"github.com/brimsec/zq/proc/sort"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v3"

--- a/ppl/cmd/zqd/root/command.go
+++ b/ppl/cmd/zqd/root/command.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/cli"
 	"github.com/brimsec/zq/cli/procflags"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 var Zqd = &charm.Spec{

--- a/ppl/cmd/zqd/winexec/command.go
+++ b/ppl/cmd/zqd/winexec/command.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/ppl/cmd/zqd/root"
-	"github.com/mccanne/charm"
+	"github.com/brimsec/zq/pkg/charm"
 )
 
 func init() {

--- a/ppl/cmd/zqd/winexec/command.go
+++ b/ppl/cmd/zqd/winexec/command.go
@@ -3,8 +3,8 @@ package winexec
 import (
 	"flag"
 
-	"github.com/brimsec/zq/ppl/cmd/zqd/root"
 	"github.com/brimsec/zq/pkg/charm"
+	"github.com/brimsec/zq/ppl/cmd/zqd/root"
 )
 
 func init() {


### PR DESCRIPTION
This commit imports the charm package from github.com/mccanne.
This way we'll be able to work on it and extend it as discussed.

We also consolidated the uses golang.org/x/crypto/ssh/terminal
with a wrapper package in pkg/terminal (which is also used by
charm to get the interactive terminal width for text formatting).